### PR TITLE
fix(testnet/homeserver)!: DockerPostgres::shared() to share Postgres instance but isolate databases and remove `pubky-test` URL query param

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -93,7 +93,7 @@ jobs:
 
     env:
       # Your code can read these, or just use the defaults above
-      TEST_PUBKY_CONNECTION_STRING: postgres://test_user:test_pass@localhost:5432/postgres?pubky-test=true
+      TEST_PUBKY_CONNECTION_STRING: postgres://test_user:test_pass@localhost:5432/postgres
 
     strategy:
       matrix:
@@ -193,7 +193,7 @@ jobs:
           --health-retries=5
     env:
       # Your code can read these, or just use the defaults above
-      TEST_PUBKY_CONNECTION_STRING: postgres://test_user:test_pass@localhost:5433/postgres?pubky-test=true
+      TEST_PUBKY_CONNECTION_STRING: postgres://test_user:test_pass@localhost:5433/postgres
 
     runs-on: ubuntu-latest
     steps:

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -17,11 +17,11 @@ docker run --name pubky-postgres \
 Then run tests with a test connection string:
 
 ```bash
-TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgres?pubky-test=true' \
+TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgres' \
   cargo test -p pubky-homeserver --all-features
 ```
 
-The `?pubky-test=true` parameter tells the test helpers to create an ephemeral `pubky_test_*` database inside the configured PostgreSQL instance. Databases are cleaned up after each test.
+In test builds, each test automatically gets its own ephemeral `pubky_test_{uuid}` database on the configured server. Databases are cleaned up after each test.
 
 ## Automatic Database Cleanup
 
@@ -93,7 +93,7 @@ async fn test_one() {
 The [`e2e`](../e2e) crate contains tests that cover cross-crate workflows using `pubky-testnet`. Run them with:
 
 ```bash
-TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgres?pubky-test=true' \
+TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgres' \
   cargo test -p e2e
 ```
 
@@ -102,7 +102,7 @@ TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgr
 Run the homeserver tests against external PostgreSQL:
 
 ```bash
-TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgres?pubky-test=true' \
+TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgres' \
   cargo test -p pubky-homeserver --all-features
 ```
 
@@ -115,6 +115,6 @@ cargo test -p pubky-testnet --features docker-postgres
 Run the full workspace test suite:
 
 ```bash
-TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgres?pubky-test=true' \
+TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgres' \
   cargo test --workspace --all-features
 ```

--- a/examples/rust/7-logging/README.md
+++ b/examples/rust/7-logging/README.md
@@ -22,7 +22,7 @@ cargo run --bin logging -- --level debug --external-postgres
 You can specify a custom connection via the `TEST_PUBKY_CONNECTION_STRING` environment variable:
 
 ```bash
-TEST_PUBKY_CONNECTION_STRING=postgres://user:pass@localhost:5432/mydb?pubky-test=true cargo run --bin logging -- --level debug --external-postgres
+TEST_PUBKY_CONNECTION_STRING=postgres://user:pass@localhost:5432/mydb cargo run --bin logging -- --level debug --external-postgres
 ```
 
-The `?pubky-test=true` parameter indicates that an ephemeral test database should be created.
+Each testnet automatically gets its own ephemeral `pubky_test_{uuid}` database on the configured server.

--- a/examples/rust/8-testnet/README.md
+++ b/examples/rust/8-testnet/README.md
@@ -22,7 +22,7 @@ cargo run --bin testnet -- --external-postgres
 You can specify a custom connection via the `TEST_PUBKY_CONNECTION_STRING` environment variable:
 
 ```bash
-TEST_PUBKY_CONNECTION_STRING=postgres://user:pass@localhost:5432/mydb?pubky-test=true cargo run --bin testnet -- --external-postgres
+TEST_PUBKY_CONNECTION_STRING=postgres://user:pass@localhost:5432/mydb cargo run --bin testnet -- --external-postgres
 ```
 
-The `?pubky-test=true` parameter indicates that an ephemeral test database should be created.
+Each testnet automatically gets its own ephemeral `pubky_test_{uuid}` database on the configured server.

--- a/examples/rust/README.md
+++ b/examples/rust/README.md
@@ -21,7 +21,7 @@ docker run --name pubky-postgres \
   -d postgres:18
 
 # Start the testnet (keep this terminal open)
-TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgres?pubky-test=true' \
+TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgres' \
   cargo run -p pubky-testnet
 ```
 

--- a/pubky-homeserver/src/app_context.rs
+++ b/pubky-homeserver/src/app_context.rs
@@ -13,7 +13,7 @@ use crate::{
     observability::{Metrics, MetricsInitError},
     persistence::{
         files::{events::EventsService, FileIoError, FileService},
-        sql::{DatabaseMode, Migrator, PgEventListener, SqlDb},
+        sql::{Migrator, PgEventListener, SqlDb},
     },
     ConfigToml, DataDir,
 };
@@ -36,12 +36,9 @@ pub enum AppContextConversionError {
     /// Failed to open SQL DB.
     #[error("Failed to open SQL DB: {0}")]
     SqlDb(sqlx::Error),
-    /// Failed to resolve the database mode (e.g. invalid TEST_PUBKY_CONNECTION_STRING).
+    /// Failed to resolve the database mode (e.g. missing URL or invalid TEST_PUBKY_CONNECTION_STRING).
     #[error("Failed to resolve database mode: {0}")]
     DatabaseResolution(anyhow::Error),
-    /// No database URL was configured (production builds require an explicit URL).
-    #[error("No database_url configured. Set [general].database_url in config.toml.")]
-    NoDatabaseUrl,
     /// Failed to run migrations.
     #[error("Failed to run migrations: {0}")]
     Migrations(anyhow::Error),
@@ -157,7 +154,9 @@ impl AppContext {
             .read_or_create_keypair()
             .map_err(AppContextConversionError::Keypair)?;
 
-        let db_mode = Self::resolve_database_mode(&conf)?;
+        let db_mode = dir
+            .resolve_database_mode(&conf)
+            .map_err(AppContextConversionError::DatabaseResolution)?;
         let sql_db = SqlDb::connect(db_mode)
             .await
             .map_err(AppContextConversionError::SqlDb)?;
@@ -208,28 +207,6 @@ impl AppContext {
 }
 
 impl AppContext {
-    /// Resolve the [`DatabaseMode`] from config.
-    ///
-    /// - Production: `database_url` must be `Some`; always [`DatabaseMode::Direct`].
-    /// - Test builds: delegates to [`DatabaseMode::resolve_test`] which resolves
-    ///   `None` via env var or default, always returning [`DatabaseMode::EphemeralTest`].
-    fn resolve_database_mode(conf: &ConfigToml) -> Result<DatabaseMode, AppContextConversionError> {
-        #[cfg(any(test, feature = "testing"))]
-        {
-            DatabaseMode::resolve_test(conf.general.database_url.clone())
-                .map_err(AppContextConversionError::DatabaseResolution)
-        }
-
-        #[cfg(not(any(test, feature = "testing")))]
-        {
-            conf.general
-                .database_url
-                .clone()
-                .map(DatabaseMode::Direct)
-                .ok_or(AppContextConversionError::NoDatabaseUrl)
-        }
-    }
-
     /// Build the pkarr client builder based on the config.
     fn build_pkarr_builder_from_config(config_toml: &ConfigToml) -> pkarr::ClientBuilder {
         let mut builder = pkarr::ClientBuilder::default();

--- a/pubky-homeserver/src/app_context.rs
+++ b/pubky-homeserver/src/app_context.rs
@@ -237,9 +237,7 @@ impl AppContext {
     }
 
     /// Connect to the SQL database.
-    ///
-    /// In test builds with `?pubky-test=true`, `SqlDb::connect` automatically
-    /// creates an ephemeral database (see [`SqlDb::connect`]).
+    /// In test builds with `?pubky-test=true`, creates an ephemeral database.
     async fn connect_to_sql_db(
         config_toml: &ConfigToml,
     ) -> Result<SqlDb, AppContextConversionError> {

--- a/pubky-homeserver/src/app_context.rs
+++ b/pubky-homeserver/src/app_context.rs
@@ -35,7 +35,7 @@ pub enum AppContextConversionError {
     Keypair(anyhow::Error),
     /// Failed to open SQL DB.
     #[error("Failed to open SQL DB: {0}")]
-    SqlDb(sqlx::Error),
+    SqlDb(crate::persistence::sql::SqlDbConnectError),
     /// Failed to run migrations.
     #[error("Failed to run migrations: {0}")]
     Migrations(anyhow::Error),
@@ -151,7 +151,9 @@ impl AppContext {
             .read_or_create_keypair()
             .map_err(AppContextConversionError::Keypair)?;
 
-        let sql_db = Self::connect_to_sql_db(&conf).await?;
+        let sql_db = SqlDb::connect(conf.general.database_url.clone())
+            .await
+            .map_err(AppContextConversionError::SqlDb)?;
         Migrator::new(&sql_db)
             .run()
             .await
@@ -203,7 +205,14 @@ impl AppContext {
     fn build_pkarr_builder_from_config(config_toml: &ConfigToml) -> pkarr::ClientBuilder {
         let mut builder = pkarr::ClientBuilder::default();
         #[cfg(any(test, feature = "testing"))]
-        if config_toml.general.database_url.is_test_db() {
+        // None (no explicit URL) or a `?pubky-test=true` URL both indicate a test
+        // environment where we must avoid contacting the public DHT.
+        if config_toml
+            .general
+            .database_url
+            .as_ref()
+            .is_none_or(|url| url.is_test_db())
+        {
             builder
                 .no_default_network()
                 // Keep the client buildable without contacting the public DHT.
@@ -235,31 +244,29 @@ impl AppContext {
         }
         builder
     }
-
-    /// Connect to the SQL database.
-    /// In test builds with `?pubky-test=true`, creates an ephemeral database.
-    async fn connect_to_sql_db(
-        config_toml: &ConfigToml,
-    ) -> Result<SqlDb, AppContextConversionError> {
-        SqlDb::connect(&config_toml.general.database_url)
-            .await
-            .map_err(AppContextConversionError::SqlDb)
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// Verifies that the test pkarr builder doesn't contact the public DHT.
+    /// Uses Debug output because pkarr::ClientBuilder has no config getters.
     #[test]
-    fn test_pkarr_builder_does_not_use_default_network() {
+    fn pkarr_builder_does_not_use_default_network() {
         let builder =
             AppContext::build_pkarr_builder_from_config(&ConfigToml::default_test_config());
         let builder_debug = format!("{builder:?}");
 
-        assert!(builder_debug.contains("127.0.0.1:9"));
+        assert!(
+            builder_debug.contains("127.0.0.1:9"),
+            "expected sentinel bootstrap node in builder: {builder_debug}"
+        );
         for relay in pkarr::DEFAULT_RELAYS {
-            assert!(!builder_debug.contains(relay));
+            assert!(
+                !builder_debug.contains(relay),
+                "default relay {relay} should not appear in test builder: {builder_debug}"
+            );
         }
         builder.build().expect("isolated pkarr client should build");
     }

--- a/pubky-homeserver/src/app_context.rs
+++ b/pubky-homeserver/src/app_context.rs
@@ -237,18 +237,18 @@ impl AppContext {
     }
 
     /// Connect to the SQL database.
-    /// If we are in a test environment and it's a test db connection string,
-    /// we use an empheral test db.
-    /// Otherwise, we use the normal db connection.
+    /// In test builds with `?pubky-test=true`, creates an ephemeral database.
     async fn connect_to_sql_db(
         config_toml: &ConfigToml,
     ) -> Result<SqlDb, AppContextConversionError> {
         #[cfg(any(test, feature = "testing"))]
         {
-            // If we are in a test environment and it's a test db connection string,
-            // we use an empheral test db.
+            // Pass the configured URL so the correct host/port are used
+            // (important when Postgres is on a non-default address, e.g. Docker).
             return if config_toml.general.database_url.is_test_db() {
-                Ok(SqlDb::test().await)
+                SqlDb::test_postgres_db(Some(config_toml.general.database_url.clone()))
+                    .await
+                    .map_err(AppContextConversionError::SqlDb)
             } else {
                 SqlDb::connect(&config_toml.general.database_url)
                     .await

--- a/pubky-homeserver/src/app_context.rs
+++ b/pubky-homeserver/src/app_context.rs
@@ -36,6 +36,9 @@ pub enum AppContextConversionError {
     /// Failed to open SQL DB.
     #[error("Failed to open SQL DB: {0}")]
     SqlDb(sqlx::Error),
+    /// Failed to resolve the database mode (e.g. invalid TEST_PUBKY_CONNECTION_STRING).
+    #[error("Failed to resolve database mode: {0}")]
+    DatabaseResolution(anyhow::Error),
     /// No database URL was configured (production builds require an explicit URL).
     #[error("No database_url configured. Set [general].database_url in config.toml.")]
     NoDatabaseUrl,
@@ -213,9 +216,8 @@ impl AppContext {
     fn resolve_database_mode(conf: &ConfigToml) -> Result<DatabaseMode, AppContextConversionError> {
         #[cfg(any(test, feature = "testing"))]
         {
-            Ok(DatabaseMode::resolve_test(
-                conf.general.database_url.clone(),
-            ))
+            DatabaseMode::resolve_test(conf.general.database_url.clone())
+                .map_err(AppContextConversionError::DatabaseResolution)
         }
 
         #[cfg(not(any(test, feature = "testing")))]

--- a/pubky-homeserver/src/app_context.rs
+++ b/pubky-homeserver/src/app_context.rs
@@ -237,32 +237,15 @@ impl AppContext {
     }
 
     /// Connect to the SQL database.
-    /// In test builds with `?pubky-test=true`, creates an ephemeral database.
+    ///
+    /// In test builds with `?pubky-test=true`, `SqlDb::connect` automatically
+    /// creates an ephemeral database (see [`SqlDb::connect`]).
     async fn connect_to_sql_db(
         config_toml: &ConfigToml,
     ) -> Result<SqlDb, AppContextConversionError> {
-        #[cfg(any(test, feature = "testing"))]
-        {
-            // Pass the configured URL so the correct host/port are used
-            // (important when Postgres is on a non-default address, e.g. Docker).
-            return if config_toml.general.database_url.is_test_db() {
-                SqlDb::test_postgres_db(Some(config_toml.general.database_url.clone()))
-                    .await
-                    .map_err(AppContextConversionError::SqlDb)
-            } else {
-                SqlDb::connect(&config_toml.general.database_url)
-                    .await
-                    .map_err(AppContextConversionError::SqlDb)
-            };
-        }
-
-        #[cfg(not(any(test, feature = "testing")))]
-        {
-            // If we are not in a test environment, we use the normal db connection.
-            return SqlDb::connect(&config_toml.general.database_url)
-                .await
-                .map_err(AppContextConversionError::SqlDb);
-        }
+        SqlDb::connect(&config_toml.general.database_url)
+            .await
+            .map_err(AppContextConversionError::SqlDb)
     }
 }
 

--- a/pubky-homeserver/src/app_context.rs
+++ b/pubky-homeserver/src/app_context.rs
@@ -13,7 +13,7 @@ use crate::{
     observability::{Metrics, MetricsInitError},
     persistence::{
         files::{events::EventsService, FileIoError, FileService},
-        sql::{Migrator, PgEventListener, SqlDb},
+        sql::{DatabaseMode, Migrator, PgEventListener, SqlDb},
     },
     ConfigToml, DataDir,
 };
@@ -35,7 +35,10 @@ pub enum AppContextConversionError {
     Keypair(anyhow::Error),
     /// Failed to open SQL DB.
     #[error("Failed to open SQL DB: {0}")]
-    SqlDb(crate::persistence::sql::SqlDbConnectError),
+    SqlDb(sqlx::Error),
+    /// No database URL was configured (production builds require an explicit URL).
+    #[error("No database_url configured. Set [general].database_url in config.toml.")]
+    NoDatabaseUrl,
     /// Failed to run migrations.
     #[error("Failed to run migrations: {0}")]
     Migrations(anyhow::Error),
@@ -151,7 +154,8 @@ impl AppContext {
             .read_or_create_keypair()
             .map_err(AppContextConversionError::Keypair)?;
 
-        let sql_db = SqlDb::connect(conf.general.database_url.clone())
+        let db_mode = Self::resolve_database_mode(&conf)?;
+        let sql_db = SqlDb::connect(db_mode)
             .await
             .map_err(AppContextConversionError::SqlDb)?;
         Migrator::new(&sql_db)
@@ -201,18 +205,36 @@ impl AppContext {
 }
 
 impl AppContext {
+    /// Resolve the [`DatabaseMode`] from config.
+    ///
+    /// - Production: `database_url` must be `Some`; always [`DatabaseMode::Direct`].
+    /// - Test builds: delegates to [`DatabaseMode::resolve_test`] which resolves
+    ///   `None` via env var or default, always returning [`DatabaseMode::EphemeralTest`].
+    fn resolve_database_mode(conf: &ConfigToml) -> Result<DatabaseMode, AppContextConversionError> {
+        #[cfg(any(test, feature = "testing"))]
+        {
+            Ok(DatabaseMode::resolve_test(
+                conf.general.database_url.clone(),
+            ))
+        }
+
+        #[cfg(not(any(test, feature = "testing")))]
+        {
+            conf.general
+                .database_url
+                .clone()
+                .map(DatabaseMode::Direct)
+                .ok_or(AppContextConversionError::NoDatabaseUrl)
+        }
+    }
+
     /// Build the pkarr client builder based on the config.
     fn build_pkarr_builder_from_config(config_toml: &ConfigToml) -> pkarr::ClientBuilder {
         let mut builder = pkarr::ClientBuilder::default();
         #[cfg(any(test, feature = "testing"))]
-        // None (no explicit URL) or a `?pubky-test=true` URL both indicate a test
-        // environment where we must avoid contacting the public DHT.
-        if config_toml
-            .general
-            .database_url
-            .as_ref()
-            .is_none_or(|url| url.is_test_db())
-        {
+        // In test builds, no explicit database_url means we're in a test environment
+        // where we must avoid contacting the public DHT.
+        if config_toml.general.database_url.is_none() {
             builder
                 .no_default_network()
                 // Keep the client buildable without contacting the public DHT.
@@ -250,12 +272,16 @@ impl AppContext {
 mod tests {
     use super::*;
 
-    /// Verifies that the test pkarr builder doesn't contact the public DHT.
-    /// Uses Debug output because pkarr::ClientBuilder has no config getters.
+    /// Verifies that the test pkarr builder doesn't contact the public DHT
+    /// when database_url is None (the default test config).
     #[test]
     fn pkarr_builder_does_not_use_default_network() {
-        let builder =
-            AppContext::build_pkarr_builder_from_config(&ConfigToml::default_test_config());
+        let config = ConfigToml::default_test_config();
+        assert!(
+            config.general.database_url.is_none(),
+            "default_test_config should have database_url = None"
+        );
+        let builder = AppContext::build_pkarr_builder_from_config(&config);
         let builder_debug = format!("{builder:?}");
 
         assert!(

--- a/pubky-homeserver/src/client_server/app.rs
+++ b/pubky-homeserver/src/client_server/app.rs
@@ -259,6 +259,7 @@ mod tests {
     use crate::{
         app_context::AppContext,
         client_server::ClientServer,
+        data_directory::{ConfigToml, MockDataDir},
         shared::quota::{GlobPattern, HttpMethod, LimitKeyType, PathLimit},
         ConfigToml, MockDataDir,
     };
@@ -335,9 +336,9 @@ mod tests {
     #[pubky_test_utils::test]
     async fn storage_metrics_only_count_resolved_requests_with_low_cardinality_labels() {
         let data_dir = MockDataDir::new(ConfigToml::minimal_test_config(), None).unwrap();
-        let context = AppContext::read_from(data_dir).await.unwrap();
+        let context = Arc::new(AppContext::read_from(data_dir).await.unwrap());
         let metrics = context.metrics.clone();
-        let router = ClientServer::create_router(Arc::new(context)).unwrap();
+        let router = ClientServer::create_router(Arc::clone(&context)).unwrap();
         let server = TestServer::new(router).unwrap();
         let user = Keypair::random();
         let cookie = signup_cookie(&server, &user).await;
@@ -380,25 +381,25 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(samples.len(), 4, "unexpected metric samples:\n{output}");
-        assert!(samples.iter().any(|sample| {
+        assert!(samples.iter().any(|sample: &&str| {
             sample.contains("addressing_mode=\"path\"")
                 && sample.contains("auth_method=\"cookie\"")
                 && sample.contains("pubky_host_header=\"matching\"")
                 && sample.contains("pubky_host_query=\"true\"")
         }));
-        assert!(samples.iter().any(|sample| {
+        assert!(samples.iter().any(|sample: &&str| {
             sample.contains("addressing_mode=\"legacy\"")
                 && sample.contains("auth_method=\"none\"")
                 && sample.contains("pubky_host_header=\"matching\"")
                 && sample.contains("pubky_host_query=\"false\"")
         }));
-        assert!(samples.iter().any(|sample| {
+        assert!(samples.iter().any(|sample: &&str| {
             sample.contains("addressing_mode=\"path\"")
                 && sample.contains("auth_method=\"none\"")
                 && sample.contains("pubky_host_header=\"other\"")
                 && sample.contains("pubky_host_query=\"false\"")
         }));
-        assert!(samples.iter().any(|sample| {
+        assert!(samples.iter().any(|sample: &&str| {
             sample.contains("addressing_mode=\"legacy\"")
                 && sample.contains("auth_method=\"none\"")
                 && sample.contains("pubky_host_header=\"absent\"")

--- a/pubky-homeserver/src/client_server/app.rs
+++ b/pubky-homeserver/src/client_server/app.rs
@@ -261,7 +261,6 @@ mod tests {
         client_server::ClientServer,
         data_directory::{ConfigToml, MockDataDir},
         shared::quota::{GlobPattern, HttpMethod, LimitKeyType, PathLimit},
-        ConfigToml, MockDataDir,
     };
 
     #[tokio::test]

--- a/pubky-homeserver/src/data_directory/config_toml.rs
+++ b/pubky-homeserver/src/data_directory/config_toml.rs
@@ -91,7 +91,8 @@ pub struct GeneralToml {
     )]
     #[serde(default)]
     pub user_storage_quota_mb: u64,
-    pub database_url: ConnectionString,
+    #[serde(default)]
+    pub database_url: Option<ConnectionString>,
 }
 
 /// A config for Homeserver tracing subscriber configuration
@@ -213,7 +214,7 @@ impl ConfigToml {
     #[cfg(any(test, feature = "testing"))]
     pub fn default_test_config() -> Self {
         let mut config = Self::default();
-        config.general.database_url = ConnectionString::default_test_db(); // Mark this db as test. This indicates that the db is not real.
+        config.general.database_url = None; // Resolved downstream via env var or default fallback.
         config.general.signup_mode = SignupMode::Open;
         // Use ephemeral ports (0) so parallel tests don't collide.
         config.drive.icann_listen_socket = SocketAddr::from(([127, 0, 0, 1], 0));

--- a/pubky-homeserver/src/data_directory/data_dir.rs
+++ b/pubky-homeserver/src/data_directory/data_dir.rs
@@ -1,4 +1,5 @@
 use super::ConfigToml;
+use crate::persistence::sql::DatabaseMode;
 use dyn_clone::DynClone;
 use std::path::Path;
 
@@ -20,6 +21,13 @@ pub trait DataDir: std::fmt::Debug + DynClone + Send + Sync {
     /// Reads the secret file from the data directory.
     /// Creates a new secret file if it doesn't exist.
     fn read_or_create_keypair(&self) -> anyhow::Result<pubky_common::crypto::Keypair>;
+
+    /// Resolve how the homeserver should connect to its database.
+    ///
+    /// Each implementation decides its own strategy:
+    /// - [`PersistentDataDir`](super::PersistentDataDir): [`DatabaseMode::Direct`] — connects to the configured URL.
+    /// - [`MockDataDir`](super::MockDataDir): [`DatabaseMode::EphemeralTest`] — creates a temporary database.
+    fn resolve_database_mode(&self, conf: &ConfigToml) -> anyhow::Result<DatabaseMode>;
 }
 
 dyn_clone::clone_trait_object!(DataDir);

--- a/pubky-homeserver/src/data_directory/data_dir.rs
+++ b/pubky-homeserver/src/data_directory/data_dir.rs
@@ -24,9 +24,7 @@ pub trait DataDir: std::fmt::Debug + DynClone + Send + Sync {
 
     /// Resolve how the homeserver should connect to its database.
     ///
-    /// Each implementation decides its own strategy:
-    /// - [`PersistentDataDir`](super::PersistentDataDir): [`DatabaseMode::Direct`] — connects to the configured URL.
-    /// - [`MockDataDir`](super::MockDataDir): [`DatabaseMode::EphemeralTest`] — creates a temporary database.
+    /// Each implementation selects the appropriate database lifecycle.
     fn resolve_database_mode(&self, conf: &ConfigToml) -> anyhow::Result<DatabaseMode>;
 }
 

--- a/pubky-homeserver/src/data_directory/mock_data_dir.rs
+++ b/pubky-homeserver/src/data_directory/mock_data_dir.rs
@@ -75,3 +75,33 @@ impl DataDir for MockDataDir {
         Ok(self.keypair.clone())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::persistence::sql::{ConnectionString, DatabaseMode};
+
+    #[test]
+    fn resolve_database_mode_returns_ephemeral() {
+        let mock = MockDataDir::test();
+        let conf = mock.config_toml.clone();
+        let mode = mock.resolve_database_mode(&conf).unwrap();
+        assert!(
+            matches!(mode, DatabaseMode::EphemeralTest(_)),
+            "MockDataDir should always resolve to EphemeralTest"
+        );
+    }
+
+    #[test]
+    fn resolve_database_mode_with_explicit_url_returns_ephemeral() {
+        let mut config = super::super::ConfigToml::default_test_config();
+        config.general.database_url =
+            Some(ConnectionString::new("postgres://custom:5432/mydb").unwrap());
+        let mock = MockDataDir::new(config.clone(), None).unwrap();
+        let mode = mock.resolve_database_mode(&config).unwrap();
+        assert!(
+            matches!(mode, DatabaseMode::EphemeralTest(_)),
+            "MockDataDir should return EphemeralTest even with an explicit URL"
+        );
+    }
+}

--- a/pubky-homeserver/src/data_directory/mock_data_dir.rs
+++ b/pubky-homeserver/src/data_directory/mock_data_dir.rs
@@ -56,6 +56,13 @@ impl DataDir for MockDataDir {
         self.temp_dir.path()
     }
 
+    fn resolve_database_mode(
+        &self,
+        conf: &super::ConfigToml,
+    ) -> anyhow::Result<crate::persistence::sql::DatabaseMode> {
+        crate::persistence::sql::DatabaseMode::resolve_test(conf.general.database_url.clone())
+    }
+
     fn ensure_data_dir_exists_and_is_writable(&self) -> anyhow::Result<()> {
         Ok(()) // Always ok because this is validated by the tempfile crate.
     }

--- a/pubky-homeserver/src/data_directory/mock_data_dir.rs
+++ b/pubky-homeserver/src/data_directory/mock_data_dir.rs
@@ -56,6 +56,7 @@ impl DataDir for MockDataDir {
         self.temp_dir.path()
     }
 
+    /// Creates a temporary database with [`DatabaseMode::EphemeralTest`](crate::persistence::sql::DatabaseMode::EphemeralTest).
     fn resolve_database_mode(
         &self,
         conf: &super::ConfigToml,

--- a/pubky-homeserver/src/data_directory/persistent_data_dir.rs
+++ b/pubky-homeserver/src/data_directory/persistent_data_dir.rs
@@ -100,6 +100,7 @@ impl DataDir for PersistentDataDir {
         &self.expanded_path
     }
 
+    /// Connects to the configured URL with [`DatabaseMode::Direct`](crate::persistence::sql::DatabaseMode::Direct).
     fn resolve_database_mode(
         &self,
         conf: &ConfigToml,

--- a/pubky-homeserver/src/data_directory/persistent_data_dir.rs
+++ b/pubky-homeserver/src/data_directory/persistent_data_dir.rs
@@ -263,6 +263,37 @@ mod tests {
     }
 
     #[test]
+    fn resolve_database_mode_returns_direct_when_url_set() {
+        use crate::persistence::sql::{ConnectionString, DatabaseMode};
+
+        let mut conf = ConfigToml::default();
+        conf.general.database_url =
+            Some(ConnectionString::new("postgres://localhost:5432/mydb").unwrap());
+
+        let temp_dir = TempDir::new().unwrap();
+        let data_dir = PersistentDataDir::new(temp_dir.path().to_path_buf());
+        let mode = data_dir.resolve_database_mode(&conf).unwrap();
+        assert!(
+            matches!(mode, DatabaseMode::Direct(_)),
+            "PersistentDataDir should resolve to Direct"
+        );
+    }
+
+    #[test]
+    fn resolve_database_mode_errors_when_no_url() {
+        let mut conf = ConfigToml::default();
+        conf.general.database_url = None;
+
+        let temp_dir = TempDir::new().unwrap();
+        let data_dir = PersistentDataDir::new(temp_dir.path().to_path_buf());
+        let result = data_dir.resolve_database_mode(&conf);
+        assert!(
+            result.is_err(),
+            "PersistentDataDir should error when database_url is None"
+        );
+    }
+
+    #[test]
     pub fn test_trim_secret_file_content() {
         let temp_dir = TempDir::new().unwrap();
         let test_path = temp_dir.path().join(".pubky");

--- a/pubky-homeserver/src/data_directory/persistent_data_dir.rs
+++ b/pubky-homeserver/src/data_directory/persistent_data_dir.rs
@@ -100,6 +100,21 @@ impl DataDir for PersistentDataDir {
         &self.expanded_path
     }
 
+    fn resolve_database_mode(
+        &self,
+        conf: &ConfigToml,
+    ) -> anyhow::Result<crate::persistence::sql::DatabaseMode> {
+        conf.general
+            .database_url
+            .clone()
+            .map(crate::persistence::sql::DatabaseMode::Direct)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "No database_url configured. Set [general].database_url in config.toml."
+                )
+            })
+    }
+
     /// Makes sure the data directory exists.
     /// Create the directory if it doesn't exist.
     fn ensure_data_dir_exists_and_is_writable(&self) -> anyhow::Result<()> {

--- a/pubky-homeserver/src/lib.rs
+++ b/pubky-homeserver/src/lib.rs
@@ -36,7 +36,7 @@ pub use data_directory::{
 };
 pub use homeserver_app::{HomeserverApp, HomeserverAppBuildError};
 pub use metrics_server::{MetricsServer, MetricsServerBuildError};
-pub use persistence::sql::ConnectionString;
+pub use persistence::sql::{ConnectionString, DatabaseMode};
 pub use shared::quota::{
     BandwidthQuota, DefaultQuotasToml, GlobPattern, HttpMethod, LimitKey, LimitKeyType, PathLimit,
     RequestCountQuota, TimeUnit,

--- a/pubky-homeserver/src/persistence/sql/connection_string.rs
+++ b/pubky-homeserver/src/persistence/sql/connection_string.rs
@@ -42,11 +42,16 @@ impl ConnectionString {
 
 #[cfg(any(test, feature = "testing"))]
 impl ConnectionString {
-    /// Returns a connection string for a test database.
-    /// This is a postgres database that is not real.
-    /// It is used as an indicator for a empheral test database.
+    /// Default connection string for ephemeral test databases.
+    ///
+    /// This is the same as [`super::sql_db::DEFAULT_TEST_CONNECTION_STRING`] with
+    /// `?pubky-test=true` appended to signal ephemeral database creation.
     pub fn default_test_db() -> Self {
-        Self::new("postgres://postgres:postgres@localhost:5432/postgres?pubky-test=true").unwrap()
+        Self::new(&format!(
+            "{}?pubky-test=true",
+            super::sql_db::DEFAULT_TEST_CONNECTION_STRING
+        ))
+        .unwrap()
     }
 
     /// Returns true if the connection string is for a test database.

--- a/pubky-homeserver/src/persistence/sql/connection_string.rs
+++ b/pubky-homeserver/src/persistence/sql/connection_string.rs
@@ -11,11 +11,16 @@ impl ConnectionString {
     /// Create a new connection string from a string.
     /// This function validates that the connection string is a postgres connection string.
     pub fn new(con_string: &str) -> anyhow::Result<Self> {
-        let con = Self(url::Url::parse(con_string)?);
-        if !con.is_postgres() {
+        Self::validated(url::Url::parse(con_string)?)
+    }
+
+    /// Shared validation: ensures the URL uses a postgres scheme.
+    fn validated(url: url::Url) -> anyhow::Result<Self> {
+        let cs = Self(url);
+        if !cs.is_postgres() {
             anyhow::bail!("Only postgres database urls are supported");
         }
-        Ok(con)
+        Ok(cs)
     }
 
     /// Get the connection string as a str.
@@ -29,7 +34,6 @@ impl ConnectionString {
 
     /// Get the database name
     /// For postgres, this is the database name directly
-    /// For sqlite, this is the path to the database file
     pub fn database_name(&self) -> &str {
         self.0.path().trim_start_matches("/")
     }
@@ -42,18 +46,6 @@ impl ConnectionString {
 
 #[cfg(any(test, feature = "testing"))]
 impl ConnectionString {
-    /// Default connection string for ephemeral test databases.
-    ///
-    /// This is the same as [`super::sql_db::DEFAULT_TEST_CONNECTION_STRING`] with
-    /// `?pubky-test=true` appended to signal ephemeral database creation.
-    pub fn default_test_db() -> Self {
-        Self::new(&format!(
-            "{}?pubky-test=true",
-            super::sql_db::DEFAULT_TEST_CONNECTION_STRING
-        ))
-        .unwrap()
-    }
-
     /// Returns true if the connection string is for a test database.
     pub fn is_test_db(&self) -> bool {
         self.0
@@ -62,17 +54,19 @@ impl ConnectionString {
     }
 }
 
-impl From<url::Url> for ConnectionString {
-    fn from(url: url::Url) -> Self {
-        Self(url)
+impl TryFrom<url::Url> for ConnectionString {
+    type Error = anyhow::Error;
+
+    fn try_from(url: url::Url) -> Result<Self, Self::Error> {
+        Self::validated(url)
     }
 }
 
 impl FromStr for ConnectionString {
-    type Err = url::ParseError;
+    type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self(url::Url::parse(s)?))
+        Self::new(s)
     }
 }
 
@@ -101,25 +95,20 @@ impl<'de> Deserialize<'de> for ConnectionString {
     }
 }
 
-impl Default for ConnectionString {
-    fn default() -> Self {
-        Self::new("postgres://localhost:5432/pubky_homeserver").unwrap()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[tokio::test]
-    #[pubky_test_utils::test]
-    async fn test_create_db() {
-        let con_strings = vec![
-            "postgres://localhost:5432/pubky_homeserver",
-            "sqlite:///path/to/sqlite.db",
-        ];
-        for con_string in con_strings {
-            let _: ConnectionString = con_string.parse().unwrap();
-        }
+    #[test]
+    fn test_valid_postgres_url() {
+        let _: ConnectionString = "postgres://localhost:5432/pubky_homeserver"
+            .parse()
+            .unwrap();
+    }
+
+    #[test]
+    fn test_non_postgres_url_rejected() {
+        let result: Result<ConnectionString, _> = "sqlite:///path/to/sqlite.db".parse();
+        assert!(result.is_err(), "sqlite URLs should be rejected");
     }
 }

--- a/pubky-homeserver/src/persistence/sql/connection_string.rs
+++ b/pubky-homeserver/src/persistence/sql/connection_string.rs
@@ -38,9 +38,30 @@ impl ConnectionString {
         self.0.path().trim_start_matches("/")
     }
 
-    /// Set the database name
+    /// Set the database name, clearing any `dbname` query parameter that would
+    /// otherwise override the path. See
+    /// <https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS>
     pub fn set_database_name(&mut self, db_name: &str) {
         self.0.set_path(db_name);
+        self.remove_query_param("dbname");
+    }
+
+    /// Remove all occurrences of a query parameter by key.
+    fn remove_query_param(&mut self, key: &str) {
+        if self.0.query().is_none() {
+            return;
+        }
+        let pairs: Vec<_> = self
+            .0
+            .query_pairs()
+            .filter(|(k, _)| k != key)
+            .map(|(k, v)| (k.into_owned(), v.into_owned()))
+            .collect();
+        if pairs.is_empty() {
+            self.0.set_query(None);
+        } else {
+            self.0.query_pairs_mut().clear().extend_pairs(&pairs);
+        }
     }
 }
 
@@ -100,5 +121,46 @@ mod tests {
     fn test_non_postgres_url_rejected() {
         let result: Result<ConnectionString, _> = "sqlite:///path/to/sqlite.db".parse();
         assert!(result.is_err(), "sqlite URLs should be rejected");
+    }
+
+    #[test]
+    fn set_database_name_changes_path() {
+        let mut cs = ConnectionString::new("postgres://user:pass@localhost:5432/original").unwrap();
+        cs.set_database_name("new_db");
+        assert_eq!(cs.database_name(), "new_db");
+    }
+
+    #[test]
+    fn set_database_name_strips_dbname_query_param() {
+        let mut cs =
+            ConnectionString::new("postgres://user:pass@localhost:5432/postgres?dbname=postgres")
+                .unwrap();
+        cs.set_database_name("pubky_test_abc123");
+        assert_eq!(cs.database_name(), "pubky_test_abc123");
+        assert!(
+            !cs.as_str().contains("dbname="),
+            "dbname query param should be removed, got: {}",
+            cs.as_str()
+        );
+    }
+
+    #[test]
+    fn set_database_name_preserves_other_query_params() {
+        let mut cs = ConnectionString::new(
+            "postgres://user:pass@localhost:5432/postgres?dbname=postgres&sslmode=require",
+        )
+        .unwrap();
+        cs.set_database_name("pubky_test_abc123");
+        assert_eq!(cs.database_name(), "pubky_test_abc123");
+        assert!(
+            !cs.as_str().contains("dbname="),
+            "dbname should be removed, got: {}",
+            cs.as_str()
+        );
+        assert!(
+            cs.as_str().contains("sslmode=require"),
+            "other params should be preserved, got: {}",
+            cs.as_str()
+        );
     }
 }

--- a/pubky-homeserver/src/persistence/sql/connection_string.rs
+++ b/pubky-homeserver/src/persistence/sql/connection_string.rs
@@ -44,16 +44,6 @@ impl ConnectionString {
     }
 }
 
-#[cfg(any(test, feature = "testing"))]
-impl ConnectionString {
-    /// Returns true if the connection string is for a test database.
-    pub fn is_test_db(&self) -> bool {
-        self.0
-            .query_pairs()
-            .any(|(key, value)| key == "pubky-test" && value == "true")
-    }
-}
-
 impl TryFrom<url::Url> for ConnectionString {
     type Error = anyhow::Error;
 

--- a/pubky-homeserver/src/persistence/sql/database_mode.rs
+++ b/pubky-homeserver/src/persistence/sql/database_mode.rs
@@ -55,21 +55,15 @@ impl DatabaseMode {
         explicit: Option<ConnectionString>,
         env_val: Option<String>,
     ) -> anyhow::Result<Self> {
-        if let Some(url) = explicit {
-            return Ok(Self::EphemeralTest(url));
-        }
-
-        if let Some(raw) = env_val {
-            let url = ConnectionString::new(&raw).map_err(|e| {
+        let url = match (explicit, env_val) {
+            (Some(url), _) => url,
+            (None, Some(raw)) => ConnectionString::new(&raw).map_err(|e| {
                 anyhow::anyhow!("Invalid TEST_PUBKY_CONNECTION_STRING: {raw}. Error: {e}")
-            })?;
-            return Ok(Self::EphemeralTest(url));
-        }
-
-        Ok(Self::EphemeralTest(
-            ConnectionString::new(DEFAULT_TEST_SERVER)
+            })?,
+            (None, None) => ConnectionString::new(DEFAULT_TEST_SERVER)
                 .expect("Default test connection string is valid"),
-        ))
+        };
+        Ok(Self::EphemeralTest(url))
     }
 }
 

--- a/pubky-homeserver/src/persistence/sql/database_mode.rs
+++ b/pubky-homeserver/src/persistence/sql/database_mode.rs
@@ -1,0 +1,123 @@
+use super::connection_string::ConnectionString;
+
+/// How the homeserver should connect to its database.
+///
+/// This enum makes the distinction between "connect to an existing database"
+/// and "create a fresh ephemeral database for this test" explicit.
+#[derive(Debug, Clone)]
+pub enum DatabaseMode {
+    /// Connect directly to the database identified by the URL.
+    /// Used in production and persistent testnets.
+    Direct(ConnectionString),
+
+    /// Create an ephemeral `pubky_test_{uuid}` database on the server
+    /// identified by the URL, then connect to it. The database is dropped
+    /// when the [`SqlDb`](super::SqlDb) is dropped.
+    ///
+    /// Only available in test / testing builds.
+    #[cfg(any(test, feature = "testing"))]
+    EphemeralTest(ConnectionString),
+}
+
+impl DatabaseMode {
+    /// Returns the underlying connection string, regardless of mode.
+    #[cfg(test)]
+    pub fn connection_string(&self) -> &ConnectionString {
+        match self {
+            Self::Direct(url) => url,
+            #[cfg(any(test, feature = "testing"))]
+            Self::EphemeralTest(url) => url,
+        }
+    }
+}
+
+#[cfg(any(test, feature = "testing"))]
+const DEFAULT_TEST_SERVER: &str = "postgres://localhost:5432/postgres";
+
+#[cfg(any(test, feature = "testing"))]
+impl DatabaseMode {
+    /// Resolve a `database_url` from config into a `DatabaseMode`.
+    ///
+    /// Priority:
+    /// 1. Explicitly provided URL (e.g. from Docker Postgres or config) → `EphemeralTest`
+    /// 2. `TEST_PUBKY_CONNECTION_STRING` environment variable → `EphemeralTest`
+    /// 3. [`DEFAULT_TEST_SERVER`] fallback → `EphemeralTest`
+    ///
+    /// Tests always get ephemeral databases — the decision is encoded here,
+    /// not in a URL query parameter.
+    pub fn resolve_test(explicit: Option<ConnectionString>) -> Self {
+        let env_val = std::env::var("TEST_PUBKY_CONNECTION_STRING").ok();
+        Self::resolve_test_inner(explicit, env_val)
+    }
+
+    /// Pure resolution logic, separated from env access for testability.
+    fn resolve_test_inner(explicit: Option<ConnectionString>, env_val: Option<String>) -> Self {
+        if let Some(url) = explicit {
+            return Self::EphemeralTest(url);
+        }
+
+        if let Some(raw) = env_val {
+            match ConnectionString::new(&raw) {
+                Ok(url) => return Self::EphemeralTest(url),
+                Err(e) => {
+                    tracing::warn!(
+                        "Invalid TEST_PUBKY_CONNECTION_STRING: {raw}. Falling back to default. Error: {e}"
+                    );
+                }
+            }
+        }
+
+        Self::EphemeralTest(
+            ConnectionString::new(DEFAULT_TEST_SERVER)
+                .expect("Default test connection string is valid"),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_explicit_wins_over_env() {
+        let explicit = ConnectionString::new("postgres://custom:5432/mydb").unwrap();
+        let env_val = Some("postgres://envhost:5432/envdb".to_string());
+        let result = DatabaseMode::resolve_test_inner(Some(explicit.clone()), env_val);
+        assert_eq!(result.connection_string(), &explicit);
+        assert!(matches!(result, DatabaseMode::EphemeralTest(_)));
+    }
+
+    #[test]
+    fn resolve_env_var_used_when_no_explicit() {
+        let env_val = Some("postgres://envhost:5432/envdb".to_string());
+        let result = DatabaseMode::resolve_test_inner(None, env_val);
+        assert_eq!(
+            result.connection_string().as_str(),
+            "postgres://envhost:5432/envdb"
+        );
+        assert!(matches!(result, DatabaseMode::EphemeralTest(_)));
+    }
+
+    #[test]
+    fn resolve_falls_back_to_default() {
+        let result = DatabaseMode::resolve_test_inner(None, None);
+        assert_eq!(result.connection_string().as_str(), DEFAULT_TEST_SERVER);
+        assert!(matches!(result, DatabaseMode::EphemeralTest(_)));
+    }
+
+    #[test]
+    fn resolve_invalid_env_var_falls_back_to_default() {
+        let env_val = Some("not-a-valid-url".to_string());
+        let result = DatabaseMode::resolve_test_inner(None, env_val);
+        assert_eq!(result.connection_string().as_str(), DEFAULT_TEST_SERVER);
+    }
+
+    #[test]
+    fn resolve_strips_pubky_test_param_gracefully() {
+        // Backwards compat: old-style URLs with ?pubky-test=true still work
+        let env_val =
+            Some("postgres://user:pass@localhost:5432/postgres?pubky-test=true".to_string());
+        let result = DatabaseMode::resolve_test_inner(None, env_val);
+        assert!(matches!(result, DatabaseMode::EphemeralTest(_)));
+    }
+}

--- a/pubky-homeserver/src/persistence/sql/database_mode.rs
+++ b/pubky-homeserver/src/persistence/sql/database_mode.rs
@@ -45,32 +45,31 @@ impl DatabaseMode {
     ///
     /// Tests always get ephemeral databases — the decision is encoded here,
     /// not in a URL query parameter.
-    pub fn resolve_test(explicit: Option<ConnectionString>) -> Self {
+    pub fn resolve_test(explicit: Option<ConnectionString>) -> anyhow::Result<Self> {
         let env_val = std::env::var("TEST_PUBKY_CONNECTION_STRING").ok();
         Self::resolve_test_inner(explicit, env_val)
     }
 
     /// Pure resolution logic, separated from env access for testability.
-    fn resolve_test_inner(explicit: Option<ConnectionString>, env_val: Option<String>) -> Self {
+    fn resolve_test_inner(
+        explicit: Option<ConnectionString>,
+        env_val: Option<String>,
+    ) -> anyhow::Result<Self> {
         if let Some(url) = explicit {
-            return Self::EphemeralTest(url);
+            return Ok(Self::EphemeralTest(url));
         }
 
         if let Some(raw) = env_val {
-            match ConnectionString::new(&raw) {
-                Ok(url) => return Self::EphemeralTest(url),
-                Err(e) => {
-                    tracing::warn!(
-                        "Invalid TEST_PUBKY_CONNECTION_STRING: {raw}. Falling back to default. Error: {e}"
-                    );
-                }
-            }
+            let url = ConnectionString::new(&raw).map_err(|e| {
+                anyhow::anyhow!("Invalid TEST_PUBKY_CONNECTION_STRING: {raw}. Error: {e}")
+            })?;
+            return Ok(Self::EphemeralTest(url));
         }
 
-        Self::EphemeralTest(
+        Ok(Self::EphemeralTest(
             ConnectionString::new(DEFAULT_TEST_SERVER)
                 .expect("Default test connection string is valid"),
-        )
+        ))
     }
 }
 
@@ -82,7 +81,7 @@ mod tests {
     fn resolve_explicit_wins_over_env() {
         let explicit = ConnectionString::new("postgres://custom:5432/mydb").unwrap();
         let env_val = Some("postgres://envhost:5432/envdb".to_string());
-        let result = DatabaseMode::resolve_test_inner(Some(explicit.clone()), env_val);
+        let result = DatabaseMode::resolve_test_inner(Some(explicit.clone()), env_val).unwrap();
         assert_eq!(result.connection_string(), &explicit);
         assert!(matches!(result, DatabaseMode::EphemeralTest(_)));
     }
@@ -90,7 +89,7 @@ mod tests {
     #[test]
     fn resolve_env_var_used_when_no_explicit() {
         let env_val = Some("postgres://envhost:5432/envdb".to_string());
-        let result = DatabaseMode::resolve_test_inner(None, env_val);
+        let result = DatabaseMode::resolve_test_inner(None, env_val).unwrap();
         assert_eq!(
             result.connection_string().as_str(),
             "postgres://envhost:5432/envdb"
@@ -100,24 +99,23 @@ mod tests {
 
     #[test]
     fn resolve_falls_back_to_default() {
-        let result = DatabaseMode::resolve_test_inner(None, None);
+        let result = DatabaseMode::resolve_test_inner(None, None).unwrap();
         assert_eq!(result.connection_string().as_str(), DEFAULT_TEST_SERVER);
         assert!(matches!(result, DatabaseMode::EphemeralTest(_)));
     }
 
     #[test]
-    fn resolve_invalid_env_var_falls_back_to_default() {
+    fn resolve_invalid_env_var_errors() {
         let env_val = Some("not-a-valid-url".to_string());
         let result = DatabaseMode::resolve_test_inner(None, env_val);
-        assert_eq!(result.connection_string().as_str(), DEFAULT_TEST_SERVER);
+        assert!(result.is_err());
     }
 
     #[test]
-    fn resolve_strips_pubky_test_param_gracefully() {
-        // Backwards compat: old-style URLs with ?pubky-test=true still work
+    fn resolve_old_style_url_with_pubky_test_param_still_works() {
         let env_val =
             Some("postgres://user:pass@localhost:5432/postgres?pubky-test=true".to_string());
-        let result = DatabaseMode::resolve_test_inner(None, env_val);
+        let result = DatabaseMode::resolve_test_inner(None, env_val).unwrap();
         assert!(matches!(result, DatabaseMode::EphemeralTest(_)));
     }
 }

--- a/pubky-homeserver/src/persistence/sql/database_mode.rs
+++ b/pubky-homeserver/src/persistence/sql/database_mode.rs
@@ -11,8 +11,13 @@ pub enum DatabaseMode {
     Direct(ConnectionString),
 
     /// Create an ephemeral `pubky_test_{uuid}` database on the server
-    /// identified by the URL, then connect to it. The database is dropped
-    /// when the [`SqlDb`](super::SqlDb) is dropped.
+    /// identified by the URL, then connect to it.
+    ///
+    /// Dropping the [`SqlDb`](super::SqlDb) **registers** the database for
+    /// cleanup but does not delete it immediately. Actual deletion requires
+    /// the `#[pubky_testnet::test]` macro or an explicit call to
+    /// [`drop_test_databases()`](pubky_test_utils::drop_test_databases).
+    /// Without either, the database will be leaked.
     ///
     /// Only available in test / testing builds.
     #[cfg(any(test, feature = "testing"))]

--- a/pubky-homeserver/src/persistence/sql/mod.rs
+++ b/pubky-homeserver/src/persistence/sql/mod.rs
@@ -6,6 +6,7 @@
 //! both pooled connections and explicit transactions.
 
 mod connection_string;
+mod database_mode;
 pub(crate) mod entities;
 mod migration;
 pub(crate) mod migrations;
@@ -15,11 +16,10 @@ mod sql_db;
 mod unified_executor;
 
 pub use connection_string::ConnectionString;
-pub use entities::entry;
-pub use entities::signup_code;
-pub(crate) use entities::user;
+pub use database_mode::DatabaseMode;
+pub use entities::*;
 pub use migrator::Migrator;
 pub(crate) use pg_event_listener::PgEventListener;
-pub use sql_db::{SqlDb, SqlDbConnectError};
+pub use sql_db::SqlDb;
 pub(crate) use unified_executor::uexecutor;
 pub(crate) use unified_executor::UnifiedExecutor;

--- a/pubky-homeserver/src/persistence/sql/mod.rs
+++ b/pubky-homeserver/src/persistence/sql/mod.rs
@@ -17,7 +17,9 @@ mod unified_executor;
 
 pub use connection_string::ConnectionString;
 pub use database_mode::DatabaseMode;
-pub use entities::*;
+pub use entities::entry;
+pub use entities::signup_code;
+pub(crate) use entities::user;
 pub use migrator::Migrator;
 pub(crate) use pg_event_listener::PgEventListener;
 pub use sql_db::SqlDb;

--- a/pubky-homeserver/src/persistence/sql/mod.rs
+++ b/pubky-homeserver/src/persistence/sql/mod.rs
@@ -20,6 +20,6 @@ pub use entities::signup_code;
 pub(crate) use entities::user;
 pub use migrator::Migrator;
 pub(crate) use pg_event_listener::PgEventListener;
-pub use sql_db::SqlDb;
+pub use sql_db::{SqlDb, SqlDbConnectError};
 pub(crate) use unified_executor::uexecutor;
 pub(crate) use unified_executor::UnifiedExecutor;

--- a/pubky-homeserver/src/persistence/sql/sql_db.rs
+++ b/pubky-homeserver/src/persistence/sql/sql_db.rs
@@ -155,6 +155,7 @@ impl SqlDb {
     /// Create a test database without running migrations
     /// If the DB_CONNECTION_STRING environment variable is not set, a temporary directory is used for the sqlite database
     /// If the DB_CONNECTION_STRING environment variable is set, the test database is created on the existing database
+    #[allow(dead_code)]
     pub async fn test_without_migrations() -> Self {
         Self::test_postgres_db(None)
             .await
@@ -164,6 +165,7 @@ impl SqlDb {
     /// Create a test database and run migrations
     /// If the DB_CONNECTION_STRING environment variable is not set, a temporary directory is used for the sqlite database
     /// If the DB_CONNECTION_STRING environment variable is set, the migrations are run on the existing database
+    #[allow(dead_code)]
     pub async fn test() -> Self {
         use crate::persistence::sql::migrator::Migrator;
         let db = Self::test_without_migrations().await;

--- a/pubky-homeserver/src/persistence/sql/sql_db.rs
+++ b/pubky-homeserver/src/persistence/sql/sql_db.rs
@@ -98,15 +98,8 @@ impl SqlDb {
     async fn create_ephemeral_test_db(
         admin_con_string: ConnectionString,
     ) -> Result<Self, sqlx::Error> {
-        use uuid::Uuid;
-
-        let admin_con = Self::connect_inner(&admin_con_string).await?;
-        let test_db_name = format!("pubky_test_{}", Uuid::new_v4().as_simple());
-        let query = format!("CREATE DATABASE \"{}\"", test_db_name);
-        sqlx::query(&query).execute(admin_con.pool()).await?;
-
-        let mut test_db_url = admin_con_string.clone();
-        test_db_url.set_database_name(&test_db_name);
+        let (test_db_url, test_db_name) =
+            Self::create_ephemeral_db_on_server(&admin_con_string).await?;
 
         let mut con = Self::connect_inner(&test_db_url).await?;
         con.db_dropper = Some(std::sync::Arc::new(TestDbDropper::new(
@@ -114,6 +107,24 @@ impl SqlDb {
             admin_con_string.to_string(),
         )));
         Ok(con)
+    }
+
+    /// Create an ephemeral `pubky_test_{uuid}` database on the given server.
+    ///
+    /// Returns the connection string to the new database and its name.
+    async fn create_ephemeral_db_on_server(
+        admin_con_string: &ConnectionString,
+    ) -> Result<(ConnectionString, String), sqlx::Error> {
+        use uuid::Uuid;
+
+        let admin_con = Self::connect_inner(admin_con_string).await?;
+        let test_db_name = format!("pubky_test_{}", Uuid::new_v4().as_simple());
+        let query = format!("CREATE DATABASE \"{}\"", test_db_name);
+        sqlx::query(&query).execute(admin_con.pool()).await?;
+
+        let mut test_db_url = admin_con_string.clone();
+        test_db_url.set_database_name(&test_db_name);
+        Ok((test_db_url, test_db_name))
     }
 
     /// Create a test database without running migrations.
@@ -143,25 +154,13 @@ impl SqlDb {
         max_connections: u32,
         acquire_timeout: std::time::Duration,
     ) -> Self {
-        use uuid::Uuid;
-
         let mode = DatabaseMode::resolve_test(None).expect("Failed to resolve test database mode");
         let admin_url = match mode {
-            DatabaseMode::EphemeralTest(url) => url,
-            DatabaseMode::Direct(url) => url,
+            DatabaseMode::EphemeralTest(url) | DatabaseMode::Direct(url) => url,
         };
-        let admin_con = Self::connect_inner(&admin_url)
-            .await
-            .expect("Failed to connect to admin database");
-        let test_db_name = format!("pubky_test_{}", Uuid::new_v4().as_simple());
-        let query = format!("CREATE DATABASE \"{}\"", test_db_name);
-        sqlx::query(&query)
-            .execute(admin_con.pool())
+        let (test_db_url, test_db_name) = Self::create_ephemeral_db_on_server(&admin_url)
             .await
             .expect("Failed to create test database");
-
-        let mut test_db_url = admin_url.clone();
-        test_db_url.set_database_name(&test_db_name);
 
         let pool = PgPoolOptions::new()
             .max_connections(max_connections)

--- a/pubky-homeserver/src/persistence/sql/sql_db.rs
+++ b/pubky-homeserver/src/persistence/sql/sql_db.rs
@@ -33,7 +33,8 @@ impl SqlDb {
     ///
     /// - [`DatabaseMode::Direct`]: connects to the database identified by the URL.
     /// - [`DatabaseMode::EphemeralTest`]: creates a fresh `pubky_test_{uuid}` database
-    ///   on the server, connects to it, and drops it when this `SqlDb` is dropped.
+    ///   on the server and connects to it. Dropping this `SqlDb` registers the
+    ///   database for cleanup; see [`DatabaseMode::EphemeralTest`] for details.
     pub async fn connect(mode: DatabaseMode) -> Result<Self, sqlx::Error> {
         match mode {
             DatabaseMode::Direct(url) => Self::connect_inner(&url).await,
@@ -60,7 +61,11 @@ impl SqlDb {
     }
 }
 
-/// Helper struct to drop the postgres test database after the db connection is dropped.
+/// Registers an ephemeral test database for cleanup when dropped.
+///
+/// Dropping this struct does **not** delete the database immediately — it
+/// queues it for later removal by [`drop_test_databases()`](pubky_test_utils::drop_test_databases),
+/// which is called automatically by the `#[pubky_testnet::test]` macro.
 #[cfg(any(test, feature = "testing"))]
 struct TestDbDropper {
     db_name: String,
@@ -94,7 +99,8 @@ impl SqlDb {
     /// Creates an ephemeral `pubky_test_{uuid}` database and connects to it.
     ///
     /// `admin_con_string` is used for the initial admin connection that creates
-    /// the database. The returned `SqlDb` will drop its database on scope exit.
+    /// the database. The returned `SqlDb` registers the database for cleanup
+    /// on drop (see [`TestDbDropper`]).
     async fn create_ephemeral_test_db(
         admin_con_string: ConnectionString,
     ) -> Result<Self, sqlx::Error> {

--- a/pubky-homeserver/src/persistence/sql/sql_db.rs
+++ b/pubky-homeserver/src/persistence/sql/sql_db.rs
@@ -119,7 +119,7 @@ impl SqlDb {
     /// Create a test database without running migrations.
     #[cfg(test)]
     pub async fn test_without_migrations() -> Self {
-        let mode = DatabaseMode::resolve_test(None);
+        let mode = DatabaseMode::resolve_test(None).expect("Failed to resolve test database mode");
         Self::connect(mode)
             .await
             .expect("Failed to create test database")
@@ -145,7 +145,7 @@ impl SqlDb {
     ) -> Self {
         use uuid::Uuid;
 
-        let mode = DatabaseMode::resolve_test(None);
+        let mode = DatabaseMode::resolve_test(None).expect("Failed to resolve test database mode");
         let admin_url = match mode {
             DatabaseMode::EphemeralTest(url) => url,
             DatabaseMode::Direct(url) => url,
@@ -189,7 +189,7 @@ mod tests {
     #[tokio::test]
     #[pubky_test_utils::test]
     async fn pg_db_available() {
-        let mode = DatabaseMode::resolve_test(None);
+        let mode = DatabaseMode::resolve_test(None).unwrap();
         let _db = SqlDb::connect(mode).await.unwrap();
     }
 }

--- a/pubky-homeserver/src/persistence/sql/sql_db.rs
+++ b/pubky-homeserver/src/persistence/sql/sql_db.rs
@@ -143,21 +143,37 @@ impl SqlDb {
         max_connections: u32,
         acquire_timeout: std::time::Duration,
     ) -> Self {
-        let admin_con_string = Self::derive_connection_string(None);
-        let test_db_con_string = Self::create_test_database(admin_con_string.clone())
+        use uuid::Uuid;
+
+        let mode = DatabaseMode::resolve_test(None);
+        let admin_url = match mode {
+            DatabaseMode::EphemeralTest(url) => url,
+            DatabaseMode::Direct(url) => url,
+        };
+        let admin_con = Self::connect_inner(&admin_url)
+            .await
+            .expect("Failed to connect to admin database");
+        let test_db_name = format!("pubky_test_{}", Uuid::new_v4().as_simple());
+        let query = format!("CREATE DATABASE \"{}\"", test_db_name);
+        sqlx::query(&query)
+            .execute(admin_con.pool())
             .await
             .expect("Failed to create test database");
+
+        let mut test_db_url = admin_url.clone();
+        test_db_url.set_database_name(&test_db_name);
+
         let pool = PgPoolOptions::new()
             .max_connections(max_connections)
             .acquire_timeout(acquire_timeout)
-            .connect(test_db_con_string.as_str())
+            .connect(test_db_url.as_str())
             .await
             .expect("Failed to connect to test database");
         let db = Self {
             pool,
             db_dropper: Some(std::sync::Arc::new(TestDbDropper::new(
-                test_db_con_string.database_name().to_string(),
-                admin_con_string.to_string(),
+                test_db_name,
+                admin_url.to_string(),
             ))),
         };
         let migrator = crate::persistence::sql::migrator::Migrator::new(&db);

--- a/pubky-homeserver/src/persistence/sql/sql_db.rs
+++ b/pubky-homeserver/src/persistence/sql/sql_db.rs
@@ -84,7 +84,7 @@ impl Drop for TestDbDropper {
 }
 
 #[cfg(any(test, feature = "testing"))]
-const DEFAULT_TEST_CONNECTION_STRING: &str = "postgres://localhost:5432/postgres";
+pub(crate) const DEFAULT_TEST_CONNECTION_STRING: &str = "postgres://localhost:5432/postgres";
 
 #[cfg(any(test, feature = "testing"))]
 impl SqlDb {

--- a/pubky-homeserver/src/persistence/sql/sql_db.rs
+++ b/pubky-homeserver/src/persistence/sql/sql_db.rs
@@ -152,20 +152,18 @@ impl SqlDb {
             .expect("Default test connection string is valid")
     }
 
-    /// Create a test database without running migrations
-    /// If the DB_CONNECTION_STRING environment variable is not set, a temporary directory is used for the sqlite database
-    /// If the DB_CONNECTION_STRING environment variable is set, the test database is created on the existing database
-    #[allow(dead_code)]
+    /// Create a test database without running migrations.
+    /// Convenience wrapper around [`Self::test_postgres_db`] that panics on failure.
+    #[cfg(test)]
     pub async fn test_without_migrations() -> Self {
         Self::test_postgres_db(None)
             .await
             .expect("Failed to create test database")
     }
 
-    /// Create a test database and run migrations
-    /// If the DB_CONNECTION_STRING environment variable is not set, a temporary directory is used for the sqlite database
-    /// If the DB_CONNECTION_STRING environment variable is set, the migrations are run on the existing database
-    #[allow(dead_code)]
+    /// Create a test database and run migrations.
+    /// Convenience wrapper around [`Self::test_without_migrations`] + [`Migrator::run`].
+    #[cfg(test)]
     pub async fn test() -> Self {
         use crate::persistence::sql::migrator::Migrator;
         let db = Self::test_without_migrations().await;

--- a/pubky-homeserver/src/persistence/sql/sql_db.rs
+++ b/pubky-homeserver/src/persistence/sql/sql_db.rs
@@ -21,6 +21,17 @@ pub struct SqlDb {
     db_dropper: Option<std::sync::Arc<TestDbDropper>>,
 }
 
+/// Errors from [`SqlDb::connect`].
+#[derive(Debug, thiserror::Error)]
+pub enum SqlDbConnectError {
+    /// SQL connection or database creation failed.
+    #[error("{0}")]
+    Sql(sqlx::Error),
+    /// No database URL configured (production builds only).
+    #[error("No database_url configured. Set [general].database_url in config.toml.")]
+    NoDatabaseUrl,
+}
+
 impl std::fmt::Debug for SqlDb {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "DbConnection")
@@ -28,17 +39,39 @@ impl std::fmt::Debug for SqlDb {
 }
 
 impl SqlDb {
-    /// Connect to the database. Respects the pubky_test flag
-    pub async fn connect(con_string: &ConnectionString) -> Result<Self, sqlx::Error> {
+    /// Connect to the database.
+    ///
+    /// In test builds (`#[cfg(test)]` or `feature = "testing"`):
+    /// - Resolves `None` via env var (`TEST_PUBKY_CONNECTION_STRING`) or built-in default
+    /// - Creates an ephemeral `pubky_test_{uuid}` database when the URL has `?pubky-test=true`
+    /// - Connects directly for non-test URLs (e.g. a real Postgres instance)
+    ///
+    /// In production builds, `None` is an error.
+    pub async fn connect(con_string: Option<ConnectionString>) -> Result<Self, SqlDbConnectError> {
         #[cfg(any(test, feature = "testing"))]
-        if con_string.is_test_db() {
-            return Self::test_postgres_db(Some(con_string.clone())).await;
+        {
+            let resolved = Self::derive_connection_string(con_string);
+            return if resolved.is_test_db() {
+                Self::create_ephemeral_test_db(resolved)
+                    .await
+                    .map_err(SqlDbConnectError::Sql)
+            } else {
+                Self::connect_inner(&resolved)
+                    .await
+                    .map_err(SqlDbConnectError::Sql)
+            };
         }
 
-        Self::connect_inner(con_string).await
+        #[cfg(not(any(test, feature = "testing")))]
+        {
+            let resolved = con_string.ok_or(SqlDbConnectError::NoDatabaseUrl)?;
+            Self::connect_inner(&resolved)
+                .await
+                .map_err(SqlDbConnectError::Sql)
+        }
     }
 
-    /// Connect to the database. directly without any test db logic.
+    /// Connect to the database directly without any test db logic.
     async fn connect_inner(con_string: &ConnectionString) -> Result<Self, sqlx::Error> {
         let pool: PgPool = PgPool::connect(con_string.as_str()).await?;
         Ok(Self {
@@ -84,40 +117,33 @@ impl Drop for TestDbDropper {
 }
 
 #[cfg(any(test, feature = "testing"))]
-pub(crate) const DEFAULT_TEST_CONNECTION_STRING: &str = "postgres://localhost:5432/postgres";
+pub(crate) const DEFAULT_TEST_CONNECTION_STRING: &str =
+    "postgres://localhost:5432/postgres?pubky-test=true";
 
 #[cfg(any(test, feature = "testing"))]
 impl SqlDb {
-    /// Creates a new test database with the name `pubky_test_{uuid}`.
-    /// The provided `admin_con_string` is used to create the test database. The database name defined by the admin connection string
-    /// is only used to create the actual test database.
-    /// If no connection string is passed, the connection string is read from the TEST_PUBKY_CONNECTION_STRING environment variable.
-    /// If the environment variable is not set, the default test connection string is used.
+    /// Creates a new `pubky_test_{uuid}` database on the server identified by
+    /// `admin_con_string`. The database name in that URL is used only for the
+    /// initial admin connection; the actual test database gets a unique name.
     async fn create_test_database(
         admin_con_string: ConnectionString,
     ) -> Result<ConnectionString, sqlx::Error> {
         use uuid::Uuid;
         let admin_con = Self::connect_inner(&admin_con_string).await?;
         let test_db_name = format!("pubky_test_{}", Uuid::new_v4().as_simple());
-        let query = format!("CREATE DATABASE {}", test_db_name);
+        let query = format!("CREATE DATABASE \"{}\"", test_db_name);
         sqlx::query(&query).execute(admin_con.pool()).await?;
         let mut test_db_con_string = admin_con_string.clone();
         test_db_con_string.set_database_name(&test_db_name);
         Ok(test_db_con_string)
     }
-    /// Creates a new test database with the name `pubky_test_{uuid}`.
-    /// The provided `admin_con_string` is used to create the test database. The database name defined by the admin connection string
-    /// is only used to create the actual test database.
-    /// If no connection string is passed, the connection string is read from the TEST_PUBKY_CONNECTION_STRING environment variable.
-    /// If the environment variable is not set, the default test connection string is used.
-    pub async fn test_postgres_db(
-        admin_con_string: Option<ConnectionString>,
+    /// Creates an ephemeral `pubky_test_{uuid}` database and connects to it.
+    /// The returned `SqlDb` will drop its database when it goes out of scope.
+    async fn create_ephemeral_test_db(
+        admin_con_string: ConnectionString,
     ) -> Result<Self, sqlx::Error> {
-        let admin_con_string = Self::derive_connection_string(admin_con_string);
-
         let test_db_con_string = Self::create_test_database(admin_con_string.clone()).await?;
 
-        // Connect to the test database.
         let mut con = Self::connect_inner(&test_db_con_string).await?;
         con.db_dropper = Some(std::sync::Arc::new(TestDbDropper::new(
             test_db_con_string.database_name().to_string(),
@@ -126,47 +152,44 @@ impl SqlDb {
         Ok(con)
     }
 
-    /// Derives the admin connection string to use for the test database creation.
+    /// Derives the connection string for test database creation.
     ///
     /// Priority:
-    /// 1. Explicitly provided URL (if different from [`ConnectionString::default_test_db`])
+    /// 1. Explicitly provided URL (e.g. Docker Postgres) — used as-is
     /// 2. `TEST_PUBKY_CONNECTION_STRING` environment variable
     /// 3. [`DEFAULT_TEST_CONNECTION_STRING`] fallback
-    ///
-    /// An explicitly provided URL that equals the default is treated as "no
-    /// explicit config" so the env var can still override it. This lets Docker
-    /// Postgres (non-default URL) pass through while the default config defers
-    /// to the user's env var.
-    pub fn derive_connection_string(
-        admin_con_string: Option<ConnectionString>,
+    pub(crate) fn derive_connection_string(explicit: Option<ConnectionString>) -> ConnectionString {
+        let env_val = std::env::var("TEST_PUBKY_CONNECTION_STRING").ok();
+        Self::resolve_connection_string(explicit, env_val)
+    }
+
+    /// Pure resolution logic, separated from env access for testability.
+    fn resolve_connection_string(
+        explicit: Option<ConnectionString>,
+        env_val: Option<String>,
     ) -> ConnectionString {
-        // If an explicitly non-default connection string was provided, use it.
-        if let Some(ref con_string) = admin_con_string {
-            if *con_string != ConnectionString::default_test_db() {
-                return con_string.clone();
-            }
+        if let Some(url) = explicit {
+            return url;
         }
 
-        // Check the environment variable.
-        if let Ok(raw_con_string) = std::env::var("TEST_PUBKY_CONNECTION_STRING") {
-            match ConnectionString::new(&raw_con_string) {
+        if let Some(raw) = env_val {
+            match ConnectionString::new(&raw) {
                 Ok(con_string) => return con_string,
                 Err(e) => {
-                    tracing::warn!("Invalid database connection string in TEST_PUBKY_CONNECTION_STRING environment variable: {}. Fallback to default test connection string. Error: {e}", raw_con_string);
+                    tracing::warn!("Invalid TEST_PUBKY_CONNECTION_STRING: {raw}. Falling back to default. Error: {e}");
                 }
             }
         }
 
-        // Final fallback.
         ConnectionString::new(DEFAULT_TEST_CONNECTION_STRING)
             .expect("Default test connection string is valid")
     }
 
     /// Create a test database without running migrations.
-    /// Convenience wrapper around [`Self::test_postgres_db`] that panics on failure.
     #[cfg(test)]
     pub async fn test_without_migrations() -> Self {
-        Self::test_postgres_db(None)
+        let resolved = Self::derive_connection_string(None);
+        Self::create_ephemeral_test_db(resolved)
             .await
             .expect("Failed to create test database")
     }
@@ -219,6 +242,39 @@ mod tests {
     #[tokio::test]
     #[pubky_test_utils::test]
     async fn test_pg_db_available() {
-        let _db = SqlDb::test_postgres_db(None).await.unwrap();
+        let resolved = SqlDb::derive_connection_string(None);
+        let _db = SqlDb::create_ephemeral_test_db(resolved).await.unwrap();
+    }
+
+    #[test]
+    fn resolve_explicit_wins_over_env() {
+        let explicit =
+            ConnectionString::new("postgres://custom:5432/mydb?pubky-test=true").unwrap();
+        let env_val = Some("postgres://envhost:5432/envdb?pubky-test=true".to_string());
+        let result = SqlDb::resolve_connection_string(Some(explicit.clone()), env_val);
+        assert_eq!(result, explicit);
+    }
+
+    #[test]
+    fn resolve_env_var_used_when_no_explicit() {
+        let env_val = Some("postgres://envhost:5432/envdb?pubky-test=true".to_string());
+        let result = SqlDb::resolve_connection_string(None, env_val);
+        assert_eq!(
+            result.as_str(),
+            "postgres://envhost:5432/envdb?pubky-test=true"
+        );
+    }
+
+    #[test]
+    fn resolve_falls_back_to_default() {
+        let result = SqlDb::resolve_connection_string(None, None);
+        assert_eq!(result.as_str(), DEFAULT_TEST_CONNECTION_STRING);
+    }
+
+    #[test]
+    fn resolve_invalid_env_var_falls_back_to_default() {
+        let env_val = Some("not-a-valid-url".to_string());
+        let result = SqlDb::resolve_connection_string(None, env_val);
+        assert_eq!(result.as_str(), DEFAULT_TEST_CONNECTION_STRING);
     }
 }

--- a/pubky-homeserver/src/persistence/sql/sql_db.rs
+++ b/pubky-homeserver/src/persistence/sql/sql_db.rs
@@ -127,18 +127,28 @@ impl SqlDb {
     }
 
     /// Derives the admin connection string to use for the test database creation.
-    /// If the user passed a connection string, use it.
-    /// If the user passed a connection string as a env variable, use it.
-    /// If no connection string is passed, use the default test connection string.
+    ///
+    /// Priority:
+    /// 1. Explicitly provided URL (if different from [`ConnectionString::default_test_db`])
+    /// 2. `TEST_PUBKY_CONNECTION_STRING` environment variable
+    /// 3. [`DEFAULT_TEST_CONNECTION_STRING`] fallback
+    ///
+    /// An explicitly provided URL that equals the default is treated as "no
+    /// explicit config" so the env var can still override it. This lets Docker
+    /// Postgres (non-default URL) pass through while the default config defers
+    /// to the user's env var.
     pub fn derive_connection_string(
         admin_con_string: Option<ConnectionString>,
     ) -> ConnectionString {
-        if let Some(con_string) = admin_con_string {
-            // If the user passed a connection string, use it.
-            return con_string.clone();
+        // If an explicitly non-default connection string was provided, use it.
+        if let Some(ref con_string) = admin_con_string {
+            if *con_string != ConnectionString::default_test_db() {
+                return con_string.clone();
+            }
         }
+
+        // Check the environment variable.
         if let Ok(raw_con_string) = std::env::var("TEST_PUBKY_CONNECTION_STRING") {
-            // If the user passed a connection string as a env variable, use it.
             match ConnectionString::new(&raw_con_string) {
                 Ok(con_string) => return con_string,
                 Err(e) => {
@@ -147,7 +157,7 @@ impl SqlDb {
             }
         }
 
-        // If no connection string is passed, use the default test connection string.
+        // Final fallback.
         ConnectionString::new(DEFAULT_TEST_CONNECTION_STRING)
             .expect("Default test connection string is valid")
     }

--- a/pubky-homeserver/src/persistence/sql/sql_db.rs
+++ b/pubky-homeserver/src/persistence/sql/sql_db.rs
@@ -3,6 +3,7 @@ use sqlx::postgres::PgPool;
 use sqlx::postgres::PgPoolOptions;
 
 use crate::persistence::sql::connection_string::ConnectionString;
+use crate::persistence::sql::database_mode::DatabaseMode;
 
 /// The SqlDb is a wrapper around the postgres connection pool.
 /// It is used to connect to the database and run queries.
@@ -21,17 +22,6 @@ pub struct SqlDb {
     db_dropper: Option<std::sync::Arc<TestDbDropper>>,
 }
 
-/// Errors from [`SqlDb::connect`].
-#[derive(Debug, thiserror::Error)]
-pub enum SqlDbConnectError {
-    /// SQL connection or database creation failed.
-    #[error("{0}")]
-    Sql(sqlx::Error),
-    /// No database URL configured (production builds only).
-    #[error("No database_url configured. Set [general].database_url in config.toml.")]
-    NoDatabaseUrl,
-}
-
 impl std::fmt::Debug for SqlDb {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "DbConnection")
@@ -39,35 +29,18 @@ impl std::fmt::Debug for SqlDb {
 }
 
 impl SqlDb {
-    /// Connect to the database.
+    /// Connect to the database using the given [`DatabaseMode`].
     ///
-    /// In test builds (`#[cfg(test)]` or `feature = "testing"`):
-    /// - Resolves `None` via env var (`TEST_PUBKY_CONNECTION_STRING`) or built-in default
-    /// - Creates an ephemeral `pubky_test_{uuid}` database when the URL has `?pubky-test=true`
-    /// - Connects directly for non-test URLs (e.g. a real Postgres instance)
-    ///
-    /// In production builds, `None` is an error.
-    pub async fn connect(con_string: Option<ConnectionString>) -> Result<Self, SqlDbConnectError> {
-        #[cfg(any(test, feature = "testing"))]
-        {
-            let resolved = Self::derive_connection_string(con_string);
-            return if resolved.is_test_db() {
-                Self::create_ephemeral_test_db(resolved)
-                    .await
-                    .map_err(SqlDbConnectError::Sql)
-            } else {
-                Self::connect_inner(&resolved)
-                    .await
-                    .map_err(SqlDbConnectError::Sql)
-            };
-        }
-
-        #[cfg(not(any(test, feature = "testing")))]
-        {
-            let resolved = con_string.ok_or(SqlDbConnectError::NoDatabaseUrl)?;
-            Self::connect_inner(&resolved)
-                .await
-                .map_err(SqlDbConnectError::Sql)
+    /// - [`DatabaseMode::Direct`]: connects to the database identified by the URL.
+    /// - [`DatabaseMode::EphemeralTest`]: creates a fresh `pubky_test_{uuid}` database
+    ///   on the server, connects to it, and drops it when this `SqlDb` is dropped.
+    pub async fn connect(mode: DatabaseMode) -> Result<Self, sqlx::Error> {
+        match mode {
+            DatabaseMode::Direct(url) => Self::connect_inner(&url).await,
+            #[cfg(any(test, feature = "testing"))]
+            DatabaseMode::EphemeralTest(admin_url) => {
+                Self::create_ephemeral_test_db(admin_url).await
+            }
         }
     }
 
@@ -117,79 +90,37 @@ impl Drop for TestDbDropper {
 }
 
 #[cfg(any(test, feature = "testing"))]
-pub(crate) const DEFAULT_TEST_CONNECTION_STRING: &str =
-    "postgres://localhost:5432/postgres?pubky-test=true";
-
-#[cfg(any(test, feature = "testing"))]
 impl SqlDb {
-    /// Creates a new `pubky_test_{uuid}` database on the server identified by
-    /// `admin_con_string`. The database name in that URL is used only for the
-    /// initial admin connection; the actual test database gets a unique name.
-    async fn create_test_database(
+    /// Creates an ephemeral `pubky_test_{uuid}` database and connects to it.
+    ///
+    /// `admin_con_string` is used for the initial admin connection that creates
+    /// the database. The returned `SqlDb` will drop its database on scope exit.
+    async fn create_ephemeral_test_db(
         admin_con_string: ConnectionString,
-    ) -> Result<ConnectionString, sqlx::Error> {
+    ) -> Result<Self, sqlx::Error> {
         use uuid::Uuid;
+
         let admin_con = Self::connect_inner(&admin_con_string).await?;
         let test_db_name = format!("pubky_test_{}", Uuid::new_v4().as_simple());
         let query = format!("CREATE DATABASE \"{}\"", test_db_name);
         sqlx::query(&query).execute(admin_con.pool()).await?;
-        let mut test_db_con_string = admin_con_string.clone();
-        test_db_con_string.set_database_name(&test_db_name);
-        Ok(test_db_con_string)
-    }
-    /// Creates an ephemeral `pubky_test_{uuid}` database and connects to it.
-    /// The returned `SqlDb` will drop its database when it goes out of scope.
-    async fn create_ephemeral_test_db(
-        admin_con_string: ConnectionString,
-    ) -> Result<Self, sqlx::Error> {
-        let test_db_con_string = Self::create_test_database(admin_con_string.clone()).await?;
 
-        let mut con = Self::connect_inner(&test_db_con_string).await?;
+        let mut test_db_url = admin_con_string.clone();
+        test_db_url.set_database_name(&test_db_name);
+
+        let mut con = Self::connect_inner(&test_db_url).await?;
         con.db_dropper = Some(std::sync::Arc::new(TestDbDropper::new(
-            test_db_con_string.database_name().to_string(),
+            test_db_name,
             admin_con_string.to_string(),
         )));
         Ok(con)
     }
 
-    /// Derives the connection string for test database creation.
-    ///
-    /// Priority:
-    /// 1. Explicitly provided URL (e.g. Docker Postgres) — used as-is
-    /// 2. `TEST_PUBKY_CONNECTION_STRING` environment variable
-    /// 3. [`DEFAULT_TEST_CONNECTION_STRING`] fallback
-    pub(crate) fn derive_connection_string(explicit: Option<ConnectionString>) -> ConnectionString {
-        let env_val = std::env::var("TEST_PUBKY_CONNECTION_STRING").ok();
-        Self::resolve_connection_string(explicit, env_val)
-    }
-
-    /// Pure resolution logic, separated from env access for testability.
-    fn resolve_connection_string(
-        explicit: Option<ConnectionString>,
-        env_val: Option<String>,
-    ) -> ConnectionString {
-        if let Some(url) = explicit {
-            return url;
-        }
-
-        if let Some(raw) = env_val {
-            match ConnectionString::new(&raw) {
-                Ok(con_string) => return con_string,
-                Err(e) => {
-                    tracing::warn!("Invalid TEST_PUBKY_CONNECTION_STRING: {raw}. Falling back to default. Error: {e}");
-                }
-            }
-        }
-
-        ConnectionString::new(DEFAULT_TEST_CONNECTION_STRING)
-            .expect("Default test connection string is valid")
-    }
-
     /// Create a test database without running migrations.
     #[cfg(test)]
     pub async fn test_without_migrations() -> Self {
-        let resolved = Self::derive_connection_string(None);
-        Self::create_ephemeral_test_db(resolved)
+        let mode = DatabaseMode::resolve_test(None);
+        Self::connect(mode)
             .await
             .expect("Failed to create test database")
     }
@@ -241,40 +172,8 @@ mod tests {
 
     #[tokio::test]
     #[pubky_test_utils::test]
-    async fn test_pg_db_available() {
-        let resolved = SqlDb::derive_connection_string(None);
-        let _db = SqlDb::create_ephemeral_test_db(resolved).await.unwrap();
-    }
-
-    #[test]
-    fn resolve_explicit_wins_over_env() {
-        let explicit =
-            ConnectionString::new("postgres://custom:5432/mydb?pubky-test=true").unwrap();
-        let env_val = Some("postgres://envhost:5432/envdb?pubky-test=true".to_string());
-        let result = SqlDb::resolve_connection_string(Some(explicit.clone()), env_val);
-        assert_eq!(result, explicit);
-    }
-
-    #[test]
-    fn resolve_env_var_used_when_no_explicit() {
-        let env_val = Some("postgres://envhost:5432/envdb?pubky-test=true".to_string());
-        let result = SqlDb::resolve_connection_string(None, env_val);
-        assert_eq!(
-            result.as_str(),
-            "postgres://envhost:5432/envdb?pubky-test=true"
-        );
-    }
-
-    #[test]
-    fn resolve_falls_back_to_default() {
-        let result = SqlDb::resolve_connection_string(None, None);
-        assert_eq!(result.as_str(), DEFAULT_TEST_CONNECTION_STRING);
-    }
-
-    #[test]
-    fn resolve_invalid_env_var_falls_back_to_default() {
-        let env_val = Some("not-a-valid-url".to_string());
-        let result = SqlDb::resolve_connection_string(None, env_val);
-        assert_eq!(result.as_str(), DEFAULT_TEST_CONNECTION_STRING);
+    async fn pg_db_available() {
+        let mode = DatabaseMode::resolve_test(None);
+        let _db = SqlDb::connect(mode).await.unwrap();
     }
 }

--- a/pubky-testnet/README.md
+++ b/pubky-testnet/README.md
@@ -34,10 +34,10 @@ TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgr
   cargo run -p pubky-testnet -- --homeserver-config my-config.toml persist ./my-testnet-data
 ```
 
-If you don't need persistent state, omit the `persist` subcommand and add `?pubky-test=true` to the connection string. The database is auto-created on startup and cleaned up on shutdown:
+If you don't need persistent state, simply omit the `persist` subcommand. An ephemeral database is auto-created on startup and cleaned up on shutdown:
 
 ```bash
-TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgres?pubky-test=true' \
+TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgres' \
   cargo run -p pubky-testnet
 ```
 

--- a/pubky-testnet/README.md
+++ b/pubky-testnet/README.md
@@ -176,7 +176,38 @@ async fn test_two() {
 
 Each testnet still gets its own ephemeral database within the shared PostgreSQL instance, so tests remain isolated.
 
-### Custom configuration
+### External PostgreSQL
+
+If you prefer to use an external Postgres instance, set the `TEST_PUBKY_CONNECTION_STRING` environment variable:
+
+```bash
+TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgres' \
+  cargo test -p my-crate
+```
+
+Or pass the connection string programmatically:
+
+```rust,no_run
+use pubky_testnet::{EphemeralTestnet, pubky_homeserver::ConnectionString};
+
+#[tokio::test]
+#[pubky_testnet::test]
+async fn my_test() {
+    let connection_string = ConnectionString::new(
+        "postgres://postgres:postgres@localhost:5432/postgres"
+    ).unwrap();
+
+    let testnet = EphemeralTestnet::builder()
+        .postgres(connection_string)
+        .build()
+        .await
+        .unwrap();
+}
+```
+
+Each test automatically gets its own ephemeral `pubky_test_{uuid}` database on the configured server. The `#[pubky_testnet::test]` macro ensures the database is cleaned up after the test completes or panics.
+
+### Custom Configuration
 
 ```rust,no_run
 use pubky_testnet::{EphemeralTestnet, pubky_homeserver::ConfigToml, pubky::Keypair};
@@ -205,4 +236,49 @@ async fn main() {
         .unwrap();
     let http_relay = testnet.http_relay();
 }
+```
+
+## StaticTestnet (CLI / Interactive)
+
+A long-running testnet with fixed, well-known ports. Use this when external processes need to connect (browser tests, mobile apps, manual debugging).
+
+### Fixed Ports
+
+| Component | Port |
+|-----------|------|
+| DHT bootstrap node | `6881` |
+| Pkarr relay | `15411` |
+| HTTP relay | `15412` |
+| Homeserver ICANN HTTP | `6286` |
+| Homeserver Pubky HTTPS | `6287` |
+| Homeserver admin | `6288` |
+
+Homeserver address: `8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo`
+
+### In-Memory Mode
+
+State is lost on shutdown. An ephemeral database is automatically created and cleaned up:
+
+```bash
+TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgres' \
+  cargo run -p pubky-testnet
+```
+
+### Persistent Mode
+
+State survives restarts. The data directory is auto-initialized on first run with a `config.toml` and server keypair. On subsequent runs, the existing state is picked up and the homeserver keeps the same identity.
+
+Persistent mode requires an explicit `database_url` in `config.toml` (the env var is not used):
+
+```bash
+cargo run -p pubky-testnet -- persist ./my-testnet-data
+```
+
+### Custom Homeserver Config
+
+Seed a custom config on first run (errors if `config.toml` already exists in the data directory):
+
+```bash
+TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgres' \
+  cargo run -p pubky-testnet -- --homeserver-config my-config.toml persist ./my-testnet-data
 ```

--- a/pubky-testnet/README.md
+++ b/pubky-testnet/README.md
@@ -80,12 +80,14 @@ async fn my_test() {
 
 ### Postgres for tests
 
-You need a running PostgreSQL instance (see [Quick start](#quick-start) for a Docker one-liner). By default, `EphemeralTestnet` reads the `TEST_PUBKY_CONNECTION_STRING` environment variable. The `?pubky-test=true` parameter tells the homeserver to create an ephemeral `pubky_test_*` database. The `#[pubky_testnet::test]` macro ensures the database is cleaned up after the test completes or panics.
+You need a running PostgreSQL instance (see [Quick start](#quick-start) for a Docker one-liner). By default, `EphemeralTestnet` reads the `TEST_PUBKY_CONNECTION_STRING` environment variable:
 
 ```bash
-TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgres?pubky-test=true' \
+TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgres' \
   cargo test -p my-crate
 ```
+
+Each test automatically gets its own ephemeral `pubky_test_{uuid}` database on the configured server. The `#[pubky_testnet::test]` macro ensures the database is cleaned up after the test completes or panics.
 
 You can also pass the connection string programmatically:
 
@@ -96,7 +98,7 @@ use pubky_testnet::{EphemeralTestnet, pubky_homeserver::ConnectionString};
 #[pubky_testnet::test]
 async fn my_test() {
     let connection_string = ConnectionString::new(
-        "postgres://postgres:postgres@localhost:5432/postgres?pubky-test=true"
+        "postgres://postgres:postgres@localhost:5432/postgres"
     ).unwrap();
 
     let testnet = EphemeralTestnet::builder()
@@ -132,9 +134,6 @@ async fn main() {
         .unwrap();
 }
 ```
-
-This uses [testcontainers](https://docs.rs/testcontainers) to run PostgreSQL in a Docker container.
-Docker must be running on the host. The container is automatically cleaned up on drop and on Ctrl+C/SIGTERM.
 
 > **Important**: If you have multiple tests, see [Sharing Docker Postgres Across Tests](#sharing-docker-postgres-across-tests) below.
 
@@ -174,39 +173,6 @@ async fn test_two() {
 # }
 ```
 
-Each testnet still gets its own ephemeral database within the shared PostgreSQL instance, so tests remain isolated.
-
-### External PostgreSQL
-
-If you prefer to use an external Postgres instance, set the `TEST_PUBKY_CONNECTION_STRING` environment variable:
-
-```bash
-TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgres' \
-  cargo test -p my-crate
-```
-
-Or pass the connection string programmatically:
-
-```rust,no_run
-use pubky_testnet::{EphemeralTestnet, pubky_homeserver::ConnectionString};
-
-#[tokio::test]
-#[pubky_testnet::test]
-async fn my_test() {
-    let connection_string = ConnectionString::new(
-        "postgres://postgres:postgres@localhost:5432/postgres"
-    ).unwrap();
-
-    let testnet = EphemeralTestnet::builder()
-        .postgres(connection_string)
-        .build()
-        .await
-        .unwrap();
-}
-```
-
-Each test automatically gets its own ephemeral `pubky_test_{uuid}` database on the configured server. The `#[pubky_testnet::test]` macro ensures the database is cleaned up after the test completes or panics.
-
 ### Custom Configuration
 
 ```rust,no_run
@@ -236,49 +202,4 @@ async fn main() {
         .unwrap();
     let http_relay = testnet.http_relay();
 }
-```
-
-## StaticTestnet (CLI / Interactive)
-
-A long-running testnet with fixed, well-known ports. Use this when external processes need to connect (browser tests, mobile apps, manual debugging).
-
-### Fixed Ports
-
-| Component | Port |
-|-----------|------|
-| DHT bootstrap node | `6881` |
-| Pkarr relay | `15411` |
-| HTTP relay | `15412` |
-| Homeserver ICANN HTTP | `6286` |
-| Homeserver Pubky HTTPS | `6287` |
-| Homeserver admin | `6288` |
-
-Homeserver address: `8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo`
-
-### In-Memory Mode
-
-State is lost on shutdown. An ephemeral database is automatically created and cleaned up:
-
-```bash
-TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgres' \
-  cargo run -p pubky-testnet
-```
-
-### Persistent Mode
-
-State survives restarts. The data directory is auto-initialized on first run with a `config.toml` and server keypair. On subsequent runs, the existing state is picked up and the homeserver keeps the same identity.
-
-Persistent mode requires an explicit `database_url` in `config.toml` (the env var is not used):
-
-```bash
-cargo run -p pubky-testnet -- persist ./my-testnet-data
-```
-
-### Custom Homeserver Config
-
-Seed a custom config on first run (errors if `config.toml` already exists in the data directory):
-
-```bash
-TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgres' \
-  cargo run -p pubky-testnet -- --homeserver-config my-config.toml persist ./my-testnet-data
 ```

--- a/pubky-testnet/README.md
+++ b/pubky-testnet/README.md
@@ -133,7 +133,16 @@ async fn main() {
 }
 ```
 
-Each call to `.with_docker_postgres()` starts a **separate** container. To share **one** container across all tests, use `DockerPostgres::shared()`:
+This uses [testcontainers](https://docs.rs/testcontainers) to run PostgreSQL in a Docker container.
+Docker must be running on the host. The container is automatically cleaned up on drop and on Ctrl+C/SIGTERM.
+
+> **Important**: If you have multiple tests, see [Sharing Docker Postgres Across Tests](#sharing-docker-postgres-across-tests) below.
+
+### Sharing Docker Postgres Across Tests
+
+Each `.with_docker_postgres()` starts a **separate** container. To avoid that overhead,
+use `DockerPostgres::shared()` to start one container and reuse it. Tests remain isolated
+— each testnet gets its own ephemeral database.
 
 ```rust
 # #[cfg(feature = "docker-postgres")]

--- a/pubky-testnet/src/docker_postgres.rs
+++ b/pubky-testnet/src/docker_postgres.rs
@@ -36,29 +36,11 @@ extern "C" fn cleanup_shared_container() {
 
 /// A containerized PostgreSQL instance for testing.
 ///
-/// This wraps a testcontainers `Postgres` container and manages its lifecycle.
-/// The container is automatically stopped and removed when this struct is dropped.
+/// The container is automatically cleaned up on drop, on Ctrl+C/SIGTERM,
+/// and (for the shared instance) on normal process exit via an `atexit` hook.
 ///
-/// # Sharing Across Tests (Recommended)
-///
-/// Each `DockerPostgres::start()` starts a **separate** PostgreSQL container.
-/// Use [`DockerPostgres::shared()`] to start **one** instance and share it across tests:
-///
-/// ```ignore
-/// use pubky_testnet::docker_postgres::DockerPostgres;
-/// use pubky_testnet::EphemeralTestnet;
-///
-/// #[tokio::test]
-/// async fn my_test() {
-///     let pg = DockerPostgres::shared().await;
-///     let testnet = EphemeralTestnet::builder()
-///         .postgres(pg.connection_string().unwrap())
-///         .build()
-///         .await
-///         .unwrap();
-///     // Each testnet gets its own ephemeral database — tests remain isolated.
-/// }
-/// ```
+/// Multiple testnets can safely share one container — each gets its own
+/// isolated database. See [`Self::connection_string()`] for details.
 pub struct DockerPostgres {
     _container: ContainerAsync<Postgres>,
     host: String,
@@ -70,14 +52,10 @@ pub struct DockerPostgres {
 pub type EmbeddedPostgres = DockerPostgres;
 
 impl DockerPostgres {
-    /// Return a shared Docker PostgreSQL instance, starting it on first call.
+    /// Return a shared Docker PostgreSQL container, starting it on first call.
     ///
-    /// This is the recommended way to share a single PostgreSQL container across
-    /// multiple tests. Docker handles all cleanup automatically.
-    ///
-    /// An `atexit` hook is registered to ensure the container is removed even on
-    /// normal process exit (Rust never drops statics, so the testcontainers
-    /// `Drop` impl alone is not sufficient).
+    /// Avoids the overhead of starting a separate container per test.
+    /// Each testnet still gets its own isolated database.
     ///
     /// # Panics
     ///
@@ -127,9 +105,14 @@ impl DockerPostgres {
     }
 
     /// Get the connection string for this Docker PostgreSQL instance.
+    ///
+    /// The returned connection string includes `?pubky-test=true` so that
+    /// each homeserver creates its own ephemeral `pubky_test_{uuid}` database.
+    /// This is what makes `DockerPostgres::shared()` safe: multiple testnets
+    /// share the same Postgres **server** but each gets an isolated database.
     pub fn connection_string(&self) -> anyhow::Result<ConnectionString> {
         let url = format!(
-            "postgres://postgres:postgres@{}:{}/postgres",
+            "postgres://postgres:postgres@{}:{}/postgres?pubky-test=true",
             self.host, self.port
         );
         ConnectionString::new(&url).map_err(|e| anyhow::anyhow!("Invalid connection string: {e}"))
@@ -296,6 +279,50 @@ mod tests {
             pg2.container_id(),
             "shared() should return the same container on repeated calls"
         );
+    }
+
+    /// Verify that two testnets sharing a `DockerPostgres` get isolated databases.
+    ///
+    /// Signs up a user on testnet A, then verifies that same keypair can sign up
+    /// on testnet B (proving it has a separate, empty database).
+    #[tokio::test]
+    async fn test_shared_docker_postgres_provides_db_isolation() {
+        let pg = DockerPostgres::start()
+            .await
+            .expect("Failed to start docker postgres");
+
+        let keypair = Keypair::random();
+
+        // Build two independent testnets sharing the same Postgres container.
+        let testnet_a = EphemeralTestnet::builder()
+            .postgres(pg.connection_string().unwrap())
+            .build()
+            .await
+            .expect("Failed to start testnet A");
+
+        let testnet_b = EphemeralTestnet::builder()
+            .postgres(pg.connection_string().unwrap())
+            .keypair(Keypair::random()) // different homeserver identity
+            .build()
+            .await
+            .expect("Failed to start testnet B");
+
+        // Sign up the user on testnet A.
+        let sdk_a = testnet_a.sdk().expect("Failed to create SDK A");
+        let signer_a = sdk_a.signer(keypair.clone());
+        signer_a
+            .signup_cookie(&testnet_a.homeserver_app().public_key(), None)
+            .await
+            .expect("Signup on testnet A should succeed");
+
+        // The same keypair should be able to sign up on testnet B,
+        // proving it has its own isolated database.
+        let sdk_b = testnet_b.sdk().expect("Failed to create SDK B");
+        let signer_b = sdk_b.signer(keypair);
+        signer_b
+            .signup_cookie(&testnet_b.homeserver_app().public_key(), None)
+            .await
+            .expect("Signup on testnet B should succeed (proves DB isolation)");
     }
 
     /// Test that specifying both docker postgres and a custom connection string fails.

--- a/pubky-testnet/src/docker_postgres.rs
+++ b/pubky-testnet/src/docker_postgres.rs
@@ -285,6 +285,11 @@ mod tests {
     ///
     /// Signs up a user on testnet A, then verifies that same keypair can sign up
     /// on testnet B (proving it has a separate, empty database).
+    ///
+    /// This also validates that `app_context.rs` correctly passes the configured
+    /// connection string (random Docker port + `?pubky-test=true`) through to
+    /// `test_postgres_db()`. Without that, it would fall back to `localhost:5432`
+    /// and fail to connect.
     #[tokio::test]
     async fn test_shared_docker_postgres_provides_db_isolation() {
         let pg = DockerPostgres::start()

--- a/pubky-testnet/src/docker_postgres.rs
+++ b/pubky-testnet/src/docker_postgres.rs
@@ -128,6 +128,7 @@ mod tests {
     use super::DockerPostgres;
     use crate::EphemeralTestnet;
     use pubky::Keypair;
+    use pubky_common::auth::jws::ClientId;
 
     const CONTAINER_ID_PREFIX: &str = "CONTAINER_ID=";
 
@@ -181,10 +182,14 @@ mod tests {
         let keypair = Keypair::random();
         let signer = pubky.signer(keypair);
 
-        let session = signer
-            .signup_cookie(&testnet.homeserver_app().public_key(), None)
+        signer
+            .signup(&testnet.homeserver_app().public_key(), None)
             .await
             .expect("Failed to signup user");
+        let session = signer
+            .signin(ClientId::new("test").unwrap())
+            .await
+            .expect("Failed to signin user");
 
         // Store and retrieve data
         let path = "/pub/test.txt";
@@ -315,7 +320,7 @@ mod tests {
         let sdk_a = testnet_a.sdk().expect("Failed to create SDK A");
         let signer_a = sdk_a.signer(keypair.clone());
         signer_a
-            .signup_cookie(&testnet_a.homeserver_app().public_key(), None)
+            .signup(&testnet_a.homeserver_app().public_key(), None)
             .await
             .expect("Signup on testnet A should succeed");
 
@@ -324,7 +329,7 @@ mod tests {
         let sdk_b = testnet_b.sdk().expect("Failed to create SDK B");
         let signer_b = sdk_b.signer(keypair);
         signer_b
-            .signup_cookie(&testnet_b.homeserver_app().public_key(), None)
+            .signup(&testnet_b.homeserver_app().public_key(), None)
             .await
             .expect("Signup on testnet B should succeed (proves DB isolation)");
     }

--- a/pubky-testnet/src/docker_postgres.rs
+++ b/pubky-testnet/src/docker_postgres.rs
@@ -288,7 +288,7 @@ mod tests {
     ///
     /// This also validates that `app_context.rs` correctly passes the configured
     /// connection string (random Docker port + `?pubky-test=true`) through to
-    /// `test_postgres_db()`. Without that, it would fall back to `localhost:5432`
+    /// `create_ephemeral_test_db()`. Without that, it would fall back to `localhost:5432`
     /// and fail to connect.
     #[tokio::test]
     async fn test_shared_docker_postgres_provides_db_isolation() {

--- a/pubky-testnet/src/docker_postgres.rs
+++ b/pubky-testnet/src/docker_postgres.rs
@@ -106,13 +106,12 @@ impl DockerPostgres {
 
     /// Get the connection string for this Docker PostgreSQL instance.
     ///
-    /// The returned connection string includes `?pubky-test=true` so that
-    /// each homeserver creates its own ephemeral `pubky_test_{uuid}` database.
-    /// This is what makes `DockerPostgres::shared()` safe: multiple testnets
-    /// share the same Postgres **server** but each gets an isolated database.
+    /// The [`DatabaseMode`](pubky_homeserver::DatabaseMode) enum — not the URL
+    /// itself — controls whether the homeserver creates an ephemeral
+    /// `pubky_test_{uuid}` database.
     pub fn connection_string(&self) -> anyhow::Result<ConnectionString> {
         let url = format!(
-            "postgres://postgres:postgres@{}:{}/postgres?pubky-test=true",
+            "postgres://postgres:postgres@{}:{}/postgres",
             self.host, self.port
         );
         ConnectionString::new(&url).map_err(|e| anyhow::anyhow!("Invalid connection string: {e}"))
@@ -286,10 +285,10 @@ mod tests {
     /// Signs up a user on testnet A, then verifies that same keypair can sign up
     /// on testnet B (proving it has a separate, empty database).
     ///
-    /// This also validates that `app_context.rs` correctly passes the configured
-    /// connection string (random Docker port + `?pubky-test=true`) through to
-    /// `create_ephemeral_test_db()`. Without that, it would fall back to `localhost:5432`
-    /// and fail to connect.
+    /// This also validates that the configured connection string (random Docker
+    /// port) flows through `DatabaseMode::resolve_test` → `EphemeralTest` →
+    /// `create_ephemeral_test_db()`. Without that, it would fall back to
+    /// `localhost:5432` and fail to connect.
     #[tokio::test]
     async fn test_shared_docker_postgres_provides_db_isolation() {
         let pg = DockerPostgres::start()

--- a/pubky-testnet/src/docker_postgres.rs
+++ b/pubky-testnet/src/docker_postgres.rs
@@ -163,6 +163,7 @@ mod tests {
     /// Basic integration test: start a testnet with docker postgres + http relay,
     /// signup a user, store and retrieve data.
     #[tokio::test]
+    #[crate::test]
     async fn test_docker_postgres_with_testnet() {
         let testnet = EphemeralTestnet::builder()
             .with_docker_postgres()
@@ -295,6 +296,7 @@ mod tests {
     /// `create_ephemeral_test_db()`. Without that, it would fall back to
     /// `localhost:5432` and fail to connect.
     #[tokio::test]
+    #[crate::test]
     async fn test_shared_docker_postgres_provides_db_isolation() {
         let pg = DockerPostgres::start()
             .await

--- a/pubky-testnet/src/ephemeral_testnet.rs
+++ b/pubky-testnet/src/ephemeral_testnet.rs
@@ -196,7 +196,7 @@ impl EphemeralTestnetBuilder {
             .unwrap_or_else(ConfigToml::minimal_test_config);
 
         if let Some(connection_string) = testnet.postgres_connection_string.as_ref() {
-            config.general.database_url = connection_string.clone();
+            config.general.database_url = Some(connection_string.clone());
         }
 
         let keypair = self
@@ -329,7 +329,7 @@ impl EphemeralTestnet {
         let mut config = config.unwrap_or_else(ConfigToml::minimal_test_config);
 
         if let Some(connection_string) = self.testnet.postgres_connection_string.as_ref() {
-            config.general.database_url = connection_string.clone();
+            config.general.database_url = Some(connection_string.clone());
         }
 
         let mock_dir = MockDataDir::new(config, Some(Keypair::random()))?;

--- a/pubky-testnet/src/ephemeral_testnet.rs
+++ b/pubky-testnet/src/ephemeral_testnet.rs
@@ -386,6 +386,7 @@ mod test {
     /// This is to prevent the case where the testnet is not cleaned up properly.
     /// For example, if the port is not released after the testnet is stopped.
     #[tokio::test]
+    #[crate::test]
     async fn test_two_testnet_in_a_row() {
         {
             let _ = EphemeralTestnet::builder().build().await.unwrap();
@@ -397,6 +398,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[crate::test]
     async fn test_homeserver_with_random_keypair() {
         // Start with just DHT + http relay, no homeserver
         let mut testnet = Testnet::new().await.unwrap();
@@ -420,6 +422,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[crate::test]
     async fn test_builder_default() {
         // Verify builder creates homeserver with minimal config (admin disabled)
         let network = EphemeralTestnet::builder().build().await.unwrap();
@@ -437,6 +440,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[crate::test]
     async fn test_builder_with_custom_config() {
         // Verify custom config is used (e.g., metrics enabled)
         let mut config = ConfigToml::minimal_test_config();
@@ -460,6 +464,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[crate::test]
     async fn test_builder_with_custom_keypair() {
         // Verify custom keypair is used
         let keypair = Keypair::random();

--- a/pubky-testnet/src/ephemeral_testnet.rs
+++ b/pubky-testnet/src/ephemeral_testnet.rs
@@ -195,9 +195,10 @@ impl EphemeralTestnetBuilder {
             .homeserver_config
             .unwrap_or_else(ConfigToml::minimal_test_config);
 
-        if let Some(connection_string) = testnet.postgres_connection_string.as_ref() {
-            config.general.database_url = Some(connection_string.clone());
-        }
+        config.general.database_url = testnet
+            .postgres_connection_string
+            .clone()
+            .or(config.general.database_url);
 
         let keypair = self
             .homeserver_keypair
@@ -328,9 +329,11 @@ impl EphemeralTestnet {
     ) -> anyhow::Result<&HomeserverApp> {
         let mut config = config.unwrap_or_else(ConfigToml::minimal_test_config);
 
-        if let Some(connection_string) = self.testnet.postgres_connection_string.as_ref() {
-            config.general.database_url = Some(connection_string.clone());
-        }
+        config.general.database_url = self
+            .testnet
+            .postgres_connection_string
+            .clone()
+            .or(config.general.database_url);
 
         let mock_dir = MockDataDir::new(config, Some(Keypair::random()))?;
         self.testnet.create_homeserver_app_with_mock(mock_dir).await

--- a/pubky-testnet/src/static_testnet.rs
+++ b/pubky-testnet/src/static_testnet.rs
@@ -432,13 +432,22 @@ impl DataDir for TestnetDataDir {
         let mut config = self.inner.read_or_create_config_file()?;
         apply_static_testnet_overrides(&mut config, self.dht_bootstrap_nodes.clone());
         if let Some(connection_string) = &self.postgres_connection_string {
-            config.general.database_url = connection_string.clone();
+            config.general.database_url = Some(connection_string.clone());
         }
-        if config.general.database_url.is_test_db() {
-            anyhow::bail!(
-                "Persistent testnet requires a real database. \
-                 Remove `?pubky-test=true` from the connection string to use a persistent database."
-            );
+        match &config.general.database_url {
+            None => {
+                anyhow::bail!(
+                    "Persistent testnet requires an explicit database URL. \
+                     Set `database_url` in config.toml under [general]."
+                );
+            }
+            Some(url) if url.is_test_db() => {
+                anyhow::bail!(
+                    "Persistent testnet requires a real database. \
+                     Remove `?pubky-test=true` from the connection string to use a persistent database."
+                );
+            }
+            Some(_) => {}
         }
         Ok(config)
     }

--- a/pubky-testnet/src/static_testnet.rs
+++ b/pubky-testnet/src/static_testnet.rs
@@ -424,6 +424,13 @@ impl DataDir for TestnetDataDir {
         self.inner.path()
     }
 
+    fn resolve_database_mode(
+        &self,
+        conf: &ConfigToml,
+    ) -> anyhow::Result<pubky_homeserver::DatabaseMode> {
+        self.inner.resolve_database_mode(conf)
+    }
+
     fn ensure_data_dir_exists_and_is_writable(&self) -> anyhow::Result<()> {
         self.inner.ensure_data_dir_exists_and_is_writable()
     }

--- a/pubky-testnet/src/static_testnet.rs
+++ b/pubky-testnet/src/static_testnet.rs
@@ -431,23 +431,15 @@ impl DataDir for TestnetDataDir {
     fn read_or_create_config_file(&self) -> anyhow::Result<ConfigToml> {
         let mut config = self.inner.read_or_create_config_file()?;
         apply_static_testnet_overrides(&mut config, self.dht_bootstrap_nodes.clone());
-        if let Some(connection_string) = &self.postgres_connection_string {
-            config.general.database_url = Some(connection_string.clone());
-        }
-        match &config.general.database_url {
-            None => {
-                anyhow::bail!(
-                    "Persistent testnet requires an explicit database URL. \
-                     Set `database_url` in config.toml under [general]."
-                );
-            }
-            Some(url) if url.is_test_db() => {
-                anyhow::bail!(
-                    "Persistent testnet requires a real database. \
-                     Remove `?pubky-test=true` from the connection string to use a persistent database."
-                );
-            }
-            Some(_) => {}
+        config.general.database_url = self
+            .postgres_connection_string
+            .clone()
+            .or(config.general.database_url);
+        if config.general.database_url.is_none() {
+            anyhow::bail!(
+                "Persistent testnet requires an explicit database URL. \
+                 Set `database_url` in config.toml under [general]."
+            );
         }
         Ok(config)
     }

--- a/pubky-testnet/src/testnet.rs
+++ b/pubky-testnet/src/testnet.rs
@@ -96,7 +96,7 @@ impl Testnet {
     pub async fn create_homeserver(&mut self) -> Result<&HomeserverApp> {
         let mut config = ConfigToml::default_test_config();
         if let Some(connection_string) = self.postgres_connection_string.as_ref() {
-            config.general.database_url = connection_string.clone();
+            config.general.database_url = Some(connection_string.clone());
         }
         let mock_dir = MockDataDir::new(config, Some(crate::common::testnet_keypair()))?;
         self.create_homeserver_app_with_mock(mock_dir).await
@@ -109,7 +109,7 @@ impl Testnet {
     pub async fn create_random_homeserver(&mut self) -> Result<&HomeserverApp> {
         let mut config = ConfigToml::default_test_config();
         if let Some(connection_string) = self.postgres_connection_string.as_ref() {
-            config.general.database_url = connection_string.clone();
+            config.general.database_url = Some(connection_string.clone());
         }
         let mock_dir = MockDataDir::new(config, Some(Keypair::random()))?;
         self.create_homeserver_app_with_mock(mock_dir).await

--- a/pubky-testnet/src/testnet.rs
+++ b/pubky-testnet/src/testnet.rs
@@ -288,6 +288,7 @@ mod test {
 
     /// If everything is linked correctly, the hs_pubky should be resolvable from the pkarr client.
     #[tokio::test]
+    #[crate::test]
     async fn test_homeserver_resolvable() {
         let mut testnet = Testnet::new().await.unwrap();
         let hs_pubky = testnet.create_homeserver().await.unwrap().public_key();

--- a/pubky-testnet/src/testnet.rs
+++ b/pubky-testnet/src/testnet.rs
@@ -39,8 +39,7 @@ impl Testnet {
             http_relays: vec![],
             homeservers: vec![],
             temp_dirs: vec![],
-            postgres_connection_string: Self::extract_postgres_connection_string_from_env_variable(
-            ),
+            postgres_connection_string: None,
         };
 
         Ok(testnet)
@@ -73,20 +72,6 @@ impl Testnet {
         };
 
         Ok(testnet)
-    }
-
-    /// Extract the postgres connection string from the TEST_PUBKY_CONNECTION_STRING environment variable.
-    /// If the environment variable is not set, None is returned.
-    /// If the environment variable is set, but the connection string is invalid, a warning is logged and None is returned.
-    fn extract_postgres_connection_string_from_env_variable() -> Option<ConnectionString> {
-        if let Ok(raw_con_string) = std::env::var("TEST_PUBKY_CONNECTION_STRING") {
-            if let Ok(con_string) = ConnectionString::new(&raw_con_string) {
-                return Some(con_string);
-            } else {
-                tracing::warn!("Invalid database connection string in TEST_PUBKY_CONNECTION_STRING environment variable. Ignoring it.");
-            }
-        }
-        None
     }
 
     /// Run the full homeserver app with core and admin server.

--- a/pubky-testnet/src/testnet.rs
+++ b/pubky-testnet/src/testnet.rs
@@ -238,6 +238,7 @@ impl Testnet {
 mod test {
     use crate::Testnet;
     use pubky::Keypair;
+    use pubky_common::auth::jws::ClientId;
 
     /// Make sure the components are kept alive even when dropped.
     #[tokio::test]
@@ -272,7 +273,8 @@ mod test {
 
         let signer = sdk.signer(Keypair::random());
 
-        let session = signer.signup_cookie(&hs.public_key(), None).await.unwrap();
+        signer.signup(&hs.public_key(), None).await.unwrap();
+        let session = signer.signin(ClientId::new("test").unwrap()).await.unwrap();
         assert_eq!(session.info().public_key(), &signer.public_key());
     }
 

--- a/pubky-testnet/src/testnet.rs
+++ b/pubky-testnet/src/testnet.rs
@@ -95,9 +95,7 @@ impl Testnet {
     /// Automatically listens on ephemeral ports and uses this Testnet's bootstrap nodes and relays.
     pub async fn create_homeserver(&mut self) -> Result<&HomeserverApp> {
         let mut config = ConfigToml::default_test_config();
-        if let Some(connection_string) = self.postgres_connection_string.as_ref() {
-            config.general.database_url = Some(connection_string.clone());
-        }
+        config.general.database_url = self.postgres_connection_string.clone();
         let mock_dir = MockDataDir::new(config, Some(crate::common::testnet_keypair()))?;
         self.create_homeserver_app_with_mock(mock_dir).await
     }
@@ -108,9 +106,7 @@ impl Testnet {
     /// Automatically listens on ephemeral ports and uses this Testnet's bootstrap nodes and relays.
     pub async fn create_random_homeserver(&mut self) -> Result<&HomeserverApp> {
         let mut config = ConfigToml::default_test_config();
-        if let Some(connection_string) = self.postgres_connection_string.as_ref() {
-            config.general.database_url = Some(connection_string.clone());
-        }
+        config.general.database_url = self.postgres_connection_string.clone();
         let mock_dir = MockDataDir::new(config, Some(Keypair::random()))?;
         self.create_homeserver_app_with_mock(mock_dir).await
     }

--- a/test_utils/drop_db_helper/src/lib.rs
+++ b/test_utils/drop_db_helper/src/lib.rs
@@ -20,7 +20,7 @@ impl DbToDrop {
     /// Drop the database.
     pub async fn drop(&self) -> Result<(), sqlx::Error> {
         let pool = PgPool::connect(&self.connection_string).await?;
-        let query = format!("DROP DATABASE {} WITH (FORCE)", self.db_name);
+        let query = format!("DROP DATABASE \"{}\" WITH (FORCE)", self.db_name);
         sqlx::query(&query).execute(&pool).await?;
         let _ = pool.close().await; // Close connection properly.
         Ok(())


### PR DESCRIPTION
The idea behind `DockerPostgres::shared()` is that the work of downloading, building and starting up Postgres shouldn't need to be done for each testnet which needs to use the Postgres instance. For example, in a test suite in which each test requires its own testnet.

The existing behaviour was that the Postgres instance and database was being shared. The fix here is to share the Postgres instance but give each test a fresh, ephemeral database.

These changes motivated a re-write of how databse urls are set, as the logic was spread across different places and behaviour not well-defined.

Previously we configured ephemeral database by a `?pubky-test=true` query parameter in the connection URL, a fragile convention that is easy to forget and adds confusion. We replaced it with a `DatabaseMode` enum that is resolved at startup based on compile-time cfg flags. In test builds you always get `EphemeralTest`, in production you always get `Direct`. The URL is now just a server address, it no longer carries behavioral intent.

We also change `database_url` from `ConnectionString` to `Option<ConnectionString>`. Test configs set it to `None`, deferring resolution to the env var or built-in default. Explicit urls (e.g. Docker Postgres) are `Some` and used as-is. Production builds throw and error if `None`.

The priority for database URL resolution in test builds is:

- Explicit URL set in config (e.g. from Docker Postgres or config.toml)
- TEST_PUBKY_CONNECTION_STRING env var
- Built-in test default
