### PR TITLE
docs(homeserver): Cloudflare tunnel guide

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -2,286 +2,32 @@
 
 How to make a Pubky homeserver reachable from the internet. This guide assumes you have already [installed the homeserver](./INSTALL.md) and have it running.
 
-Commands and package names assume a Debian-based system (Ubuntu, Debian, etc.), adapt as needed for other distributions.
+> **Note:** These guides cover homeserver-specific setup only, not general server hardening. If you're new to running public-facing servers, look into basic Linux server security before proceeding.
 
-> **Note:** This guide covers homeserver-specific setup only, not general server hardening. If you're new to running public-facing servers, look into basic Linux server security before proceeding.
+## Protocols
 
-## Contents
+The homeserver speaks two protocols. Both serve the same data — the difference is how clients find and connect to your server:
 
-- [Choose Your Setup](#choose-your-setup)
-- [Open Ports](#open-ports)
-- [Configure the Homeserver](#configure-the-homeserver)
-- [Set Up HTTPS](#set-up-https)
-  - [With a Domain](#with-a-domain)
-  - [IP Address Only](#ip-address-only)
-- [Verify the Deployment](#verify-the-deployment)
-  - [Check ICANN HTTPS](#check-icann-https)
-  - [Find Your Public Key](#find-your-public-key)
-  - [Check PKARR Record](#check-pkarr-record)
-  - [Check Internal Ports Are Not Exposed](#check-internal-ports-are-not-exposed)
-  - [Check Pubky TLS](#check-pubky-tls)
-- [Production Notes](#production-notes)
-- [Troubleshooting](#troubleshooting)
+- **Pubky TLS** (port 6287) — the native protocol. Clients resolve your homeserver's public key on the DHT and connect directly, bypassing any certificate authority.
+- **HTTPS** (port 443) — standard web TLS. Browsers and the browser-based SDK use this, which requires a CA-issued certificate.
+
+Ideally your deployment supports both, but some setups only provide HTTPS. The comparison table below shows what each option gives you.
 
 ## Choose Your Setup
 
-There are two ways to expose your homeserver over HTTPS:
-
-- **With a Domain** — requires a domain name and DNS setup. Standard 90-day Let's Encrypt certificates.
-- **IP Address Only** — no domain needed. Uses short-lived (~6-day) Let's Encrypt certificates, so the server must stay healthy for renewals.
-
-This guide covers both options.
-
-## Open Ports
-
-The homeserver speaks two protocols. Both endpoints serve the same data, the difference is how clients find and connect to your server:
-
-**Pubky TLS** is the native protocol: clients resolve your homeserver's public key on the DHT and connect directly on port 6287, bypassing any certificate authority.
-
-**CA-authenticated TLS** is the HTTPS you already know from the regular internet: browsers and the browser-based SDK use this on port 443, which requires a TLS certificate from a certificate authority for your domain or IP address.
-
-The homeserver serves plain HTTP on an internal port; we place [Caddy](https://caddyserver.com/) in front of it to add the CA-authenticated TLS layer and serve HTTPS on port 443. Caddy manages the certificates automatically.
-
-Open these three ports for inbound traffic:
-
-| Port | Purpose |
-| --- | --- |
-| 80 | HTTP — [Caddy](#set-up-https) needs this for automatic TLS certificate provisioning. |
-| 443 | HTTPS — serves your homeserver via [Caddy](#set-up-https). Also used for TLS-ALPN-01 certificate challenges. |
-| 6287 | Pubky TLS — direct Pubky protocol connections (no certificate needed). |
-
-How you open these depends on your setup: a cloud provider's security group, a router's port-forwarding rules, or a host firewall.
-
-Do **not** expose these ports directly to the internet:
-
-| Port | Purpose |
-| --- | --- |
-| 6286 | ICANN HTTP — Caddy proxies to this internally. |
-| 6288 | Admin API — admin operations. |
-| 6289 | Metrics — internal monitoring only. |
-
-> **Warning:** The guide below changes `pubky_listen_socket` to `0.0.0.0:6287` so Pubky TLS is reachable externally. Do **not** apply the same `0.0.0.0` bind to `icann_listen_socket`, `admin.listen_socket`, or `metrics.listen_socket` — those must stay on `127.0.0.1` to avoid exposing internal APIs to the internet.
-
-## Configure the Homeserver
-
-Edit `~/.pubky/config.toml` with the following settings:
-
-```toml
-[drive]
-# Listen on all interfaces so Pubky TLS is reachable from the internet
-pubky_listen_socket = "0.0.0.0:6287"
-
-# icann_listen_socket defaults to 127.0.0.1:6286 — no change needed.
-
-[pkdns]
-# The public-facing IP of this machine. Published to the DHT so that
-# Pubky TLS clients can connect directly to the homeserver.
-public_ip = "YOUR_IP"
-
-# With a Domain: your domain name for HTTPS browser access.
-# IP Address Only: set this to your IP address (same as public_ip).
-icann_domain = "YOUR_DOMAIN_OR_IP"
-```
-
-Replace `YOUR_IP` with the public IP of the machine running the homeserver. You can find it with `curl -4 ifconfig.me`.
-
-Replace `YOUR_DOMAIN_OR_IP` with your domain name or public IP, depending on [which setup you chose](#choose-your-setup).
-
-
-> **Important:** Ensure your server has a **static (reserved) public IP**. If your IP changes then the PKARR record (which embeds `public_ip`), your Caddy configuration, and any DNS records will silently point at a dead address.
-
-Restart the homeserver after editing `config.toml` for the changes to take effect. See [Run](./INSTALL.md#run) in the install guide.
-
-> ℹ️ For the full list of settings (including `public_pubky_tls_port` and `public_icann_http_port` for non-standard port setups), see [`pubky-homeserver/config.sample.toml`](../pubky-homeserver/config.sample.toml).
-
-## Set Up HTTPS
-
-Install [Caddy](https://caddyserver.com/docs/install#debian-ubuntu-raspbian).
-
-Now follow **one** of the two options below.
-
----
-
-### With a Domain
-
-This option uses a domain name with standard 90-day Let's Encrypt certificates.
-
-#### Set Up DNS
-
-Configure your domain with an A record pointing to your server's public IP. If your server also has a public IPv6 address, add an AAAA record too.
-
-| Record Type | Name | Value |
-| --- | --- | --- |
-| A | YOUR_DOMAIN | YOUR_IPV4_ADDRESS |
-| AAAA | YOUR_DOMAIN | YOUR_IPV6_ADDRESS (optional) |
-
-Wait for DNS propagation, then verify:
-
-```bash
-dig +short YOUR_DOMAIN        # A record
-dig +short AAAA YOUR_DOMAIN   # AAAA record (if configured)
-```
-
-These should return your server's public IP(s).
-
-#### Configure Caddy
-
-> **Prerequisites:** [DNS propagation](#set-up-dns) must be complete before this step, and [port 80 must be open](#open-ports). Caddy uses port 80 to complete the ACME challenge when obtaining a TLS certificate — if either DNS or port 80 are not ready then certificate provisioning will fail.
-
-Edit the Caddyfile:
-
-```bash
-sudo nano /etc/caddy/Caddyfile
-```
-
-Replace its contents with:
-
-```
-your_domain.com {
-    reverse_proxy 127.0.0.1:6286
-}
-```
-
-> **Important:** The domain in the Caddyfile must exactly match both your DNS A-record name and the `icann_domain` value in `config.toml`. A mismatch between any of these is a common source of silent failures.
-
-Reload Caddy and check the logs:
-
-```bash
-sudo systemctl reload caddy
-journalctl -u caddy --no-pager | tail -50
-```
-
-Look for "certificate obtained" to confirm success, or any ACME errors.
-
-> **Tip:** The most common cause of ACME certificate errors is port 80 not being reachable from the internet. If you see an ACME error in the logs then double-check your firewall rules.
-
----
-
-### IP Address Only
-
-This option uses your server's IP address directly with shortlived (~6-day) Let's Encrypt certificates. No domain registration or DNS setup needed.
-
-> **Prerequisites:** [Port 80 must be open](#open-ports). Caddy uses port 80 to complete the ACME HTTP-01 challenge.
-
-IP address certificates require Caddy v2.10.1 or later. Check your version with `caddy version` and run `sudo caddy upgrade` if needed.
-
-#### Configure Caddy
-
-Edit the Caddyfile:
-
-```bash
-sudo nano /etc/caddy/Caddyfile
-```
-
-Replace its contents with:
-
-```
-{
-    default_sni YOUR_IP
-}
-
-YOUR_IP {
-    tls {
-        issuer acme {
-            profile shortlived
-        }
-    }
-    reverse_proxy 127.0.0.1:6286
-}
-```
-
-The `default_sni` line is required because TLS clients don't send SNI when connecting to an IP address. Without it, Caddy can't match incoming connections to your site block.
-
-Replace `YOUR_IP` with your server's public IP address (same value as `public_ip` and `icann_domain` in `config.toml`).
-
-Reload Caddy and check the logs:
-
-```bash
-sudo systemctl reload caddy
-journalctl -u caddy --no-pager | tail -50
-```
-
-Look for "certificate obtained" to confirm success, or any ACME errors.
-
-> **Tip:** The most common cause of ACME certificate errors is port 80 not being reachable from the internet. If you see an ACME error in the logs then double-check firewall rules.
-
----
-
-## Verify the Deployment
-
-### Check ICANN HTTPS
-
-From your local machine, verify that HTTP redirects to HTTPS and the homeserver responds. Replace `YOUR_HOST` with your domain or IP address:
-
-```bash
-# Should redirect to HTTPS (Caddy returns 308 by default)
-curl -I http://YOUR_HOST
-
-# Should return 200
-curl -I https://YOUR_HOST
-```
-
-### Find Your Public Key
-
-The remaining checks need your homeserver's public key. The admin API binds to localhost, so run this from the server itself:
-
-```bash
-# Use your configured admin password. Default is "admin".
-curl -s "http://127.0.0.1:6288/info" -H "X-Admin-Password: admin"
-```
-
-The response is JSON — look for the `public_key` field.
-
-### Check PKARR Record
-
-Look up your public key on [pkdns.net](https://pkdns.net/). The record should contain your server's public IP and your domain or IP address (from `icann_domain`).
-
-For a more thorough check, resolve the record from the DHT directly using the `resolve` example from the [pkarr](https://github.com/pubky/pkarr) repository:
-
-```bash
-cargo run --example resolve <homeserver-public-key>
-```
-
-This performs a cold lookup, a cached lookup, and a network-only lookup, printing the resolved DNS records and timings for each. Verify that the output contains an `A` record with your server's public IP and `HTTPS` (SVCB) records — one for the Pubky TLS port and one pointing to your domain or IP address.
-
-### Check Pubky TLS
-
-From a separate machine with the [pkarr](https://github.com/pubky/pkarr) repository cloned:
-
-```bash
-cargo run --features=reqwest-builder --example http-get https://<homeserver-public-key>
-```
-
-A successful response prints `Pubky Homeserver`.
-
-
-## Production Notes
-
-- Back up the homeserver's state regularly:
-  - The keypair at `~/.pubky/secret` — this is the homeserver's identity. If lost, the server cannot be recovered.
-  - User data — by default stored in `~/.pubky/data/files` (depends on `storage.type`).
-  - The PostgreSQL database.
-- Change the default admin password in `[admin].admin_password`.
-- **IP Address Only users:** Shortlived certificates expire in ~6 days. Caddy renews them automatically, but if renewal fails for more than a few days your HTTPS endpoint will go down. Ensure port 80 stays reachable.
-
-## Troubleshooting
-
-### Caddy fails to obtain a certificate
-
-Ensure ports 80 and 443 are open and reachable from the internet. Caddy attempts ACME challenges on both port 80 (HTTP-01) and port 443 (TLS-ALPN-01) — both should be open. Check your cloud firewall and any host-level firewall (`ufw`, `iptables`).
-
-**With a Domain:** Verify that DNS has propagated — `dig +short YOUR_DOMAIN` should return your IP.
-
-**IP Address Only:** Ensure you're running Caddy v2.10.1+ (`caddy version`). Older versions don't support IP address certificates. If you see a `rejectedIdentifier` ACME error, make sure the `profile shortlived` is set in your Caddyfile.
-
-### Pubky TLS connections time out
-
-Verify that port 6287 is open in your firewall and that the homeserver is listening on `0.0.0.0:6287`, not `127.0.0.1:6287`. Check with:
-
-```bash
-sudo ss -tlnp | grep 6287
-```
-
-### PKARR record shows wrong IP
-
-Check `pkdns.public_ip` in `~/.pubky/config.toml`. It must be the server's public IP, not a private or localhost address. After updating, restart the homeserver and allow a few minutes for the DHT record to propagate.
+| | [Domain](deploy/domain.md) | [IP Address Only](deploy/ip-only.md) | [Cloudflare Tunnel](deploy/cloudflare-tunnel.md) |
+| --- | --- | --- | --- |
+| Static IP required | Yes | Yes | No |
+| Domain required | Yes | No | Yes (on Cloudflare) |
+| Open ports required | 80, 443, 6287 | 80, 443, 6287 | 6287 only (if reachable) |
+| Pubky TLS (native) | Yes | Yes | Only if port 6287 is reachable |
+| HTTPS (browsers) | Yes | Yes | Yes |
+| Certificate lifetime | 90 days (auto-renewed) | ~6 days (auto-renewed) | Managed by Cloudflare |
+| Extra software | Caddy | Caddy (v2.10.1+) | cloudflared |
+| Best for | Production servers | Quick setup, no domain | Home networks, no static IP |
+
+Pick an option and follow the linked guide:
+
+- **[With a Domain](deploy/domain.md)** — standard setup with a domain name and static IP. Long-lived certificates, full protocol support. The recommended production option.
+- **[IP Address Only](deploy/ip-only.md)** — no domain registration needed. Uses short-lived certificates that auto-renew, so the server must stay healthy. Full protocol support.
+- **[Cloudflare Tunnel](deploy/cloudflare-tunnel.md)** — no static IP or open ports needed for HTTPS. Cloudflare proxies traffic through an outbound tunnel. Ideal for home servers behind NAT/CGNAT. Pubky TLS requires port 6287 to be separately reachable.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -15,19 +15,20 @@ Ideally your deployment supports both, but some setups only provide HTTPS. The c
 
 ## Choose Your Setup
 
+There are three deployment guides depending on your requirements and network limitations. Compare them below and follow the one that fits your situation.
+
+- **[With a Domain](deploy/domain.md)** — standard setup with a domain name and static IP. Long-lived certificates, full protocol support. The recommended production option.
+- **[IP Address Only](deploy/ip-only.md)** — no domain registration needed. Uses short-lived certificates that auto-renew, so the server must stay healthy. Full protocol support.
+- **[Cloudflare Tunnel](deploy/cloudflare-tunnel.md)** — no static IP or open ports needed. Cloudflare proxies HTTPS traffic through an outbound tunnel. Ideal for home servers behind NAT/CGNAT. **Does not support Pubky TLS.**
+
 | | [Domain](deploy/domain.md) | [IP Address Only](deploy/ip-only.md) | [Cloudflare Tunnel](deploy/cloudflare-tunnel.md) |
 | --- | --- | --- | --- |
 | Static IP required | Yes | Yes | No |
-| Domain required | Yes | No | Yes (on Cloudflare) |
-| Open ports required | 80, 443, 6287 | 80, 443, 6287 | 6287 only (if reachable) |
-| Pubky TLS (native) | Yes | Yes | Only if port 6287 is reachable |
+| Domain required | Yes | No | Yes (Cloudflare-managed, from ~$5/year) |
+| Open ports required | 80, 443, 6287 | 80, 443, 6287 | None |
+| Pubky TLS (native) | Yes | Yes | No |
 | HTTPS (browsers) | Yes | Yes | Yes |
 | Certificate lifetime | 90 days (auto-renewed) | ~6 days (auto-renewed) | Managed by Cloudflare |
 | Extra software | Caddy | Caddy (v2.10.1+) | cloudflared |
 | Best for | Production servers | Quick setup, no domain | Home networks, no static IP |
 
-Pick an option and follow the linked guide:
-
-- **[With a Domain](deploy/domain.md)** — standard setup with a domain name and static IP. Long-lived certificates, full protocol support. The recommended production option.
-- **[IP Address Only](deploy/ip-only.md)** — no domain registration needed. Uses short-lived certificates that auto-renew, so the server must stay healthy. Full protocol support.
-- **[Cloudflare Tunnel](deploy/cloudflare-tunnel.md)** — no static IP or open ports needed for HTTPS. Cloudflare proxies traffic through an outbound tunnel. Ideal for home servers behind NAT/CGNAT. Pubky TLS requires port 6287 to be separately reachable.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -141,6 +141,8 @@ pubky-homeserver --data-dir /path/to/pubky-data init
 
 The homeserver requires a running PostgreSQL instance with an empty database.
 
+> **Note:** The examples below use a simple password for quick local setup. If your server is public-facing then you may wish to use a strong password and review the [Docker security best practices](https://docs.docker.com/build/building/best-practices/#security).
+
 ### Docker
 
 Requires [Docker Engine](https://docs.docker.com/engine/install/ubuntu/).
@@ -243,7 +245,7 @@ Create a service file:
 sudo nano /etc/systemd/system/pubky-homeserver.service
 ```
 
-Paste the following:
+Paste the following, replacing `YOUR_USER` in both lines with your Linux username (the output of `whoami`):
 
 ```ini
 [Unit]

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -221,23 +221,32 @@ sed -i 's|^# \[general\]|[general]|; s|^# database_url = .*|database_url = "post
 ### Docker
 
 ```bash
-docker run -d --restart unless-stopped --network=host -v ~/.pubky:/root/.pubky pubky-homeserver homeserver
+docker run -d --name pubky-homeserver --restart unless-stopped --network=host -v ~/.pubky:/root/.pubky pubky-homeserver homeserver
 ```
 
 `--network=host` lets the container reach PostgreSQL on the host and expose its endpoints. The volume mount shares the data directory (config and keypair) with the container. `--restart unless-stopped` ensures the homeserver starts automatically after a reboot.
 
+Managing the container:
 
-### Native
+```bash
+docker logs -f pubky-homeserver        # view logs
+docker restart pubky-homeserver        # restart (e.g. after editing config.toml)
+docker stop pubky-homeserver           # stop
+```
 
-Start the homeserver:
+### Native (foreground)
+
+Start the homeserver in the foreground (useful for testing, does not survive reboots):
 
 ```bash
 pubky-homeserver
 ```
 
+Press `Ctrl+C` to stop. For production use, set up a [systemd service](#systemd-service) instead.
+
 ### systemd Service
 
-Below is an example setup using systemd, which is available on most Linux distributions. This will run the homeserver in the background, start it on boot, and restart it automatically on failure.
+systemd is available on most Linux distributions. It runs the homeserver in the background, starts it on boot, and restarts it automatically on failure.
 
 Create a service file:
 
@@ -278,16 +287,13 @@ sudo systemctl enable pubky-homeserver
 sudo systemctl start pubky-homeserver
 ```
 
-Check that it is running:
+Managing the service:
 
 ```bash
-systemctl status pubky-homeserver
-```
-
-View logs:
-
-```bash
-journalctl -u pubky-homeserver -f
+systemctl status pubky-homeserver              # check status
+sudo systemctl restart pubky-homeserver        # restart (e.g. after editing config.toml)
+journalctl -u pubky-homeserver -f              # view logs
+sudo systemctl stop pubky-homeserver           # stop
 ```
  
 ## Next Steps

--- a/docs/deploy/cloudflare-tunnel.md
+++ b/docs/deploy/cloudflare-tunnel.md
@@ -1,3 +1,170 @@
 # Deploy with a Cloudflare Tunnel
 
-<!-- TODO: Write this guide -->
+This guide is for users who **cannot open ports** on their network or **don't have a static IP** — for example behind NAT, CGNAT, or a home router without port-forwarding access. Cloudflare proxies incoming HTTPS traffic through an outbound tunnel from your machine, so no inbound ports are needed.
+
+If you can open ports and have a static IP, consider [deploying with a domain](domain.md) or [deploying with an IP address](ip-only.md) instead — both support full Pubky TLS connectivity.
+
+This guide assumes you have already [installed the homeserver](../INSTALL.md).
+
+Commands and package names assume a Debian-based system (Ubuntu, Debian, etc.), adapt as needed for other distributions.
+
+## Requirements
+
+- A free [Cloudflare account](https://dash.cloudflare.com/sign-up)
+- A **domain name** with its DNS managed by Cloudflare (free plan is fine)
+- `cloudflared` installed on the server
+
+## Limitations
+
+Cloudflare Tunnels only proxy HTTP/HTTPS traffic. **Pubky TLS (native protocol on port 6287) will not work with this setup.** Your homeserver will be reachable by browsers and the browser-based SDK over HTTPS, but not by native Pubky protocol clients.
+
+## Install cloudflared
+
+Install the `cloudflared` daemon following [Cloudflare's official instructions](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/).
+
+## Authenticate with Cloudflare
+
+Log in to your Cloudflare account:
+
+```bash
+cloudflared login
+```
+
+This opens a browser window. Select the domain you want to use and authorize `cloudflared`. A certificate is saved to `~/.cloudflared/cert.pem`.
+
+## Create the Tunnel
+
+Create a named tunnel:
+
+```bash
+cloudflared tunnel create pubky-homeserver
+```
+
+This outputs a **Tunnel ID** (a UUID) and creates a credentials file at `~/.cloudflared/<TUNNEL_ID>.json`. You'll need the Tunnel ID for the next steps.
+
+## Route DNS
+
+Point your domain at the tunnel:
+
+```bash
+cloudflared tunnel route dns pubky-homeserver YOUR_DOMAIN
+```
+
+Replace `YOUR_DOMAIN` with the domain (or subdomain) you want to use, e.g. `homeserver.example.com`. This creates a CNAME record in your Cloudflare DNS that routes traffic to the tunnel.
+
+## Configure the Tunnel
+
+Create the cloudflared config file:
+
+```bash
+mkdir -p ~/.cloudflared
+nano ~/.cloudflared/config.yml
+```
+
+Add the following:
+
+```yaml
+tunnel: <TUNNEL_ID>
+credentials-file: /home/<YOUR_USER>/.cloudflared/<TUNNEL_ID>.json
+
+ingress:
+  - hostname: YOUR_DOMAIN
+    service: http://127.0.0.1:6286
+  - service: http_status:404
+```
+
+Replace `<TUNNEL_ID>` with your Tunnel ID, `<YOUR_USER>` with your system username, and `YOUR_DOMAIN` with the domain you configured in the previous step.
+
+The ingress rule sends traffic for your domain to the homeserver's internal HTTP port (6286). The catch-all rule at the bottom returns 404 for anything else.
+
+## Configure the Homeserver
+
+Edit `~/.pubky/config.toml`:
+
+```toml
+[pkdns]
+# Your domain name — the tunnel makes this reachable via Cloudflare.
+icann_domain = "YOUR_DOMAIN"
+
+# Set to 443 since Cloudflare terminates TLS and browsers connect
+# on the standard HTTPS port.
+public_icann_http_port = 443
+```
+
+Replace `YOUR_DOMAIN` with the domain you routed to the tunnel.
+
+Restart the homeserver after editing `config.toml`. See [Run](../INSTALL.md#run) in the install guide.
+
+> For the full list of settings, see [`pubky-homeserver/config.sample.toml`](../../pubky-homeserver/config.sample.toml).
+
+## Run the Tunnel
+
+### Test manually first
+
+```bash
+cloudflared tunnel run pubky-homeserver
+```
+
+Verify that `https://YOUR_DOMAIN` responds (see [Verify](#verify-the-deployment) below). Press Ctrl+C to stop.
+
+### Install as a system service
+
+Once the manual test passes, install `cloudflared` as a systemd service so it starts on boot:
+
+```bash
+sudo cloudflared service install
+sudo systemctl enable cloudflared
+sudo systemctl start cloudflared
+```
+
+Check the service status:
+
+```bash
+sudo systemctl status cloudflared
+journalctl -u cloudflared --no-pager | tail -20
+```
+
+## Verify the Deployment
+
+### Check ICANN HTTPS
+
+From your local machine:
+
+```bash
+# Should return 200
+curl -I https://YOUR_DOMAIN
+```
+
+Then follow the [common verification steps](post-setup.md): find your public key and check your PKARR record. (The Pubky TLS check does not apply to this setup.)
+
+## Production Notes
+
+See the [common production notes](post-setup.md#production-notes), plus:
+
+- Back up `~/.cloudflared/` — contains your tunnel credentials. If lost, you'll need to recreate the tunnel.
+- The tunnel must stay running for HTTPS to work. Monitor the `cloudflared` service and set up alerts if it goes down.
+- Cloudflare's free plan has no bandwidth caps for tunnels, but review their [terms of service](https://www.cloudflare.com/terms/) for your use case.
+
+## Troubleshooting
+
+### Tunnel connects but HTTPS returns 502
+
+The tunnel is reaching Cloudflare but can't connect to the homeserver locally. Verify the homeserver is running and listening on port 6286:
+
+```bash
+curl -I http://127.0.0.1:6286
+sudo ss -tlnp | grep 6286
+```
+
+### cloudflared won't start
+
+Check the credentials file exists and matches the tunnel ID in `config.yml`:
+
+```bash
+ls ~/.cloudflared/*.json
+cat ~/.cloudflared/config.yml
+```
+
+If you moved or recreated the tunnel, the credentials file path may have changed.
+
+For PKARR troubleshooting, see [common troubleshooting](post-setup.md#troubleshooting).

--- a/docs/deploy/cloudflare-tunnel.md
+++ b/docs/deploy/cloudflare-tunnel.md
@@ -1,0 +1,3 @@
+# Deploy with a Cloudflare Tunnel
+
+<!-- TODO: Write this guide -->

--- a/docs/deploy/cloudflare-tunnel.md
+++ b/docs/deploy/cloudflare-tunnel.md
@@ -1,22 +1,18 @@
 # Deploy with a Cloudflare Tunnel
 
-This guide is for users who **cannot open ports** on their network or **don't have a static IP** — for example behind NAT, CGNAT, or a home router without port-forwarding access. Cloudflare proxies incoming HTTPS traffic through an outbound tunnel from your machine, so no inbound ports are needed.
+How to deploy a Pubky homeserver behind a Cloudflare Tunnel — no open ports or static IP needed.
 
-If you can open ports and have a static IP, consider [deploying with a domain](domain.md) or [deploying with an IP address](ip-only.md) instead — both support full Pubky TLS connectivity.
+> **Important limitation:** Cloudflare Tunnels only proxy HTTP/HTTPS traffic. **Pubky TLS (the native protocol on port 6287) will not work with this setup.** Your homeserver will be reachable by browsers and the browser-based SDK over HTTPS, but not by native Pubky protocol clients. If you can open ports, consider [deploying with a domain](domain.md) or [deploying with an IP address](ip-only.md) instead — both support full Pubky TLS connectivity.
 
-This guide assumes you have already [installed the homeserver](../INSTALL.md).
+This guide assumes you have already [installed the homeserver](../INSTALL.md) and have it running.
 
 Commands and package names assume a Debian-based system (Ubuntu, Debian, etc.), adapt as needed for other distributions.
 
 ## Requirements
 
 - A free [Cloudflare account](https://dash.cloudflare.com/sign-up)
-- A **domain name** with its DNS managed by Cloudflare (free plan is fine)
+- A **domain name** with its DNS managed by Cloudflare (free plan is fine) — you can [buy one from Cloudflare](https://developers.cloudflare.com/registrar/get-started/register-domain/) for under $10/year or [transfer an existing domain](https://developers.cloudflare.com/fundamentals/setup/manage-domains/add-site/)
 - `cloudflared` installed on the server
-
-## Limitations
-
-Cloudflare Tunnels only proxy HTTP/HTTPS traffic. **Pubky TLS (native protocol on port 6287) will not work with this setup.** Your homeserver will be reachable by browsers and the browser-based SDK over HTTPS, but not by native Pubky protocol clients.
 
 ## Install cloudflared
 
@@ -24,44 +20,31 @@ Install the `cloudflared` daemon following [Cloudflare's official instructions](
 
 ## Authenticate with Cloudflare
 
-Log in to your Cloudflare account:
-
 ```bash
 cloudflared login
 ```
 
-This opens a browser window. Select the domain you want to use and authorize `cloudflared`. A certificate is saved to `~/.cloudflared/cert.pem`.
+Select the domain you want to use in the browser window that opens and authorize `cloudflared`. A certificate is saved to `~/.cloudflared/cert.pem`.
 
 ## Create the Tunnel
-
-Create a named tunnel:
 
 ```bash
 cloudflared tunnel create pubky-homeserver
 ```
 
-This outputs a **Tunnel ID** (a UUID) and creates a credentials file at `~/.cloudflared/<TUNNEL_ID>.json`. You'll need the Tunnel ID for the next steps.
+Note the **Tunnel ID** (a UUID) from the output — you'll need it for the next steps. A credentials file is created at `~/.cloudflared/<TUNNEL_ID>.json`.
 
 ## Route DNS
-
-Point your domain at the tunnel:
 
 ```bash
 cloudflared tunnel route dns pubky-homeserver YOUR_DOMAIN
 ```
 
-Replace `YOUR_DOMAIN` with the domain (or subdomain) you want to use, e.g. `homeserver.example.com`. This creates a CNAME record in your Cloudflare DNS that routes traffic to the tunnel.
+Replace `YOUR_DOMAIN` with your domain or subdomain (e.g. `homeserver.example.com`). This creates a CNAME record in Cloudflare DNS pointing to the tunnel.
 
 ## Configure the Tunnel
 
-Create the cloudflared config file:
-
-```bash
-mkdir -p ~/.cloudflared
-nano ~/.cloudflared/config.yml
-```
-
-Add the following:
+Create `~/.cloudflared/config.yml`:
 
 ```yaml
 tunnel: <TUNNEL_ID>
@@ -73,7 +56,7 @@ ingress:
   - service: http_status:404
 ```
 
-Replace `<TUNNEL_ID>` with your Tunnel ID, `<YOUR_USER>` with your system username, and `YOUR_DOMAIN` with the domain you configured in the previous step.
+Replace `<TUNNEL_ID>`, `<YOUR_USER>`, and `YOUR_DOMAIN` with your values.
 
 The ingress rule sends traffic for your domain to the homeserver's internal HTTP port (6286). The catch-all rule at the bottom returns 404 for anything else.
 
@@ -83,15 +66,19 @@ Edit `~/.pubky/config.toml`:
 
 ```toml
 [pkdns]
-# Your domain name — the tunnel makes this reachable via Cloudflare.
-icann_domain = "YOUR_DOMAIN"
-
 # Set to 443 since Cloudflare terminates TLS and browsers connect
 # on the standard HTTPS port.
 public_icann_http_port = 443
-```
 
-Replace `YOUR_DOMAIN` with the domain you routed to the tunnel.
+# Your domain name — the tunnel makes this reachable via Cloudflare.
+icann_domain = "YOUR_DOMAIN"
+
+# public_ip is not needed — Cloudflare proxies all traffic, so there is
+# no direct IP for Pubky TLS clients to connect to.
+
+# pubky_listen_socket can stay at the default (127.0.0.1:6287) since
+# Pubky TLS is not used with this setup.
+```
 
 Restart the homeserver after editing `config.toml`. See [Run](../INSTALL.md#run) in the install guide.
 
@@ -109,10 +96,10 @@ Verify that `https://YOUR_DOMAIN` responds (see [Verify](#verify-the-deployment)
 
 ### Install as a system service
 
-Once the manual test passes, install `cloudflared` as a systemd service so it starts on boot:
+Once the manual test passes, install `cloudflared` as a systemd service so it starts on boot. You must pass the config path explicitly because `sudo` changes the home directory to `/root`:
 
 ```bash
-sudo cloudflared service install
+sudo cloudflared --config ~/.cloudflared/config.yml service install
 sudo systemctl enable cloudflared
 sudo systemctl start cloudflared
 ```
@@ -135,7 +122,7 @@ From your local machine:
 curl -I https://YOUR_DOMAIN
 ```
 
-Then follow the [common verification steps](post-setup.md): find your public key and check your PKARR record. (The Pubky TLS check does not apply to this setup.)
+Then follow the [common verification steps](post-setup.md) to find your public key and check your PKARR record. (The Pubky TLS check does not apply to this setup.)
 
 ## Production Notes
 

--- a/docs/deploy/domain.md
+++ b/docs/deploy/domain.md
@@ -127,7 +127,7 @@ Look for "certificate obtained" to confirm success, or any ACME errors.
 
 ### Check ICANN HTTPS
 
-From your local machine, verify that HTTP redirects to HTTPS and the homeserver responds. Replace `YOUR_DOMAIN` with your domain:
+From your local machine, verify that HTTP redirects to HTTPS and the homeserver responds:
 
 ```bash
 # Should redirect to HTTPS (Caddy returns 308 by default)
@@ -137,55 +137,11 @@ curl -I http://YOUR_DOMAIN
 curl -I https://YOUR_DOMAIN
 ```
 
-### Find Your Public Key
-
-The remaining checks need your homeserver's public key. The admin API binds to localhost, so run this from the server itself:
-
-```bash
-# Use your configured admin password. Default is "admin".
-curl -s "http://127.0.0.1:6288/info" -H "X-Admin-Password: admin"
-```
-
-The response is JSON — look for the `public_key` field.
-
-### Check PKARR Record
-
-Look up your public key on [pkdns.net](https://pkdns.net/). The record should contain your server's public IP and your domain (from `icann_domain`).
-
-For a more thorough check, resolve the record from the DHT directly using the `resolve` example from the [pkarr](https://github.com/pubky/pkarr) repository:
-
-```bash
-cargo run --example resolve <homeserver-public-key>
-```
-
-This performs a cold lookup, a cached lookup, and a network-only lookup, printing the resolved DNS records and timings for each. Verify that the output contains an `A` record with your server's public IP and `HTTPS` (SVCB) records — one for the Pubky TLS port and one pointing to your domain.
-
-### Check Internal Ports Are Not Exposed
-
-```bash
-# These should all fail/timeout from an external machine:
-curl http://YOUR_DOMAIN:6286   # ICANN HTTP (internal)
-curl http://YOUR_DOMAIN:6288   # Admin API
-curl http://YOUR_DOMAIN:6289   # Metrics
-```
-
-### Check Pubky TLS
-
-From a separate machine with the [pkarr](https://github.com/pubky/pkarr) repository cloned:
-
-```bash
-cargo run --features=reqwest-builder --example http-get https://<homeserver-public-key>
-```
-
-A successful response prints `Pubky Homeserver`.
+Then follow the [common verification steps](post-setup.md): find your public key, check your PKARR record, and test Pubky TLS.
 
 ## Production Notes
 
-- Back up the homeserver's state regularly:
-  - The keypair at `~/.pubky/secret` — this is the homeserver's identity. If lost, the server cannot be recovered.
-  - User data — by default stored in `~/.pubky/data/files` (depends on `storage.type`).
-  - The PostgreSQL database.
-- Change the default admin password in `[admin].admin_password`.
+See the [common production notes](post-setup.md#production-notes).
 
 ## Troubleshooting
 
@@ -195,14 +151,4 @@ Ensure ports 80 and 443 are open and reachable from the internet. Caddy attempts
 
 Verify that DNS has propagated — `dig +short YOUR_DOMAIN` should return your IP.
 
-### Pubky TLS connections time out
-
-Verify that port 6287 is open in your firewall and that the homeserver is listening on `0.0.0.0:6287`, not `127.0.0.1:6287`. Check with:
-
-```bash
-sudo ss -tlnp | grep 6287
-```
-
-### PKARR record shows wrong IP
-
-Check `pkdns.public_ip` in `~/.pubky/config.toml`. It must be the server's public IP, not a private or localhost address. After updating, restart the homeserver and allow a few minutes for the DHT record to propagate.
+For PKARR and Pubky TLS troubleshooting, see [common troubleshooting](post-setup.md#troubleshooting).

--- a/docs/deploy/domain.md
+++ b/docs/deploy/domain.md
@@ -1,0 +1,208 @@
+# Deploy with a Domain
+
+How to deploy a Pubky homeserver using a domain name and a static IP address. This gives you full connectivity: both HTTPS (for browsers) and Pubky TLS (the native protocol).
+
+This guide assumes you have already [installed the homeserver](../INSTALL.md) and have it running.
+
+Commands and package names assume a Debian-based system (Ubuntu, Debian, etc.), adapt as needed for other distributions.
+
+## Requirements
+
+- A server with a **static public IP address**
+- A **domain name** with access to its DNS settings
+- Ports 80, 443, and 6287 available for inbound traffic
+
+## Open Ports
+
+The homeserver speaks two protocols. Both endpoints serve the same data, the difference is how clients find and connect to your server:
+
+**Pubky TLS** is the native protocol: clients resolve your homeserver's public key on the DHT and connect directly on port 6287, bypassing any certificate authority.
+
+**CA-authenticated TLS** is the HTTPS you already know from the regular internet: browsers and the browser-based SDK use this on port 443, which requires a TLS certificate from a certificate authority for your domain.
+
+The homeserver serves plain HTTP on an internal port; we place [Caddy](https://caddyserver.com/) in front of it to add the CA-authenticated TLS layer and serve HTTPS on port 443. Caddy manages the certificates automatically.
+
+Open these three ports for inbound traffic:
+
+| Port | Purpose |
+| --- | --- |
+| 80 | HTTP — [Caddy](#set-up-caddy) needs this for automatic TLS certificate provisioning. |
+| 443 | HTTPS — serves your homeserver via [Caddy](#set-up-caddy). Also used for TLS-ALPN-01 certificate challenges. |
+| 6287 | Pubky TLS — direct Pubky protocol connections (no certificate needed). |
+
+How you open these depends on your setup: a cloud provider's security group, a router's port-forwarding rules, or a host firewall.
+
+Do **not** expose these ports directly to the internet:
+
+| Port | Purpose |
+| --- | --- |
+| 6286 | ICANN HTTP — Caddy proxies to this internally. |
+| 6288 | Admin API — admin operations. |
+| 6289 | Metrics — internal monitoring only. |
+
+## Configure the Homeserver
+
+Edit `~/.pubky/config.toml` with the following settings:
+
+```toml
+[drive]
+# Listen on all interfaces so Pubky TLS is reachable from the internet
+pubky_listen_socket = "0.0.0.0:6287"
+
+# icann_listen_socket defaults to 127.0.0.1:6286 — no change needed.
+
+[pkdns]
+# The public-facing IP of this machine. Published to the DHT so that
+# Pubky TLS clients can connect directly to the homeserver.
+public_ip = "YOUR_IP"
+
+# Your domain name for HTTPS browser access.
+icann_domain = "YOUR_DOMAIN"
+```
+
+Replace `YOUR_IP` with the public IP of the machine running the homeserver. You can find it with `curl -4 ifconfig.me`.
+
+Replace `YOUR_DOMAIN` with your domain name.
+
+> **Warning:** Do **not** apply `0.0.0.0` to `icann_listen_socket`, `admin.listen_socket`, or `metrics.listen_socket` — those must stay on `127.0.0.1` to avoid exposing internal APIs to the internet.
+
+> **Important:** Ensure your server has a **static (reserved) public IP**. If your IP changes then the PKARR record (which embeds `public_ip`), your Caddy configuration, and any DNS records will silently point at a dead address.
+
+Restart the homeserver after editing `config.toml` for the changes to take effect. See [Run](../INSTALL.md#run) in the install guide.
+
+> For the full list of settings (including `public_pubky_tls_port` and `public_icann_http_port` for non-standard port setups), see [`pubky-homeserver/config.sample.toml`](../../pubky-homeserver/config.sample.toml).
+
+## Set Up DNS
+
+Configure your domain with an A record pointing to your server's public IP. If your server also has a public IPv6 address, add an AAAA record too.
+
+| Record Type | Name | Value |
+| --- | --- | --- |
+| A | YOUR_DOMAIN | YOUR_IPV4_ADDRESS |
+| AAAA | YOUR_DOMAIN | YOUR_IPV6_ADDRESS (optional) |
+
+Wait for DNS propagation, then verify:
+
+```bash
+dig +short YOUR_DOMAIN        # A record
+dig +short AAAA YOUR_DOMAIN   # AAAA record (if configured)
+```
+
+These should return your server's public IP(s).
+
+## Set Up Caddy
+
+Install [Caddy](https://caddyserver.com/docs/install#debian-ubuntu-raspbian).
+
+> **Prerequisites:** [DNS propagation](#set-up-dns) must be complete before this step, and [port 80 must be open](#open-ports). Caddy uses port 80 to complete the ACME challenge when obtaining a TLS certificate — if either DNS or port 80 are not ready then certificate provisioning will fail.
+
+Edit the Caddyfile:
+
+```bash
+sudo nano /etc/caddy/Caddyfile
+```
+
+Replace its contents with:
+
+```
+your_domain.com {
+    reverse_proxy 127.0.0.1:6286
+}
+```
+
+> **Important:** The domain in the Caddyfile must exactly match both your DNS A-record name and the `icann_domain` value in `config.toml`. A mismatch between any of these is a common source of silent failures.
+
+Reload Caddy and check the logs:
+
+```bash
+sudo systemctl reload caddy
+journalctl -u caddy --no-pager | tail -50
+```
+
+Look for "certificate obtained" to confirm success, or any ACME errors.
+
+> **Tip:** The most common cause of ACME certificate errors is port 80 not being reachable from the internet. If you see an ACME error in the logs then double-check your firewall rules.
+
+## Verify the Deployment
+
+### Check ICANN HTTPS
+
+From your local machine, verify that HTTP redirects to HTTPS and the homeserver responds. Replace `YOUR_DOMAIN` with your domain:
+
+```bash
+# Should redirect to HTTPS (Caddy returns 308 by default)
+curl -I http://YOUR_DOMAIN
+
+# Should return 200
+curl -I https://YOUR_DOMAIN
+```
+
+### Find Your Public Key
+
+The remaining checks need your homeserver's public key. The admin API binds to localhost, so run this from the server itself:
+
+```bash
+# Use your configured admin password. Default is "admin".
+curl -s "http://127.0.0.1:6288/info" -H "X-Admin-Password: admin"
+```
+
+The response is JSON — look for the `public_key` field.
+
+### Check PKARR Record
+
+Look up your public key on [pkdns.net](https://pkdns.net/). The record should contain your server's public IP and your domain (from `icann_domain`).
+
+For a more thorough check, resolve the record from the DHT directly using the `resolve` example from the [pkarr](https://github.com/pubky/pkarr) repository:
+
+```bash
+cargo run --example resolve <homeserver-public-key>
+```
+
+This performs a cold lookup, a cached lookup, and a network-only lookup, printing the resolved DNS records and timings for each. Verify that the output contains an `A` record with your server's public IP and `HTTPS` (SVCB) records — one for the Pubky TLS port and one pointing to your domain.
+
+### Check Internal Ports Are Not Exposed
+
+```bash
+# These should all fail/timeout from an external machine:
+curl http://YOUR_DOMAIN:6286   # ICANN HTTP (internal)
+curl http://YOUR_DOMAIN:6288   # Admin API
+curl http://YOUR_DOMAIN:6289   # Metrics
+```
+
+### Check Pubky TLS
+
+From a separate machine with the [pkarr](https://github.com/pubky/pkarr) repository cloned:
+
+```bash
+cargo run --features=reqwest-builder --example http-get https://<homeserver-public-key>
+```
+
+A successful response prints `Pubky Homeserver`.
+
+## Production Notes
+
+- Back up the homeserver's state regularly:
+  - The keypair at `~/.pubky/secret` — this is the homeserver's identity. If lost, the server cannot be recovered.
+  - User data — by default stored in `~/.pubky/data/files` (depends on `storage.type`).
+  - The PostgreSQL database.
+- Change the default admin password in `[admin].admin_password`.
+
+## Troubleshooting
+
+### Caddy fails to obtain a certificate
+
+Ensure ports 80 and 443 are open and reachable from the internet. Caddy attempts ACME challenges on both port 80 (HTTP-01) and port 443 (TLS-ALPN-01) — both should be open. Check your cloud firewall and any host-level firewall (`ufw`, `iptables`).
+
+Verify that DNS has propagated — `dig +short YOUR_DOMAIN` should return your IP.
+
+### Pubky TLS connections time out
+
+Verify that port 6287 is open in your firewall and that the homeserver is listening on `0.0.0.0:6287`, not `127.0.0.1:6287`. Check with:
+
+```bash
+sudo ss -tlnp | grep 6287
+```
+
+### PKARR record shows wrong IP
+
+Check `pkdns.public_ip` in `~/.pubky/config.toml`. It must be the server's public IP, not a private or localhost address. After updating, restart the homeserver and allow a few minutes for the DHT record to propagate.

--- a/docs/deploy/ip-only.md
+++ b/docs/deploy/ip-only.md
@@ -130,55 +130,12 @@ curl -I http://YOUR_IP
 curl -I https://YOUR_IP
 ```
 
-### Find Your Public Key
-
-The remaining checks need your homeserver's public key. The admin API binds to localhost, so run this from the server itself:
-
-```bash
-# Use your configured admin password. Default is "admin".
-curl -s "http://127.0.0.1:6288/info" -H "X-Admin-Password: admin"
-```
-
-The response is JSON — look for the `public_key` field.
-
-### Check PKARR Record
-
-Look up your public key on [pkdns.net](https://pkdns.net/). The record should contain your server's public IP (from `icann_domain`).
-
-For a more thorough check, resolve the record from the DHT directly using the `resolve` example from the [pkarr](https://github.com/pubky/pkarr) repository:
-
-```bash
-cargo run --example resolve <homeserver-public-key>
-```
-
-This performs a cold lookup, a cached lookup, and a network-only lookup, printing the resolved DNS records and timings for each. Verify that the output contains an `A` record with your server's public IP and `HTTPS` (SVCB) records — one for the Pubky TLS port and one pointing to your IP address.
-
-### Check Internal Ports Are Not Exposed
-
-```bash
-# These should all fail/timeout from an external machine:
-curl http://YOUR_IP:6286   # ICANN HTTP (internal)
-curl http://YOUR_IP:6288   # Admin API
-curl http://YOUR_IP:6289   # Metrics
-```
-
-### Check Pubky TLS
-
-From a separate machine with the [pkarr](https://github.com/pubky/pkarr) repository cloned:
-
-```bash
-cargo run --features=reqwest-builder --example http-get https://<homeserver-public-key>
-```
-
-A successful response prints `Pubky Homeserver`.
+Then follow the [common verification steps](post-setup.md): find your public key, check your PKARR record, and test Pubky TLS.
 
 ## Production Notes
 
-- Back up the homeserver's state regularly:
-  - The keypair at `~/.pubky/secret` — this is the homeserver's identity. If lost, the server cannot be recovered.
-  - User data — by default stored in `~/.pubky/data/files` (depends on `storage.type`).
-  - The PostgreSQL database.
-- Change the default admin password in `[admin].admin_password`.
+See the [common production notes](post-setup.md#production-notes), plus:
+
 - **Shortlived certificates expire in ~6 days.** Caddy renews them automatically, but if renewal fails for more than a few days your HTTPS endpoint will go down. Ensure port 80 stays reachable.
 
 ## Troubleshooting
@@ -189,14 +146,4 @@ Ensure ports 80 and 443 are open and reachable from the internet. Caddy attempts
 
 Ensure you're running Caddy v2.10.1+ (`caddy version`). Older versions don't support IP address certificates. If you see a `rejectedIdentifier` ACME error, make sure the `profile shortlived` is set in your Caddyfile.
 
-### Pubky TLS connections time out
-
-Verify that port 6287 is open in your firewall and that the homeserver is listening on `0.0.0.0:6287`, not `127.0.0.1:6287`. Check with:
-
-```bash
-sudo ss -tlnp | grep 6287
-```
-
-### PKARR record shows wrong IP
-
-Check `pkdns.public_ip` in `~/.pubky/config.toml`. It must be the server's public IP, not a private or localhost address. After updating, restart the homeserver and allow a few minutes for the DHT record to propagate.
+For PKARR and Pubky TLS troubleshooting, see [common troubleshooting](post-setup.md#troubleshooting).

--- a/docs/deploy/ip-only.md
+++ b/docs/deploy/ip-only.md
@@ -1,0 +1,202 @@
+# Deploy with IP Address Only
+
+How to deploy a Pubky homeserver using just an IP address — no domain name needed. This gives you full connectivity: both HTTPS (for browsers) and Pubky TLS (the native protocol). Uses short-lived (~6-day) Let's Encrypt certificates, so the server must stay healthy for automatic renewals.
+
+This guide assumes you have already [installed the homeserver](../INSTALL.md) and have it running.
+
+Commands and package names assume a Debian-based system (Ubuntu, Debian, etc.), adapt as needed for other distributions.
+
+## Requirements
+
+- A server with a **static public IP address**
+- Ports 80, 443, and 6287 available for inbound traffic
+- **Caddy v2.10.1 or later** (IP address certificates require this version)
+
+## Open Ports
+
+The homeserver speaks two protocols. Both endpoints serve the same data, the difference is how clients find and connect to your server:
+
+**Pubky TLS** is the native protocol: clients resolve your homeserver's public key on the DHT and connect directly on port 6287, bypassing any certificate authority.
+
+**CA-authenticated TLS** is the HTTPS you already know from the regular internet: browsers and the browser-based SDK use this on port 443, which requires a TLS certificate from a certificate authority for your IP address.
+
+The homeserver serves plain HTTP on an internal port; we place [Caddy](https://caddyserver.com/) in front of it to add the CA-authenticated TLS layer and serve HTTPS on port 443. Caddy manages the certificates automatically.
+
+Open these three ports for inbound traffic:
+
+| Port | Purpose |
+| --- | --- |
+| 80 | HTTP — [Caddy](#set-up-caddy) needs this for automatic TLS certificate provisioning. |
+| 443 | HTTPS — serves your homeserver via [Caddy](#set-up-caddy). Also used for TLS-ALPN-01 certificate challenges. |
+| 6287 | Pubky TLS — direct Pubky protocol connections (no certificate needed). |
+
+How you open these depends on your setup: a cloud provider's security group, a router's port-forwarding rules, or a host firewall.
+
+Do **not** expose these ports directly to the internet:
+
+| Port | Purpose |
+| --- | --- |
+| 6286 | ICANN HTTP — Caddy proxies to this internally. |
+| 6288 | Admin API — admin operations. |
+| 6289 | Metrics — internal monitoring only. |
+
+## Configure the Homeserver
+
+Edit `~/.pubky/config.toml` with the following settings:
+
+```toml
+[drive]
+# Listen on all interfaces so Pubky TLS is reachable from the internet
+pubky_listen_socket = "0.0.0.0:6287"
+
+# icann_listen_socket defaults to 127.0.0.1:6286 — no change needed.
+
+[pkdns]
+# The public-facing IP of this machine. Published to the DHT so that
+# Pubky TLS clients can connect directly to the homeserver.
+public_ip = "YOUR_IP"
+
+# No domain — set this to your IP address (same as public_ip).
+icann_domain = "YOUR_IP"
+```
+
+Replace `YOUR_IP` with the public IP of the machine running the homeserver. You can find it with `curl -4 ifconfig.me`.
+
+> **Warning:** Do **not** apply `0.0.0.0` to `icann_listen_socket`, `admin.listen_socket`, or `metrics.listen_socket` — those must stay on `127.0.0.1` to avoid exposing internal APIs to the internet.
+
+> **Important:** Ensure your server has a **static (reserved) public IP**. If your IP changes then the PKARR record (which embeds `public_ip`) and your Caddy configuration will silently point at a dead address.
+
+Restart the homeserver after editing `config.toml` for the changes to take effect. See [Run](../INSTALL.md#run) in the install guide.
+
+> For the full list of settings (including `public_pubky_tls_port` and `public_icann_http_port` for non-standard port setups), see [`pubky-homeserver/config.sample.toml`](../../pubky-homeserver/config.sample.toml).
+
+## Set Up Caddy
+
+Install [Caddy](https://caddyserver.com/docs/install#debian-ubuntu-raspbian).
+
+IP address certificates require Caddy v2.10.1 or later. Check your version with `caddy version` and run `sudo caddy upgrade` if needed.
+
+> **Prerequisites:** [Port 80 must be open](#open-ports). Caddy uses port 80 to complete the ACME HTTP-01 challenge.
+
+Edit the Caddyfile:
+
+```bash
+sudo nano /etc/caddy/Caddyfile
+```
+
+Replace its contents with:
+
+```
+{
+    default_sni YOUR_IP
+}
+
+YOUR_IP {
+    tls {
+        issuer acme {
+            profile shortlived
+        }
+    }
+    reverse_proxy 127.0.0.1:6286
+}
+```
+
+The `default_sni` line is required because TLS clients don't send SNI when connecting to an IP address. Without it, Caddy can't match incoming connections to your site block.
+
+Replace `YOUR_IP` with your server's public IP address (same value as `public_ip` and `icann_domain` in `config.toml`).
+
+Reload Caddy and check the logs:
+
+```bash
+sudo systemctl reload caddy
+journalctl -u caddy --no-pager | tail -50
+```
+
+Look for "certificate obtained" to confirm success, or any ACME errors.
+
+> **Tip:** The most common cause of ACME certificate errors is port 80 not being reachable from the internet. If you see an ACME error in the logs then double-check firewall rules.
+
+## Verify the Deployment
+
+### Check ICANN HTTPS
+
+From your local machine, verify that HTTP redirects to HTTPS and the homeserver responds. Replace `YOUR_IP` with your server's public IP:
+
+```bash
+# Should redirect to HTTPS (Caddy returns 308 by default)
+curl -I http://YOUR_IP
+
+# Should return 200
+curl -I https://YOUR_IP
+```
+
+### Find Your Public Key
+
+The remaining checks need your homeserver's public key. The admin API binds to localhost, so run this from the server itself:
+
+```bash
+# Use your configured admin password. Default is "admin".
+curl -s "http://127.0.0.1:6288/info" -H "X-Admin-Password: admin"
+```
+
+The response is JSON — look for the `public_key` field.
+
+### Check PKARR Record
+
+Look up your public key on [pkdns.net](https://pkdns.net/). The record should contain your server's public IP (from `icann_domain`).
+
+For a more thorough check, resolve the record from the DHT directly using the `resolve` example from the [pkarr](https://github.com/pubky/pkarr) repository:
+
+```bash
+cargo run --example resolve <homeserver-public-key>
+```
+
+This performs a cold lookup, a cached lookup, and a network-only lookup, printing the resolved DNS records and timings for each. Verify that the output contains an `A` record with your server's public IP and `HTTPS` (SVCB) records — one for the Pubky TLS port and one pointing to your IP address.
+
+### Check Internal Ports Are Not Exposed
+
+```bash
+# These should all fail/timeout from an external machine:
+curl http://YOUR_IP:6286   # ICANN HTTP (internal)
+curl http://YOUR_IP:6288   # Admin API
+curl http://YOUR_IP:6289   # Metrics
+```
+
+### Check Pubky TLS
+
+From a separate machine with the [pkarr](https://github.com/pubky/pkarr) repository cloned:
+
+```bash
+cargo run --features=reqwest-builder --example http-get https://<homeserver-public-key>
+```
+
+A successful response prints `Pubky Homeserver`.
+
+## Production Notes
+
+- Back up the homeserver's state regularly:
+  - The keypair at `~/.pubky/secret` — this is the homeserver's identity. If lost, the server cannot be recovered.
+  - User data — by default stored in `~/.pubky/data/files` (depends on `storage.type`).
+  - The PostgreSQL database.
+- Change the default admin password in `[admin].admin_password`.
+- **Shortlived certificates expire in ~6 days.** Caddy renews them automatically, but if renewal fails for more than a few days your HTTPS endpoint will go down. Ensure port 80 stays reachable.
+
+## Troubleshooting
+
+### Caddy fails to obtain a certificate
+
+Ensure ports 80 and 443 are open and reachable from the internet. Caddy attempts ACME challenges on both port 80 (HTTP-01) and port 443 (TLS-ALPN-01) — both should be open. Check your cloud firewall and any host-level firewall (`ufw`, `iptables`).
+
+Ensure you're running Caddy v2.10.1+ (`caddy version`). Older versions don't support IP address certificates. If you see a `rejectedIdentifier` ACME error, make sure the `profile shortlived` is set in your Caddyfile.
+
+### Pubky TLS connections time out
+
+Verify that port 6287 is open in your firewall and that the homeserver is listening on `0.0.0.0:6287`, not `127.0.0.1:6287`. Check with:
+
+```bash
+sudo ss -tlnp | grep 6287
+```
+
+### PKARR record shows wrong IP
+
+Check `pkdns.public_ip` in `~/.pubky/config.toml`. It must be the server's public IP, not a private or localhost address. After updating, restart the homeserver and allow a few minutes for the DHT record to propagate.

--- a/docs/deploy/post-setup.md
+++ b/docs/deploy/post-setup.md
@@ -25,7 +25,7 @@ For a more thorough check, resolve the record from the DHT directly using the `r
 cargo run --example resolve <homeserver-public-key>
 ```
 
-This performs a cold lookup, a cached lookup, and a network-only lookup, printing the resolved DNS records and timings for each.
+This performs a cold lookup, a cached lookup, and a network-only lookup, printing the resolved DNS records and timings for each. If your deployment sets `public_ip`, verify that the output contains an `A` record with your server's public IP. You should also see `HTTPS` (SVCB) records — one for the Pubky TLS port (if applicable) and one pointing to your domain or IP address.
 
 ### Check Pubky TLS
 

--- a/docs/deploy/post-setup.md
+++ b/docs/deploy/post-setup.md
@@ -1,0 +1,62 @@
+# Post-Setup
+
+Common verification, production, and troubleshooting steps that apply to all deployment methods.
+
+## Verification
+
+### Find Your Public Key
+
+The remaining checks need your homeserver's public key. The admin API binds to localhost, so run this from the server itself:
+
+```bash
+# Use your configured admin password. Default is "admin".
+curl -s "http://127.0.0.1:6288/info" -H "X-Admin-Password: admin"
+```
+
+The response is JSON — look for the `public_key` field.
+
+### Check PKARR Record
+
+Look up your public key on [pkdns.net](https://pkdns.net/). The record should contain your `icann_domain` value and, if you set `public_ip`, your server's IP address.
+
+For a more thorough check, resolve the record from the DHT directly using the `resolve` example from the [pkarr](https://github.com/pubky/pkarr) repository:
+
+```bash
+cargo run --example resolve <homeserver-public-key>
+```
+
+This performs a cold lookup, a cached lookup, and a network-only lookup, printing the resolved DNS records and timings for each.
+
+### Check Pubky TLS
+
+> **Note:** This only applies if your deployment supports Pubky TLS (port 6287 is publicly reachable). If you deployed with a [Cloudflare Tunnel](cloudflare-tunnel.md), skip this step.
+
+From a separate machine with the [pkarr](https://github.com/pubky/pkarr) repository cloned:
+
+```bash
+cargo run --features=reqwest-builder --example http-get https://<homeserver-public-key>
+```
+
+A successful response prints `Pubky Homeserver`.
+
+## Production Notes
+
+- Back up the homeserver's state regularly:
+  - The keypair at `~/.pubky/secret` — this is the homeserver's identity. If lost, the server cannot be recovered.
+  - User data — by default stored in `~/.pubky/data/files` (depends on `storage.type`).
+  - The PostgreSQL database.
+- Change the default admin password in `[admin].admin_password`.
+
+## Troubleshooting
+
+### PKARR record missing or incorrect
+
+Verify `icann_domain` (and `public_ip` if set) in `~/.pubky/config.toml`. After updating, restart the homeserver and allow a few minutes for the DHT record to propagate.
+
+### Pubky TLS connections time out
+
+Verify that port 6287 is open in your firewall and that the homeserver is listening on `0.0.0.0:6287`, not `127.0.0.1:6287`. Check with:
+
+```bash
+sudo ss -tlnp | grep 6287
+```

--- a/docs/v0.10-migration/README.md
+++ b/docs/v0.10-migration/README.md
@@ -84,7 +84,6 @@ let caps = Capabilities::builder()
 const caps = "/pub/my-cool-app/:rw";
 ```
 
-
 ## Event Stream Path Filters
 
 Event streams without a `path` filter return only public (`/pub/`) events.


### PR DESCRIPTION
- Adds hs deploy guide for getting setup with cloudflare tunnel
- Split deploy guide into 3 separate guides for each method: domain, ip-only and cloudflare tunnel
- Centralised prod notes, verification steps and troubleshooting