### PR TITLE
refactor(homeserver): All user-based operations to flow through `UserService`

### DIFF
--- a/pubky-homeserver/src/admin_server/app.rs
+++ b/pubky-homeserver/src/admin_server/app.rs
@@ -226,14 +226,11 @@ mod tests {
         paths: &[&str],
     ) -> pubky_common::crypto::PublicKey {
         use crate::persistence::files::events::EventType;
-        use crate::persistence::sql::user::UserRepository;
         use crate::shared::webdav::{EntryPath, StoragePath};
         use pubky_common::crypto::{Hash, Keypair};
 
         let pubkey = Keypair::random().public_key();
-        let user = UserRepository::create(&pubkey, &mut context.sql_db.pool().into())
-            .await
-            .unwrap();
+        let user = context.user_service.create(&pubkey).await.unwrap();
         for p in paths {
             let path = EntryPath::new(pubkey.clone(), StoragePath::new(p).unwrap());
             context
@@ -471,7 +468,6 @@ mod tests {
     #[tokio::test]
     #[pubky_test_utils::test]
     async fn test_dav_put_get_delete_file() {
-        use crate::persistence::sql::user::UserRepository;
         use pubky_common::crypto::Keypair;
 
         let context = AppContext::test().await;
@@ -481,9 +477,7 @@ mod tests {
         // Register a user so storage finalization can lock and account for the write.
         let keypair = Keypair::from_secret(&[0; 32]);
         let pubkey = keypair.public_key();
-        UserRepository::create(&pubkey, &mut context.sql_db.pool().into())
-            .await
-            .unwrap();
+        context.user_service.create(&pubkey).await.unwrap();
 
         let file_content = b"hello webdav";
         let file_url = format!("/dav/{}/pub/test.txt", pubkey.z32());
@@ -540,7 +534,6 @@ mod tests {
     #[tokio::test]
     #[pubky_test_utils::test]
     async fn test_dav_put_quota_overflow_returns_500() {
-        use crate::persistence::sql::user::UserRepository;
         use pubky_common::crypto::Keypair;
 
         let mut context = AppContext::test().await;
@@ -550,9 +543,7 @@ mod tests {
 
         let keypair = Keypair::from_secret(&[0; 32]);
         let pubkey = keypair.public_key();
-        UserRepository::create(&pubkey, &mut context.sql_db.pool().into())
-            .await
-            .unwrap();
+        context.user_service.create(&pubkey).await.unwrap();
 
         let pubkey = keypair.public_key().z32();
         let file1_url = format!("/dav/{pubkey}/pub/one.bin");

--- a/pubky-homeserver/src/admin_server/app_state.rs
+++ b/pubky-homeserver/src/admin_server/app_state.rs
@@ -25,7 +25,6 @@ pub(crate) struct AppState {
     pub(crate) admin_password: String,
     pub(crate) inner_dav_handler: DavHandler,
     pub(crate) metadata: AdminMetadata,
-    /// User service for quota cache eviction on admin updates.
     pub(crate) user_service: UserService,
     /// Event service for the admin all-events stream.
     pub(crate) events_service: EventsService,

--- a/pubky-homeserver/src/admin_server/routes/admin_events.rs
+++ b/pubky-homeserver/src/admin_server/routes/admin_events.rs
@@ -18,10 +18,7 @@ use url::form_urlencoded;
 
 use super::super::app_state::AppState;
 use crate::{
-    persistence::{
-        files::events::{AllEventsFilter, Mode, PathFilter, MAX_EVENT_STREAM_USERS},
-        sql::user::UserRepository,
-    },
+    persistence::files::events::{AllEventsFilter, Mode, PathFilter, MAX_EVENT_STREAM_USERS},
     shared::{webdav::StoragePath, HttpError, HttpResult},
 };
 
@@ -144,12 +141,10 @@ async fn resolve_filter(
     } else {
         let mut ids = Vec::with_capacity(params.users.len());
         for pk in &params.users {
-            let id = UserRepository::get_id(pk, &mut state.sql_db.pool().into())
-                .await
-                .map_err(|e| match e {
-                    sqlx::Error::RowNotFound => HttpError::not_found(),
-                    e => HttpError::from(e),
-                })?;
+            let id = state.user_service.get_id(pk).await.map_err(|e| match e {
+                sqlx::Error::RowNotFound => HttpError::not_found(),
+                e => HttpError::from(e),
+            })?;
             ids.push(id);
         }
         Some(ids)

--- a/pubky-homeserver/src/admin_server/routes/delete_entry.rs
+++ b/pubky-homeserver/src/admin_server/routes/delete_entry.rs
@@ -24,7 +24,7 @@ mod tests {
         FileService,
     };
     use crate::persistence::sql::entry::EntryRepository;
-    use crate::persistence::sql::user::UserRepository;
+    use crate::services::user_service::UserService;
     use crate::shared::webdav::{EntryPath, StoragePath};
     use crate::AppContext;
     use axum::{routing::delete, Router};
@@ -60,9 +60,8 @@ mod tests {
 
         // Write a test file
         let storage_path = StoragePath::new(format!("/pub/{}", file_path).as_str()).unwrap();
-        UserRepository::create(&pubkey, &mut db.pool().into())
-            .await
-            .unwrap();
+        let user_service = UserService::new(db.clone());
+        user_service.create(&pubkey).await.unwrap();
         let entry_path = EntryPath::new(pubkey.clone(), storage_path);
 
         write_test_file(&file_service, &entry_path).await;

--- a/pubky-homeserver/src/admin_server/routes/disable_users.rs
+++ b/pubky-homeserver/src/admin_server/routes/disable_users.rs
@@ -1,69 +1,38 @@
 use super::super::app_state::AppState;
-use crate::{
-    persistence::sql::{uexecutor, user::UserRepository},
-    shared::{HttpError, HttpResult, Z32Pubkey},
-};
+use crate::shared::{HttpResult, Z32Pubkey};
 use axum::{
     extract::{Path, State},
     http::StatusCode,
     response::IntoResponse,
 };
 
-/// Delete a single entry from the database.
+/// Disable a user account.
 ///
 /// # Errors
 ///
 /// - `400` if the pubkey is invalid.
-/// - `404` if the entry does not exist.
+/// - `404` if the user does not exist.
 ///
 pub async fn disable_user(
     State(state): State<AppState>,
     Path(pubkey): Path<Z32Pubkey>,
 ) -> HttpResult<impl IntoResponse> {
-    let mut tx = state.sql_db.pool().begin().await?;
-    let mut user = match UserRepository::get(&pubkey.0, uexecutor!(tx)).await {
-        Ok(user) => user,
-        Err(sqlx::Error::RowNotFound) => {
-            return Err(HttpError::new_with_message(
-                StatusCode::NOT_FOUND,
-                "User not found",
-            ))
-        }
-        Err(e) => return Err(e.into()),
-    };
-    user.disabled = true;
-    UserRepository::update(&user, uexecutor!(tx)).await?;
-    tx.commit().await?;
-
+    state.user_service.admin_disable(&pubkey.0).await?;
     Ok((StatusCode::OK, "Ok"))
 }
 
-/// Delete a single entry from the database.
+/// Enable a user account.
 ///
 /// # Errors
 ///
 /// - `400` if the pubkey is invalid.
-/// - `404` if the entry does not exist.
+/// - `404` if the user does not exist.
 ///
 pub async fn enable_user(
     State(state): State<AppState>,
     Path(pubkey): Path<Z32Pubkey>,
 ) -> HttpResult<impl IntoResponse> {
-    let mut tx = state.sql_db.pool().begin().await?;
-    let mut user = match UserRepository::get(&pubkey.0, uexecutor!(tx)).await {
-        Ok(user) => user,
-        Err(sqlx::Error::RowNotFound) => {
-            return Err(HttpError::new_with_message(
-                StatusCode::NOT_FOUND,
-                "User not found",
-            ))
-        }
-        Err(e) => return Err(e.into()),
-    };
-    user.disabled = false;
-    UserRepository::update(&user, uexecutor!(tx)).await?;
-    tx.commit().await?;
-
+    state.user_service.admin_enable(&pubkey.0).await?;
     Ok((StatusCode::OK, "Ok"))
 }
 
@@ -83,14 +52,10 @@ mod tests {
         let pubkey = Keypair::random().public_key();
 
         // Create new user
-        UserRepository::create(&pubkey, &mut context.sql_db.pool().into())
-            .await
-            .unwrap();
+        context.user_service.create(&pubkey).await.unwrap();
 
         // Check that the tenant is enabled
-        let user = UserRepository::get(&pubkey, &mut context.sql_db.pool().into())
-            .await
-            .unwrap();
+        let user = context.user_service.get(&pubkey).await.unwrap();
         assert!(!user.disabled);
 
         // Setup server
@@ -116,9 +81,7 @@ mod tests {
         assert_eq!(response.status_code(), StatusCode::OK);
 
         // Check that the tenant is disabled
-        let user = UserRepository::get(&pubkey, &mut context.sql_db.pool().into())
-            .await
-            .unwrap();
+        let user = context.user_service.get(&pubkey).await.unwrap();
         assert!(user.disabled);
 
         // Enable the tenant again
@@ -128,9 +91,7 @@ mod tests {
         assert_eq!(response.status_code(), StatusCode::OK);
 
         // Check that the tenant is enabled
-        let user = UserRepository::get(&pubkey, &mut context.sql_db.pool().into())
-            .await
-            .unwrap();
+        let user = context.user_service.get(&pubkey).await.unwrap();
         assert!(!user.disabled);
     }
 }

--- a/pubky-homeserver/src/admin_server/routes/info.rs
+++ b/pubky-homeserver/src/admin_server/routes/info.rs
@@ -1,6 +1,5 @@
 use super::super::app_state::AppState;
 use crate::persistence::sql::signup_code::SignupCodeRepository;
-use crate::persistence::sql::user::UserRepository;
 use crate::shared::HttpResult;
 use axum::{extract::State, http::StatusCode, Json};
 use serde::Serialize;
@@ -20,7 +19,7 @@ pub(crate) struct InfoResponse {
 
 /// Return summary statistics about the homeserver.
 pub async fn info(State(state): State<AppState>) -> HttpResult<(StatusCode, Json<InfoResponse>)> {
-    let user_overview = UserRepository::get_overview(&mut state.sql_db.pool().into()).await?;
+    let user_overview = state.user_service.get_overview().await?;
     let signup_code_overview =
         SignupCodeRepository::get_overview(&mut state.sql_db.pool().into()).await?;
 

--- a/pubky-homeserver/src/admin_server/routes/user_quota.rs
+++ b/pubky-homeserver/src/admin_server/routes/user_quota.rs
@@ -75,6 +75,8 @@ mod tests {
 
     use axum_test::TestServer;
 
+    use pubky_common::crypto::Keypair;
+
     use super::*;
     use crate::admin_server::app::create_app;
     use crate::data_directory::quota_config::BandwidthQuota;
@@ -120,17 +122,11 @@ mod tests {
     #[tokio::test]
     #[pubky_test_utils::test]
     async fn test_user_quota_crud() {
-        use crate::persistence::sql::user::UserRepository;
-        use pubky_common::crypto::Keypair;
-
         let context = AppContext::test().await;
         let server = create_test_server(&context);
-        let keypair = Keypair::random();
-        let pubkey = keypair.public_key();
+        let pubkey = Keypair::random().public_key();
 
-        UserRepository::create(&pubkey, &mut context.sql_db.pool().into())
-            .await
-            .unwrap();
+        context.user_service.create(&pubkey).await.unwrap();
 
         let url = format!("/users/{}/quota", pubkey.z32());
 
@@ -202,17 +198,11 @@ mod tests {
     #[tokio::test]
     #[pubky_test_utils::test]
     async fn test_get_effective_resolves_defaults() {
-        use crate::persistence::sql::user::UserRepository;
-        use pubky_common::crypto::Keypair;
-
         let context = AppContext::test().await;
         let server = create_test_server_with_defaults(&context);
-        let keypair = Keypair::random();
-        let pubkey = keypair.public_key();
+        let pubkey = Keypair::random().public_key();
 
-        UserRepository::create(&pubkey, &mut context.sql_db.pool().into())
-            .await
-            .unwrap();
+        context.user_service.create(&pubkey).await.unwrap();
 
         let url = format!("/users/{}/quota", pubkey.z32());
 
@@ -280,17 +270,11 @@ mod tests {
     #[tokio::test]
     #[pubky_test_utils::test]
     async fn test_user_quota_invalid_rate_rejected() {
-        use crate::persistence::sql::user::UserRepository;
-        use pubky_common::crypto::Keypair;
-
         let context = AppContext::test().await;
         let server = create_test_server(&context);
-        let keypair = Keypair::random();
-        let pubkey = keypair.public_key();
+        let pubkey = Keypair::random().public_key();
 
-        UserRepository::create(&pubkey, &mut context.sql_db.pool().into())
-            .await
-            .unwrap();
+        context.user_service.create(&pubkey).await.unwrap();
 
         let url = format!("/users/{}/quota", pubkey.z32());
 
@@ -328,17 +312,11 @@ mod tests {
     #[tokio::test]
     #[pubky_test_utils::test]
     async fn test_default_vs_unlimited_distinguishable() {
-        use crate::persistence::sql::user::UserRepository;
-        use pubky_common::crypto::Keypair;
-
         let context = AppContext::test().await;
         let server = create_test_server(&context);
-        let keypair = Keypair::random();
-        let pubkey = keypair.public_key();
+        let pubkey = Keypair::random().public_key();
 
-        UserRepository::create(&pubkey, &mut context.sql_db.pool().into())
-            .await
-            .unwrap();
+        context.user_service.create(&pubkey).await.unwrap();
 
         let url = format!("/users/{}/quota", pubkey.z32());
 
@@ -371,17 +349,11 @@ mod tests {
     #[tokio::test]
     #[pubky_test_utils::test]
     async fn test_patch_user_quota_merges() {
-        use crate::persistence::sql::user::UserRepository;
-        use pubky_common::crypto::Keypair;
-
         let context = AppContext::test().await;
         let server = create_test_server(&context);
-        let keypair = Keypair::random();
-        let pubkey = keypair.public_key();
+        let pubkey = Keypair::random().public_key();
 
-        UserRepository::create(&pubkey, &mut context.sql_db.pool().into())
-            .await
-            .unwrap();
+        context.user_service.create(&pubkey).await.unwrap();
 
         let url = format!("/users/{}/quota", pubkey.z32());
 
@@ -469,17 +441,11 @@ mod tests {
     #[tokio::test]
     #[pubky_test_utils::test]
     async fn test_patch_invalid_rate_rejected() {
-        use crate::persistence::sql::user::UserRepository;
-        use pubky_common::crypto::Keypair;
-
         let context = AppContext::test().await;
         let server = create_test_server(&context);
-        let keypair = Keypair::random();
-        let pubkey = keypair.public_key();
+        let pubkey = Keypair::random().public_key();
 
-        UserRepository::create(&pubkey, &mut context.sql_db.pool().into())
-            .await
-            .unwrap();
+        context.user_service.create(&pubkey).await.unwrap();
 
         let url = format!("/users/{}/quota", pubkey.z32());
         let patch = serde_json::json!({

--- a/pubky-homeserver/src/client_server/auth/cookie/persistence.rs
+++ b/pubky-homeserver/src/client_server/auth/cookie/persistence.rs
@@ -206,7 +206,8 @@ mod tests {
     use pubky_common::capabilities::Capability;
     use pubky_common::crypto::Keypair;
 
-    use crate::persistence::sql::{entities::user::UserRepository, SqlDb};
+    use crate::persistence::sql::SqlDb;
+    use crate::services::user_service::UserService;
 
     use super::*;
 
@@ -225,7 +226,8 @@ mod tests {
         let user_pubkey = Keypair::random().public_key();
 
         // Test create user
-        let user = UserRepository::create(&user_pubkey, &mut db.pool().into())
+        let user = UserService::new(db.clone())
+            .create(&user_pubkey)
             .await
             .unwrap();
 

--- a/pubky-homeserver/src/client_server/auth/cookie/service.rs
+++ b/pubky-homeserver/src/client_server/auth/cookie/service.rs
@@ -4,7 +4,8 @@ use pubky_common::{
     auth::AuthToken, capabilities::Capabilities, crypto::PublicKey, session::CookieSessionRecord,
 };
 
-use crate::persistence::sql::{signup_code::SignupCode, uexecutor, user::UserRepository, SqlDb};
+use crate::persistence::sql::{signup_code::SignupCode, uexecutor, SqlDb};
+use crate::services::user_service::UserService;
 use crate::shared::{HttpError, HttpResult};
 
 use super::persistence::{SessionEntity, SessionRepository, SessionSecret};
@@ -14,6 +15,7 @@ use crate::client_server::auth::{AuthRevocation, AuthSession, SignupService};
 #[derive(Clone, Debug)]
 pub(crate) struct CookieAuthService {
     sql_db: SqlDb,
+    user_service: UserService,
     verifier: CookieAuthVerifier,
     signup_service: SignupService,
 }
@@ -21,11 +23,13 @@ pub(crate) struct CookieAuthService {
 impl CookieAuthService {
     pub(crate) fn new(
         sql_db: SqlDb,
+        user_service: UserService,
         verifier: CookieAuthVerifier,
         signup_service: SignupService,
     ) -> Self {
         Self {
             sql_db,
+            user_service,
             verifier,
             signup_service,
         }
@@ -53,7 +57,9 @@ impl CookieAuthService {
     pub(crate) async fn signin(&self, body: &[u8]) -> HttpResult<CookieSessionCreation> {
         let token = self.verify(body)?;
         let public_key = token.public_key();
-        let user = UserRepository::get(public_key, &mut self.sql_db.pool().into())
+        let user = self
+            .user_service
+            .get(public_key)
             .await
             .map_err(|e| match e {
                 sqlx::Error::RowNotFound => HttpError::not_found(),

--- a/pubky-homeserver/src/client_server/auth/grant/persistence/grant.rs
+++ b/pubky-homeserver/src/client_server/auth/grant/persistence/grant.rs
@@ -280,7 +280,8 @@ mod tests {
         crypto::Keypair,
     };
 
-    use crate::persistence::sql::{entities::user::UserRepository, SqlDb};
+    use crate::persistence::sql::SqlDb;
+    use crate::services::user_service::UserService;
 
     fn make_new_grant(user_id: i32) -> NewGrant {
         let now = chrono::Utc::now().timestamp() as u64;
@@ -300,7 +301,8 @@ mod tests {
     async fn test_create_and_get_grant() {
         let db = SqlDb::test().await;
         let keypair = Keypair::random();
-        let user = UserRepository::create(&keypair.public_key(), &mut db.pool().into())
+        let user = UserService::new(db.clone())
+            .create(&keypair.public_key())
             .await
             .unwrap();
 
@@ -333,7 +335,8 @@ mod tests {
     #[pubky_test_utils::test]
     async fn test_create_grant_is_idempotent() {
         let db = SqlDb::test().await;
-        let user = UserRepository::create(&Keypair::random().public_key(), &mut db.pool().into())
+        let user = UserService::new(db.clone())
+            .create(&Keypair::random().public_key())
             .await
             .unwrap();
 
@@ -351,7 +354,8 @@ mod tests {
     #[pubky_test_utils::test]
     async fn test_revoke_and_is_revoked() {
         let db = SqlDb::test().await;
-        let user = UserRepository::create(&Keypair::random().public_key(), &mut db.pool().into())
+        let user = UserService::new(db.clone())
+            .create(&Keypair::random().public_key())
             .await
             .unwrap();
 
@@ -387,7 +391,8 @@ mod tests {
     #[pubky_test_utils::test]
     async fn test_list_active_for_user() {
         let db = SqlDb::test().await;
-        let user = UserRepository::create(&Keypair::random().public_key(), &mut db.pool().into())
+        let user = UserService::new(db.clone())
+            .create(&Keypair::random().public_key())
             .await
             .unwrap();
 
@@ -428,7 +433,8 @@ mod tests {
     #[pubky_test_utils::test]
     async fn test_list_active_for_user_empty() {
         let db = SqlDb::test().await;
-        let user = UserRepository::create(&Keypair::random().public_key(), &mut db.pool().into())
+        let user = UserService::new(db.clone())
+            .create(&Keypair::random().public_key())
             .await
             .unwrap();
 

--- a/pubky-homeserver/src/client_server/auth/grant/persistence/grant_session.rs
+++ b/pubky-homeserver/src/client_server/auth/grant/persistence/grant_session.rs
@@ -157,13 +157,12 @@ mod tests {
 
     use crate::client_server::auth::grant::crypto::session_token::SessionBearer;
     use crate::client_server::auth::grant::persistence::grant::{GrantRepository, NewGrant};
-    use crate::persistence::sql::{entities::user::UserRepository, SqlDb};
+    use crate::persistence::sql::SqlDb;
+    use crate::services::user_service::UserService;
 
     async fn setup_user_and_grant(db: &SqlDb) -> GrantId {
         let pubkey = Keypair::random().public_key();
-        let user = UserRepository::create(&pubkey, &mut db.pool().into())
-            .await
-            .unwrap();
+        let user = UserService::new(db.clone()).create(&pubkey).await.unwrap();
         let now = chrono::Utc::now().timestamp() as u64;
         let grant_id = GrantId::generate();
         let new_grant = NewGrant {
@@ -264,9 +263,7 @@ mod tests {
         let grant_b_id = GrantId::generate();
         let now = chrono::Utc::now().timestamp() as u64;
         let pubkey = Keypair::random().public_key();
-        let user = UserRepository::create(&pubkey, &mut db.pool().into())
-            .await
-            .unwrap();
+        let user = UserService::new(db.clone()).create(&pubkey).await.unwrap();
         let new_grant_b = NewGrant {
             id: grant_b_id.clone(),
             user_id: user.id,

--- a/pubky-homeserver/src/client_server/auth/grant/service.rs
+++ b/pubky-homeserver/src/client_server/auth/grant/service.rs
@@ -3,12 +3,8 @@
 //! Route handlers call `AuthService` methods instead of orchestrating
 //! verification, persistence, and minting steps directly.
 
-use crate::persistence::sql::{
-    signup_code::SignupCode,
-    uexecutor,
-    user::{UserEntity, UserRepository},
-    SqlDb, UnifiedExecutor,
-};
+use crate::persistence::sql::{signup_code::SignupCode, uexecutor, SqlDb, UnifiedExecutor};
+use crate::services::user_service::{UserEntity, UserService};
 use chrono::Utc;
 use pubky_common::{
     auth::grant::GrantClaims,
@@ -52,6 +48,7 @@ pub struct GrantAuthService {
     sql_db: SqlDb,
     homeserver_public_key: PublicKey,
     signup_service: SignupService,
+    user_service: UserService,
 }
 
 impl GrantAuthService {
@@ -60,11 +57,13 @@ impl GrantAuthService {
         sql_db: SqlDb,
         homeserver_public_key: PublicKey,
         signup_service: SignupService,
+        user_service: UserService,
     ) -> Self {
         Self {
             sql_db,
             homeserver_public_key,
             signup_service,
+            user_service,
         }
     }
 
@@ -333,7 +332,7 @@ impl GrantAuthService {
     /// Look up the user identified by the grant's `iss` claim. Returns error if not found.
     async fn find_user(&self, grant: &GrantClaims) -> Result<UserEntity, AuthServiceError> {
         map_not_found(
-            UserRepository::get(&grant.iss, &mut self.sql_db.pool().into()).await,
+            self.user_service.get(&grant.iss).await,
             AuthServiceError::UserNotFound,
         )
     }
@@ -496,15 +495,13 @@ mod tests {
         let db = SqlDb::test().await;
         let hs_kp = Keypair::random();
         let user_service = crate::services::user_service::UserService::new(db.clone());
-        let signup_service = SignupService::new(db.clone(), signup_mode, user_service);
-        GrantAuthService::new(db, hs_kp.public_key(), signup_service)
+        let signup_service = SignupService::new(db.clone(), signup_mode, user_service.clone());
+        GrantAuthService::new(db, hs_kp.public_key(), signup_service, user_service)
     }
 
     async fn create_test_user(service: &GrantAuthService) -> (Keypair, i32) {
         let kp = Keypair::random();
-        let user = UserRepository::create(&kp.public_key(), &mut service.sql_db.pool().into())
-            .await
-            .unwrap();
+        let user = service.user_service.create(&kp.public_key()).await.unwrap();
         (kp, user.id)
     }
 
@@ -692,7 +689,9 @@ mod tests {
             .signup_grant_account(&grant_jws, &pop_jws, None)
             .await
             .unwrap();
-        let user = UserRepository::get(&user_kp.public_key(), &mut service.sql_db.pool().into())
+        let user = service
+            .user_service
+            .get(&user_kp.public_key())
             .await
             .unwrap();
         assert_eq!(user.public_key, user_kp.public_key());

--- a/pubky-homeserver/src/client_server/auth/middleware/authentication.rs
+++ b/pubky-homeserver/src/client_server/auth/middleware/authentication.rs
@@ -59,7 +59,6 @@ mod tests {
     use crate::client_server::auth::cookie::persistence::SessionRepository;
     use crate::client_server::auth::AuthSession;
     use crate::client_server::middleware::request_tenant::RequestTenant;
-    use crate::persistence::sql::user::UserRepository;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
     use axum::response::IntoResponse;
@@ -100,7 +99,9 @@ mod tests {
     }
 
     async fn cookie_for_user(context: &AppContext, keypair: &Keypair) -> Cookie<'static> {
-        let user = UserRepository::create(&keypair.public_key(), &mut context.sql_db.pool().into())
+        let user = context
+            .user_service
+            .create(&keypair.public_key())
             .await
             .unwrap();
         let secret = SessionRepository::create(

--- a/pubky-homeserver/src/client_server/auth/signup_service.rs
+++ b/pubky-homeserver/src/client_server/auth/signup_service.rs
@@ -2,9 +2,7 @@
 
 use crate::persistence::sql::{
     signup_code::{SignupCode, SignupCodeRepository},
-    uexecutor,
-    user::UserRepository,
-    SqlDb,
+    uexecutor, SqlDb,
 };
 use crate::services::user_service::{UserEntity, UserService};
 use crate::shared::user_quota::UserQuota;
@@ -84,7 +82,7 @@ impl SignupService {
         signup_token: Option<&SignupCode>,
         tx: &mut sqlx::Transaction<'static, sqlx::Postgres>,
     ) -> Result<UserEntity, SignupServiceError> {
-        Self::ensure_user_not_exists(public_key, tx).await?;
+        self.ensure_user_not_exists(public_key, tx).await?;
         let quota = if self.signup_mode == SignupMode::TokenRequired {
             Self::validate_and_consume_signup_token(signup_token, public_key, tx).await?
         } else {
@@ -103,10 +101,15 @@ impl SignupService {
 
     /// Fails if a user row already exists for `public_key`.
     async fn ensure_user_not_exists(
+        &self,
         public_key: &PublicKey,
         tx: &mut sqlx::Transaction<'static, sqlx::Postgres>,
     ) -> Result<(), SignupServiceError> {
-        match UserRepository::get(public_key, uexecutor!(*tx)).await {
+        match self
+            .user_service
+            .get_in_tx(public_key, uexecutor!(*tx))
+            .await
+        {
             Ok(_) => Err(SignupServiceError::UserAlreadyExists),
             Err(sqlx::Error::RowNotFound) => Ok(()),
             Err(e) => Err(e.into()),

--- a/pubky-homeserver/src/client_server/auth/signup_service.rs
+++ b/pubky-homeserver/src/client_server/auth/signup_service.rs
@@ -3,10 +3,10 @@
 use crate::persistence::sql::{
     signup_code::{SignupCode, SignupCodeRepository},
     uexecutor,
-    user::{UserEntity, UserRepository},
+    user::UserRepository,
     SqlDb,
 };
-use crate::services::user_service::UserService;
+use crate::services::user_service::{UserEntity, UserService};
 use crate::shared::user_quota::UserQuota;
 use crate::SignupMode;
 use pubky_common::crypto::PublicKey;
@@ -90,8 +90,14 @@ impl SignupService {
         } else {
             UserQuota::default()
         };
-        let user = UserRepository::create(public_key, uexecutor!(*tx)).await?;
-        let user = UserRepository::set_quota(user.id, &quota, uexecutor!(*tx)).await?;
+        let user = self
+            .user_service
+            .create_in_tx(public_key, uexecutor!(*tx))
+            .await?;
+        let user = self
+            .user_service
+            .set_quota_in_tx(user.id, &quota, uexecutor!(*tx))
+            .await?;
         Ok(user)
     }
 

--- a/pubky-homeserver/src/client_server/auth/state.rs
+++ b/pubky-homeserver/src/client_server/auth/state.rs
@@ -32,9 +32,11 @@ impl AuthState {
                 context.sql_db.clone(),
                 context.keypair.public_key(),
                 signup_service.clone(),
+                context.user_service.clone(),
             ),
             cookie_auth_service: CookieAuthService::new(
                 context.sql_db.clone(),
+                context.user_service.clone(),
                 CookieAuthVerifier::default(),
                 signup_service,
             ),

--- a/pubky-homeserver/src/client_server/middleware/rate_limiter/bandwidth_rate_limit.rs
+++ b/pubky-homeserver/src/client_server/middleware/rate_limiter/bandwidth_rate_limit.rs
@@ -442,21 +442,18 @@ mod tests {
     #[tokio::test]
     #[pubky_test_utils::test]
     async fn test_authenticated_user_gets_per_user_rate_from_db() {
-        use crate::persistence::sql::user::UserRepository;
-
         let db = SqlDb::test().await;
         let user_service = UserService::new(db.clone());
 
         let keypair = Keypair::random();
         let pubkey = keypair.public_key();
-        let user = UserRepository::create(&pubkey, &mut db.pool().into())
-            .await
-            .unwrap();
+        let user = user_service.create(&pubkey).await.unwrap();
         let quota = UserQuota {
             rate_read: QuotaOverride::Value("100mb/s".parse().unwrap()),
             ..Default::default()
         };
-        UserRepository::set_quota(user.id, &quota, &mut db.pool().into())
+        user_service
+            .set_quota_in_tx(user.id, &quota, &mut db.pool().into())
             .await
             .unwrap();
 

--- a/pubky-homeserver/src/client_server/routes/events.rs
+++ b/pubky-homeserver/src/client_server/routes/events.rs
@@ -389,10 +389,14 @@ pub async fn feed_stream(
         .authorize(session, &state.auth_state)
         .await?;
 
-    let mut user_cursor_map =
-        resolve_user_cursors(&params.user_cursors, &state.events_service, &state.sql_db)
-            .await
-            .map_err(HttpError::from)?;
+    let mut user_cursor_map = resolve_user_cursors(
+        &params.user_cursors,
+        &state.events_service,
+        &state.sql_db,
+        &state.user_service,
+    )
+    .await
+    .map_err(HttpError::from)?;
 
     let mut total_sent: usize = 0;
     let stream = async_stream::stream! {
@@ -537,13 +541,13 @@ async fn resolve_user_cursors(
     user_cursors: &[(PublicKey, Option<String>)],
     events_service: &EventsService,
     sql_db: &SqlDb,
+    user_service: &crate::services::user_service::UserService,
 ) -> Result<HashMap<i32, Option<EventCursor>>, EventStreamError> {
-    use crate::persistence::sql::user::UserRepository;
-
     let mut user_cursor_map: HashMap<i32, Option<EventCursor>> = HashMap::new();
 
     for (user_pubkey, cursor_str_opt) in user_cursors {
-        let user_id = UserRepository::get_id(user_pubkey, &mut sql_db.pool().into())
+        let user_id = user_service
+            .get_id(user_pubkey)
             .await
             .map_err(|e| match e {
                 sqlx::Error::RowNotFound => EventStreamError::UserNotFound,

--- a/pubky-homeserver/src/client_server/routes/tenants/write.rs
+++ b/pubky-homeserver/src/client_server/routes/tenants/write.rs
@@ -137,8 +137,8 @@ async fn fail_if_size_hint_exceeds_quota<'a>(
 mod tests {
     use pubky_common::crypto::Keypair;
 
-    use crate::persistence::sql::user::UserRepository;
     use crate::persistence::sql::SqlDb;
+    use crate::services::user_service::UserService;
     use crate::shared::webdav::StoragePath;
 
     use super::*;
@@ -167,7 +167,9 @@ mod tests {
     async fn test_no_size_hint_always_ok() {
         let db = SqlDb::test().await;
         let pk = Keypair::random().public_key();
-        let user = UserRepository::create_with_quota_mb(&db, &pk, 1).await;
+        let user = UserService::new(db.clone())
+            .create_with_quota_mb(&pk, 1)
+            .await;
 
         // No size hint → always OK regardless of quota
         check_hint(&db, &user, None, "/test.txt", None)
@@ -180,7 +182,9 @@ mod tests {
     async fn test_small_hint_within_quota() {
         let db = SqlDb::test().await;
         let pk = Keypair::random().public_key();
-        let user = UserRepository::create_with_quota_mb(&db, &pk, 1).await;
+        let user = UserService::new(db.clone())
+            .create_with_quota_mb(&pk, 1)
+            .await;
 
         // 100 bytes + FILE_METADATA_SIZE is well within 1 MB
         check_hint(&db, &user, None, "/test.txt", Some(100))
@@ -193,7 +197,9 @@ mod tests {
     async fn test_hint_exceeds_quota() {
         let db = SqlDb::test().await;
         let pk = Keypair::random().public_key();
-        let user = UserRepository::create_with_quota_mb(&db, &pk, 1).await;
+        let user = UserService::new(db.clone())
+            .create_with_quota_mb(&pk, 1)
+            .await;
 
         // 1 MB content + FILE_METADATA_SIZE > 1 MB quota
         check_hint(&db, &user, None, "/test.txt", Some(1024 * 1024))
@@ -206,7 +212,9 @@ mod tests {
     async fn test_new_file_accounts_for_metadata_overhead() {
         let db = SqlDb::test().await;
         let pk = Keypair::random().public_key();
-        let user = UserRepository::create_with_quota_mb(&db, &pk, 1).await;
+        let user = UserService::new(db.clone())
+            .create_with_quota_mb(&pk, 1)
+            .await;
 
         let one_mb = 1024u64 * 1024;
         let max_content = one_mb - FILE_METADATA_SIZE;
@@ -228,9 +236,7 @@ mod tests {
         let db = SqlDb::test().await;
         // No system default → unlimited for Default users
         let pk = Keypair::random().public_key();
-        let user = UserRepository::create(&pk, &mut db.pool().into())
-            .await
-            .unwrap();
+        let user = UserService::new(db.clone()).create(&pk).await.unwrap();
 
         // Even a huge hint should pass with unlimited quota
         check_hint(&db, &user, None, "/test.txt", Some(10 * 1024 * 1024 * 1024))

--- a/pubky-homeserver/src/homeserver_app.rs
+++ b/pubky-homeserver/src/homeserver_app.rs
@@ -90,7 +90,7 @@ impl HomeserverApp {
         let republish_interval =
             Duration::from_secs(context.config_toml.pkdns.user_keys_republisher_interval);
         let user_keys_republisher_job = UserKeysRepublisherJob::start(
-            context.sql_db.clone(),
+            context.user_service.clone(),
             pkarr_builder,
             context.keypair.public_key(),
             republish_interval,

--- a/pubky-homeserver/src/persistence/files/events/events_repository.rs
+++ b/pubky-homeserver/src/persistence/files/events/events_repository.rs
@@ -401,8 +401,7 @@ mod tests {
     use pubky_common::crypto::{Hash, Keypair};
 
     use crate::{
-        persistence::sql::{user::UserRepository, SqlDb},
-        shared::webdav::StoragePath,
+        persistence::sql::SqlDb, services::user_service::UserService, shared::webdav::StoragePath,
     };
 
     use super::*;
@@ -416,12 +415,11 @@ mod tests {
     #[pubky_test_utils::test]
     async fn test_create_list_event() {
         let db = SqlDb::test().await;
+        let user_service = UserService::new(db.clone());
         let user_pubkey = Keypair::random().public_key();
 
         // Create user
-        let user = UserRepository::create(&user_pubkey, &mut db.pool().into())
-            .await
-            .unwrap();
+        let user = user_service.create(&user_pubkey).await.unwrap();
 
         // Create events
         for _ in 0..10 {
@@ -461,10 +459,9 @@ mod tests {
     #[pubky_test_utils::test]
     async fn test_get_by_cursor_public_visibility_excludes_private() {
         let db = SqlDb::test().await;
+        let user_service = UserService::new(db.clone());
         let user_pubkey = Keypair::random().public_key();
-        let user = UserRepository::create(&user_pubkey, &mut db.pool().into())
-            .await
-            .unwrap();
+        let user = user_service.create(&user_pubkey).await.unwrap();
 
         // Interleave public, private, and look-alike roots that must NOT match
         // the `/pub/` prefix (`/public/...` and `/pub` without a trailing slash).
@@ -538,12 +535,11 @@ mod tests {
     #[pubky_test_utils::test]
     async fn test_transform_legacy_cursor() {
         let db = SqlDb::test().await;
+        let user_service = UserService::new(db.clone());
         let user_pubkey = Keypair::random().public_key();
 
         // Create user
-        let user = UserRepository::create(&user_pubkey, &mut db.pool().into())
-            .await
-            .unwrap();
+        let user = user_service.create(&user_pubkey).await.unwrap();
 
         let mut timestamp_events = Vec::new();
         // Create events with specific timestamps
@@ -579,12 +575,11 @@ mod tests {
     #[pubky_test_utils::test]
     async fn test_parse_cursor_backwards_compatibility() {
         let db = SqlDb::test().await;
+        let user_service = UserService::new(db.clone());
         let user_pubkey = Keypair::random().public_key();
 
         // Create user
-        let user = UserRepository::create(&user_pubkey, &mut db.pool().into())
-            .await
-            .unwrap();
+        let user = user_service.create(&user_pubkey).await.unwrap();
 
         // Create test events with specific timestamps
         let mut events = Vec::new();
@@ -666,10 +661,9 @@ mod tests {
     #[pubky_test_utils::test]
     async fn test_get_by_user_cursors_multi_path_union_and_boundaries() {
         let db = SqlDb::test().await;
+        let user_service = UserService::new(db.clone());
         let user_pubkey = Keypair::random().public_key();
-        let user = UserRepository::create(&user_pubkey, &mut db.pool().into())
-            .await
-            .unwrap();
+        let user = user_service.create(&user_pubkey).await.unwrap();
 
         // ids 1..=6
         let paths = [
@@ -740,10 +734,9 @@ mod tests {
     #[pubky_test_utils::test]
     async fn test_get_by_user_cursors_escapes_like_metacharacters() {
         let db = SqlDb::test().await;
+        let user_service = UserService::new(db.clone());
         let user_pubkey = Keypair::random().public_key();
-        let user = UserRepository::create(&user_pubkey, &mut db.pool().into())
-            .await
-            .unwrap();
+        let user = user_service.create(&user_pubkey).await.unwrap();
 
         for p in ["/priv/a_b/x", "/priv/axb/y", "/priv/a%/m", "/priv/apct/n"] {
             let path = EntryPath::new(user_pubkey.clone(), StoragePath::new(p).unwrap());
@@ -790,14 +783,11 @@ mod tests {
     #[pubky_test_utils::test]
     async fn test_get_by_user_cursors_multi_user_public_filter_excludes_private() {
         let db = SqlDb::test().await;
+        let user_service = UserService::new(db.clone());
         let ka = Keypair::random().public_key();
         let kb = Keypair::random().public_key();
-        let ua = UserRepository::create(&ka, &mut db.pool().into())
-            .await
-            .unwrap();
-        let ub = UserRepository::create(&kb, &mut db.pool().into())
-            .await
-            .unwrap();
+        let ua = user_service.create(&ka).await.unwrap();
+        let ub = user_service.create(&kb).await.unwrap();
 
         for (k, uid) in [(&ka, ua.id), (&kb, ub.id)] {
             for p in ["/pub/x", "/priv/secret"] {

--- a/pubky-homeserver/src/persistence/files/events/events_service.rs
+++ b/pubky-homeserver/src/persistence/files/events/events_service.rs
@@ -342,7 +342,8 @@ fn accept_live_event(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::persistence::sql::{user::UserRepository, SqlDb};
+    use crate::persistence::sql::SqlDb;
+    use crate::services::user_service::UserService;
     use crate::shared::webdav::StoragePath;
     use pubky_common::crypto::Keypair;
 
@@ -351,11 +352,10 @@ mod tests {
     async fn test_events_service_create_and_broadcast() {
         let db = SqlDb::test().await;
         let events_service = EventsService::new(100);
+        let user_service = UserService::new(db.clone());
 
         let user_pubkey = Keypair::random().public_key();
-        let user = UserRepository::create(&user_pubkey, &mut db.pool().into())
-            .await
-            .unwrap();
+        let user = user_service.create(&user_pubkey).await.unwrap();
 
         let path = EntryPath::new(user_pubkey.clone(), StoragePath::new("/test.txt").unwrap());
 
@@ -392,11 +392,10 @@ mod tests {
     async fn test_events_service_get_public_by_cursor() {
         let db = SqlDb::test().await;
         let events_service = EventsService::new(100);
+        let user_service = UserService::new(db.clone());
 
         let user_pubkey = Keypair::random().public_key();
-        let user = UserRepository::create(&user_pubkey, &mut db.pool().into())
-            .await
-            .unwrap();
+        let user = user_service.create(&user_pubkey).await.unwrap();
 
         // Interleave public and private events: ids 1=/pub/a, 2=/priv/x,
         // 3=/pub/b, 4=/priv/y, 5=/pub/c.
@@ -448,11 +447,10 @@ mod tests {
     async fn test_events_service_get_all_events_includes_private() {
         let db = SqlDb::test().await;
         let events_service = EventsService::new(100);
+        let user_service = UserService::new(db.clone());
 
         let user_pubkey = Keypair::random().public_key();
-        let user = UserRepository::create(&user_pubkey, &mut db.pool().into())
-            .await
-            .unwrap();
+        let user = user_service.create(&user_pubkey).await.unwrap();
 
         // Same interleaving as the public test: ids 1=/pub/a, 2=/priv/x,
         // 3=/pub/b, 4=/priv/y, 5=/pub/c.

--- a/pubky-homeserver/src/persistence/files/file/file_service.rs
+++ b/pubky-homeserver/src/persistence/files/file/file_service.rs
@@ -47,6 +47,7 @@ impl FileService {
         let opendal_service = OpendalService::new_from_config(
             &config.storage,
             data_directory,
+            db.clone(),
             events_service,
             user_service,
         )?;
@@ -140,10 +141,7 @@ impl FileService {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        persistence::sql::user::UserRepository, services::user_service::FILE_METADATA_SIZE,
-        shared::webdav::StoragePath,
-    };
+    use crate::{services::user_service::FILE_METADATA_SIZE, shared::webdav::StoragePath};
     use futures_lite::StreamExt;
 
     use super::*;
@@ -154,11 +152,10 @@ mod tests {
         let context = AppContext::test().await;
         let file_service = FileService::new_from_context(&context).unwrap();
         let db = context.sql_db.clone();
+        let user_service = context.user_service.clone();
         let pubkey = pubky_common::crypto::Keypair::random().public_key();
 
-        let user = UserRepository::create(&pubkey, &mut db.pool().into())
-            .await
-            .unwrap();
+        let user = user_service.create(&pubkey).await.unwrap();
 
         // User should not have any data usage yet
         assert_eq!(user.used_bytes, 0);
@@ -178,9 +175,7 @@ mod tests {
         let stream = futures_util::stream::iter(chunks);
 
         file_service.write_stream(&path, stream).await.unwrap();
-        let user = UserRepository::get(&pubkey, &mut db.pool().into())
-            .await
-            .unwrap();
+        let user = user_service.get(&pubkey).await.unwrap();
         assert_eq!(
             user.used_bytes,
             test_data.len() as u64 + FILE_METADATA_SIZE,
@@ -207,9 +202,7 @@ mod tests {
         file_service.delete(&path).await.unwrap();
         let result = file_service.get_stream(&path).await;
         assert!(result.is_err(), "Should error for deleted file");
-        let user = UserRepository::get(&pubkey, &mut db.pool().into())
-            .await
-            .unwrap();
+        let user = user_service.get(&pubkey).await.unwrap();
         assert_eq!(
             user.used_bytes, 0,
             "Data usage should be 0 after deleting file"
@@ -223,9 +216,7 @@ mod tests {
         let chunks = vec![Ok(Bytes::from(test_data.as_slice()))];
         let stream = futures_util::stream::iter(chunks);
         file_service.write_stream(&path, stream).await.unwrap();
-        let user = UserRepository::get(&pubkey, &mut db.pool().into())
-            .await
-            .unwrap();
+        let user = user_service.get(&pubkey).await.unwrap();
         assert_eq!(
             user.used_bytes,
             test_data.len() as u64 + FILE_METADATA_SIZE,
@@ -253,9 +244,7 @@ mod tests {
         file_service.delete(&path).await.unwrap();
         let result = file_service.get_stream(&path).await;
         assert!(result.is_err(), "Should error for deleted file");
-        let user = UserRepository::get(&pubkey, &mut db.pool().into())
-            .await
-            .unwrap();
+        let user = user_service.get(&pubkey).await.unwrap();
         assert_eq!(
             user.used_bytes, 0,
             "Data usage should be 0 after deleting file"
@@ -268,11 +257,10 @@ mod tests {
         let context = AppContext::test().await;
         let file_service = FileService::new_from_context(&context).unwrap();
         let db = context.sql_db.clone();
+        let user_service = context.user_service.clone();
 
         let pubkey = pubky_common::crypto::Keypair::random().public_key();
-        UserRepository::create(&pubkey, &mut db.pool().into())
-            .await
-            .unwrap();
+        user_service.create(&pubkey).await.unwrap();
 
         let test_data = b"Hello, world!";
         let buffer = Buffer::from(test_data.as_slice());
@@ -295,25 +283,22 @@ mod tests {
         let context = AppContext::test().await;
         let file_service = FileService::new_from_context(&context).unwrap();
         let db = context.sql_db.clone();
+        let user_service = context.user_service.clone();
 
         let pubkey = pubky_common::crypto::Keypair::random().public_key();
-        UserRepository::create_with_quota_mb(&db, &pubkey, 1).await;
+        user_service.create_with_quota_mb(&pubkey, 1).await;
 
         let path = EntryPath::new(pubkey.clone(), StoragePath::new("/test_file.txt").unwrap());
         let test_data = vec![1u8; 1024];
         let buffer = Buffer::from(test_data.clone());
 
         file_service.write(&path, buffer).await.unwrap();
-        let user = UserRepository::get(&pubkey, &mut db.pool().into())
-            .await
-            .unwrap();
+        let user = user_service.get(&pubkey).await.unwrap();
         assert_eq!(user.used_bytes, test_data.len() as u64 + FILE_METADATA_SIZE);
 
         // Delete the file and check if the data usage is updated correctly.
         file_service.delete(&path).await.unwrap();
-        let user = UserRepository::get(&pubkey, &mut db.pool().into())
-            .await
-            .unwrap();
+        let user = user_service.get(&pubkey).await.unwrap();
         assert_eq!(user.used_bytes, 0);
     }
 
@@ -324,9 +309,10 @@ mod tests {
         let context = AppContext::test().await;
         let file_service = FileService::new_from_context(&context).unwrap();
         let db = context.sql_db.clone();
+        let user_service = context.user_service.clone();
 
         let pubkey = pubky_common::crypto::Keypair::random().public_key();
-        UserRepository::create_with_quota_mb(&db, &pubkey, 1).await;
+        user_service.create_with_quota_mb(&pubkey, 1).await;
 
         let path = EntryPath::new(pubkey.clone(), StoragePath::new("/test_file.txt").unwrap());
         let test_data = vec![1u8; 1024];
@@ -341,10 +327,7 @@ mod tests {
         file_service.write(&path, buffer2).await.unwrap();
 
         assert_eq!(
-            UserRepository::get(&pubkey, &mut db.pool().into())
-                .await
-                .unwrap()
-                .used_bytes,
+            user_service.get(&pubkey).await.unwrap().used_bytes,
             test_data2.len() as u64 + FILE_METADATA_SIZE
         );
     }
@@ -355,11 +338,10 @@ mod tests {
         let context = AppContext::test().await;
         let file_service = FileService::new_from_context(&context).unwrap();
         let db = context.sql_db.clone();
+        let user_service = context.user_service.clone();
 
         let pubkey = pubky_common::crypto::Keypair::random().public_key();
-        UserRepository::create(&pubkey, &mut db.pool().into())
-            .await
-            .unwrap();
+        user_service.create(&pubkey).await.unwrap();
 
         let exact_path = EntryPath::new(pubkey.clone(), StoragePath::new("/pub/app/foo").unwrap());
         let descendant_path = EntryPath::new(
@@ -393,11 +375,10 @@ mod tests {
         let context = AppContext::test().await;
         let file_service = FileService::new_from_context(&context).unwrap();
         let db = context.sql_db.clone();
+        let user_service = context.user_service.clone();
 
         let pubkey = pubky_common::crypto::Keypair::random().public_key();
-        UserRepository::create(&pubkey, &mut db.pool().into())
-            .await
-            .unwrap();
+        user_service.create(&pubkey).await.unwrap();
 
         let exact_path = EntryPath::new(pubkey.clone(), StoragePath::new("/pub/app/foo").unwrap());
         let descendant_path =
@@ -430,9 +411,10 @@ mod tests {
         let context = AppContext::test().await;
         let file_service = FileService::new_from_context(&context).unwrap();
         let db = context.sql_db.clone();
+        let user_service = context.user_service.clone();
 
         let pubkey = pubky_common::crypto::Keypair::random().public_key();
-        UserRepository::create_with_quota_mb(&db, &pubkey, 1).await;
+        user_service.create_with_quota_mb(&pubkey, 1).await;
 
         let path = EntryPath::new(pubkey.clone(), StoragePath::new("/test_file.txt").unwrap());
         let test_data = vec![1u8; 1024 * 1024 - FILE_METADATA_SIZE as usize];
@@ -441,10 +423,7 @@ mod tests {
         file_service.write(&path, buffer).await.unwrap();
 
         assert_eq!(
-            UserRepository::get(&pubkey, &mut db.pool().into())
-                .await
-                .unwrap()
-                .used_bytes,
+            user_service.get(&pubkey).await.unwrap().used_bytes,
             test_data.len() as u64 + FILE_METADATA_SIZE
         );
     }
@@ -455,9 +434,10 @@ mod tests {
         let context = AppContext::test().await;
         let file_service = FileService::new_from_context(&context).unwrap();
         let db = context.sql_db.clone();
+        let user_service = context.user_service.clone();
 
         let pubkey = pubky_common::crypto::Keypair::random().public_key();
-        UserRepository::create_with_quota_mb(&db, &pubkey, 1).await;
+        user_service.create_with_quota_mb(&pubkey, 1).await;
 
         let path = EntryPath::new(pubkey.clone(), StoragePath::new("/test_file.txt").unwrap());
         let test_data = vec![1u8; 1024 * 1024 + 1];
@@ -471,13 +451,7 @@ mod tests {
             }
         }
 
-        assert_eq!(
-            UserRepository::get(&pubkey, &mut db.pool().into())
-                .await
-                .unwrap()
-                .used_bytes,
-            0
-        );
+        assert_eq!(user_service.get(&pubkey).await.unwrap().used_bytes, 0);
     }
 
     /// Override and existing entry and check if the data usage is updated correctly.
@@ -487,9 +461,10 @@ mod tests {
         let context = AppContext::test().await;
         let file_service = FileService::new_from_context(&context).unwrap();
         let db = context.sql_db.clone();
+        let user_service = context.user_service.clone();
 
         let pubkey = pubky_common::crypto::Keypair::random().public_key();
-        UserRepository::create_with_quota_mb(&db, &pubkey, 1).await;
+        user_service.create_with_quota_mb(&pubkey, 1).await;
 
         let path = EntryPath::new(pubkey.clone(), StoragePath::new("/test_file.txt").unwrap());
         let test_data = vec![1u8; 1024];
@@ -510,10 +485,7 @@ mod tests {
         }
 
         assert_eq!(
-            UserRepository::get(&pubkey, &mut db.pool().into())
-                .await
-                .unwrap()
-                .used_bytes,
+            user_service.get(&pubkey).await.unwrap().used_bytes,
             test_data.len() as u64 + FILE_METADATA_SIZE
         );
     }

--- a/pubky-homeserver/src/persistence/files/file/file_service.rs
+++ b/pubky-homeserver/src/persistence/files/file/file_service.rs
@@ -151,7 +151,6 @@ mod tests {
     async fn test_write_get_delete_db_and_opendal() {
         let context = AppContext::test().await;
         let file_service = FileService::new_from_context(&context).unwrap();
-        let db = context.sql_db.clone();
         let user_service = context.user_service.clone();
         let pubkey = pubky_common::crypto::Keypair::random().public_key();
 
@@ -256,7 +255,6 @@ mod tests {
     async fn test_write_get_basic() {
         let context = AppContext::test().await;
         let file_service = FileService::new_from_context(&context).unwrap();
-        let db = context.sql_db.clone();
         let user_service = context.user_service.clone();
 
         let pubkey = pubky_common::crypto::Keypair::random().public_key();
@@ -282,7 +280,6 @@ mod tests {
     async fn test_data_usage_update_basic() {
         let context = AppContext::test().await;
         let file_service = FileService::new_from_context(&context).unwrap();
-        let db = context.sql_db.clone();
         let user_service = context.user_service.clone();
 
         let pubkey = pubky_common::crypto::Keypair::random().public_key();
@@ -308,7 +305,6 @@ mod tests {
     async fn test_data_usage_override_existing_entry() {
         let context = AppContext::test().await;
         let file_service = FileService::new_from_context(&context).unwrap();
-        let db = context.sql_db.clone();
         let user_service = context.user_service.clone();
 
         let pubkey = pubky_common::crypto::Keypair::random().public_key();
@@ -410,7 +406,6 @@ mod tests {
     async fn test_data_usage_exactly_to_quota() {
         let context = AppContext::test().await;
         let file_service = FileService::new_from_context(&context).unwrap();
-        let db = context.sql_db.clone();
         let user_service = context.user_service.clone();
 
         let pubkey = pubky_common::crypto::Keypair::random().public_key();
@@ -433,7 +428,6 @@ mod tests {
     async fn test_data_usage_above_quota() {
         let context = AppContext::test().await;
         let file_service = FileService::new_from_context(&context).unwrap();
-        let db = context.sql_db.clone();
         let user_service = context.user_service.clone();
 
         let pubkey = pubky_common::crypto::Keypair::random().public_key();
@@ -460,7 +454,6 @@ mod tests {
     async fn test_data_usage_override_existing_above_quota() {
         let context = AppContext::test().await;
         let file_service = FileService::new_from_context(&context).unwrap();
-        let db = context.sql_db.clone();
         let user_service = context.user_service.clone();
 
         let pubkey = pubky_common::crypto::Keypair::random().public_key();

--- a/pubky-homeserver/src/persistence/files/opendal/opendal_service.rs
+++ b/pubky-homeserver/src/persistence/files/opendal/opendal_service.rs
@@ -3,9 +3,12 @@ use std::path::Path;
 #[cfg(test)]
 use crate::AppContext;
 use crate::{
-    persistence::files::{
-        events::EventsService, write_finalization_layer::WriteFinalizationLayer,
-        write_path_layer::WritePathLayer,
+    persistence::{
+        files::{
+            events::EventsService, write_finalization_layer::WriteFinalizationLayer,
+            write_path_layer::WritePathLayer,
+        },
+        sql::SqlDb,
     },
     services::user_service::UserService,
     shared::webdav::EntryPath,
@@ -28,6 +31,7 @@ use super::super::{FileIoError, FileMetadata, FileMetadataBuilder, FileStream, W
 pub fn build_storage_operators(
     storage_config: &StorageToml,
     data_directory: &Path,
+    sql_db: SqlDb,
     events_service: EventsService,
     user_service: UserService,
 ) -> Result<(Operator, Operator), FileIoError> {
@@ -66,6 +70,7 @@ pub fn build_storage_operators(
     // needs its own finalization layer.
     let admin_operator = backend_operator.clone().layer(WriteFinalizationLayer::new(
         user_service.clone(),
+        sql_db.clone(),
         events_service.clone(),
         storage_config.default_quota_mb,
         false,
@@ -73,6 +78,7 @@ pub fn build_storage_operators(
     let operator = backend_operator
         .layer(WriteFinalizationLayer::new(
             user_service.clone(),
+            sql_db,
             events_service,
             storage_config.default_quota_mb,
             true,
@@ -89,6 +95,7 @@ pub fn build_storage_operators_from_context(
     build_storage_operators(
         &context.config_toml.storage,
         context.data_dir.path(),
+        context.sql_db.clone(),
         context.events_service.clone(),
         context.user_service.clone(),
     )
@@ -114,11 +121,17 @@ impl OpendalService {
     pub fn new_from_config(
         storage_config: &StorageToml,
         data_directory: &Path,
+        sql_db: SqlDb,
         events_service: EventsService,
         user_service: UserService,
     ) -> Result<Self, FileIoError> {
-        let (operator, admin_operator) =
-            build_storage_operators(storage_config, data_directory, events_service, user_service)?;
+        let (operator, admin_operator) = build_storage_operators(
+            storage_config,
+            data_directory,
+            sql_db,
+            events_service,
+            user_service,
+        )?;
         Ok(Self {
             operator,
             admin_operator,
@@ -248,7 +261,6 @@ impl OpendalService {
 mod tests {
     use super::*;
     use crate::persistence::files::opendal::opendal_test_operators::OpendalTestOperators;
-    use crate::persistence::sql::user::UserRepository;
     use crate::shared::webdav::StoragePath;
 
     #[tokio::test]
@@ -260,9 +272,7 @@ mod tests {
         let service =
             OpendalService::new(&context).expect("Failed to create OpenDAL service for testing");
         let pubky = pubky_common::crypto::Keypair::random().public_key();
-        UserRepository::create(&pubky, &mut context.sql_db.pool().into())
-            .await
-            .unwrap();
+        context.user_service.create(&pubky).await.unwrap();
         let path = EntryPath::new(pubky, StoragePath::new("/test.txt").unwrap());
         assert!(!service.exists(&path).await.unwrap());
     }
@@ -276,7 +286,7 @@ mod tests {
         let service =
             OpendalService::new(&context).expect("Failed to create OpenDAL service for testing");
         let pubky = pubky_common::crypto::Keypair::random().public_key();
-        UserRepository::create_with_quota_mb(&context.sql_db, &pubky, 1).await;
+        context.user_service.create_with_quota_mb(&pubky, 1).await;
         let path = EntryPath::new(pubky, StoragePath::new("/test.txt").unwrap());
         let write_result = service.write(&path, vec![42u8; 1024 * 1024]).await;
         assert!(write_result.is_err());

--- a/pubky-homeserver/src/persistence/files/write_finalization_layer/delete.rs
+++ b/pubky-homeserver/src/persistence/files/write_finalization_layer/delete.rs
@@ -139,7 +139,7 @@ impl<R: oio::Delete> oio::Delete for WriteFinalizationDeleter<R> {
 
 impl Finalizer {
     async fn finalize_delete(&self, entry_path: &EntryPath) -> Result<DeleteOutcome> {
-        let mut tx = self.user_service.pool().begin().await.map_err(|error| {
+        let mut tx = self.sql_db.pool().begin().await.map_err(|error| {
             unexpected("Failed to begin delete finalization transaction", error)
         })?;
 
@@ -252,7 +252,7 @@ impl Finalizer {
             .saturating_add(FILE_METADATA_SIZE);
         user.used_bytes = user.used_bytes.saturating_sub(bytes_delta);
         self.user_service
-            .update(&user, executor)
+            .update_in_tx(&user, executor)
             .await
             .map_err(|error| {
                 unexpected(

--- a/pubky-homeserver/src/persistence/files/write_finalization_layer/layer.rs
+++ b/pubky-homeserver/src/persistence/files/write_finalization_layer/layer.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::persistence::files::{events::EventsService, layer_domain_error::LayerDomainError};
-use crate::persistence::sql::{entry::EntryRepository, UnifiedExecutor};
+use crate::persistence::sql::{entry::EntryRepository, SqlDb, UnifiedExecutor};
 use crate::services::user_service::UserService;
 use crate::shared::webdav::EntryPath;
 use opendal::raw::*;
@@ -47,6 +47,7 @@ impl CollisionPolicy {
 #[derive(Debug)]
 pub(super) struct Finalizer {
     pub(super) user_service: UserService,
+    pub(super) sql_db: SqlDb,
     pub(super) events_service: EventsService,
     pub(super) default_storage_mb: Option<u64>,
     pub(super) collision_policy: CollisionPolicy,
@@ -55,6 +56,7 @@ pub(super) struct Finalizer {
 impl WriteFinalizationLayer {
     pub fn new(
         user_service: UserService,
+        sql_db: SqlDb,
         events_service: EventsService,
         default_storage_mb: Option<u64>,
         enforce_path_collisions: bool,
@@ -62,6 +64,7 @@ impl WriteFinalizationLayer {
         Self {
             finalizer: Arc::new(Finalizer::new(
                 user_service,
+                sql_db,
                 events_service,
                 default_storage_mb,
                 CollisionPolicy::from_enforcement(enforce_path_collisions),
@@ -195,12 +198,14 @@ impl<A: Access> LayeredAccess for WriteFinalizationAccessor<A> {
 impl Finalizer {
     fn new(
         user_service: UserService,
+        sql_db: SqlDb,
         events_service: EventsService,
         default_storage_mb: Option<u64>,
         collision_policy: CollisionPolicy,
     ) -> Self {
         Self {
             user_service,
+            sql_db,
             events_service,
             default_storage_mb,
             collision_policy,
@@ -212,11 +217,11 @@ impl Finalizer {
             return Ok(());
         }
 
-        check_no_path_collision(entry_path, &mut self.user_service.pool().into()).await
+        check_no_path_collision(entry_path, &mut self.sql_db.pool().into()).await
     }
 
     pub(super) fn notify_event(&self) {
-        let pool = self.user_service.pool().clone();
+        let pool = self.sql_db.pool().clone();
         drop(tokio::spawn(async move {
             EventsService::notify_event(&pool).await;
         }));
@@ -231,13 +236,14 @@ pub(super) mod test_support {
         events::{EventEntity, EventRepository, EventVisibility},
         opendal::opendal_test_operators::get_memory_operator,
     };
-    use crate::persistence::sql::{user::UserRepository, SqlDb};
+    use crate::persistence::sql::SqlDb;
 
     use super::*;
 
     pub(in super::super) fn test_finalizer(db: &SqlDb) -> Finalizer {
         Finalizer::new(
             UserService::new(db.clone()),
+            db.clone(),
             EventsService::new(100),
             None,
             CollisionPolicy::Enforce,
@@ -247,17 +253,21 @@ pub(super) mod test_support {
     pub(in super::super) fn test_operator(db: &SqlDb) -> opendal::Operator {
         get_memory_operator().layer(WriteFinalizationLayer::new(
             UserService::new(db.clone()),
+            db.clone(),
             EventsService::new(100),
             None,
             true,
         ))
     }
 
+    pub(in super::super) fn test_user_service(db: &SqlDb) -> UserService {
+        UserService::new(db.clone())
+    }
+
     pub(in super::super) async fn create_user(db: &SqlDb) -> pubky_common::crypto::PublicKey {
         let pubkey = Keypair::random().public_key();
-        UserRepository::create(&pubkey, &mut db.pool().into())
-            .await
-            .unwrap();
+        let user_service = test_user_service(db);
+        user_service.create(&pubkey).await.unwrap();
         pubkey
     }
 
@@ -265,10 +275,8 @@ pub(super) mod test_support {
         db: &SqlDb,
         pubkey: &pubky_common::crypto::PublicKey,
     ) -> u64 {
-        UserRepository::get(pubkey, &mut db.pool().into())
-            .await
-            .unwrap()
-            .used_bytes
+        let user_service = test_user_service(db);
+        user_service.get(pubkey).await.unwrap().used_bytes
     }
 
     pub(in super::super) async fn all_events(db: &SqlDb) -> Vec<EventEntity> {

--- a/pubky-homeserver/src/persistence/files/write_finalization_layer/write.rs
+++ b/pubky-homeserver/src/persistence/files/write_finalization_layer/write.rs
@@ -104,7 +104,7 @@ impl Finalizer {
         file_metadata: &FileMetadata,
     ) -> Result<opendal::Metadata> {
         let mut tx =
-            self.user_service.pool().begin().await.map_err(|error| {
+            self.sql_db.pool().begin().await.map_err(|error| {
                 unexpected("Failed to begin write finalization transaction", error)
             })?;
 
@@ -248,7 +248,7 @@ impl Finalizer {
             })?;
         user.used_bytes = user.used_bytes.saturating_add_signed(bytes_delta);
         self.user_service
-            .update(&user, executor)
+            .update_in_tx(&user, executor)
             .await
             .map_err(|error| {
                 unexpected(

--- a/pubky-homeserver/src/persistence/files/write_path_layer.rs
+++ b/pubky-homeserver/src/persistence/files/write_path_layer.rs
@@ -183,7 +183,6 @@ mod tests {
     use crate::persistence::files::{
         events::EventsService, write_finalization_layer::WriteFinalizationLayer,
     };
-    use crate::persistence::sql::user::UserRepository;
     use crate::persistence::sql::SqlDb;
     use crate::services::user_service::UserService;
     use crate::shared::user_quota::UserQuota;
@@ -201,14 +200,14 @@ mod tests {
         allowed_write_paths: Option<Vec<StoragePath>>,
     ) -> pubky_common::crypto::PublicKey {
         let pubkey = pubky_common::crypto::Keypair::random().public_key();
-        let user = UserRepository::create(&pubkey, &mut db.pool().into())
-            .await
-            .unwrap();
+        let user_service = UserService::new(db.clone());
+        let user = user_service.create(&pubkey).await.unwrap();
         let config = UserQuota {
             allowed_write_paths,
             ..Default::default()
         };
-        UserRepository::set_quota(user.id, &config, &mut db.pool().into())
+        user_service
+            .set_quota_in_tx(user.id, &config, &mut db.pool().into())
             .await
             .unwrap();
         pubkey
@@ -228,8 +227,13 @@ mod tests {
 
     fn build_test_operator_with(db: &SqlDb, base: opendal::Operator) -> opendal::Operator {
         let user_service = UserService::new(db.clone());
-        let write_finalization_layer =
-            WriteFinalizationLayer::new(user_service.clone(), EventsService::new(100), None, true);
+        let write_finalization_layer = WriteFinalizationLayer::new(
+            user_service.clone(),
+            db.clone(),
+            EventsService::new(100),
+            None,
+            true,
+        );
         let write_path_layer = WritePathLayer::new(user_service);
         base.layer(write_finalization_layer).layer(write_path_layer)
     }
@@ -309,9 +313,8 @@ mod tests {
 
         // Create with no restrictions, write a file, then restrict.
         let pubkey = pubky_common::crypto::Keypair::random().public_key();
-        let user = UserRepository::create(&pubkey, &mut db.pool().into())
-            .await
-            .unwrap();
+        let user_service = UserService::new(db.clone());
+        let user = user_service.create(&pubkey).await.unwrap();
         let raw = pubkey.z32();
 
         operator
@@ -324,7 +327,8 @@ mod tests {
             allowed_write_paths: Some(vec![wdp("/pub/tokens/")]),
             ..Default::default()
         };
-        UserRepository::set_quota(user.id, &config, &mut db.pool().into())
+        user_service
+            .set_quota_in_tx(user.id, &config, &mut db.pool().into())
             .await
             .unwrap();
         // Invalidate cache by creating a fresh operator.
@@ -391,9 +395,8 @@ mod tests {
 
         // Create unrestricted, write a file, then restrict.
         let pubkey = pubky_common::crypto::Keypair::random().public_key();
-        let user = UserRepository::create(&pubkey, &mut db.pool().into())
-            .await
-            .unwrap();
+        let user_service = UserService::new(db.clone());
+        let user = user_service.create(&pubkey).await.unwrap();
         let raw = pubkey.z32();
 
         let operator = build_test_operator(&db);
@@ -406,7 +409,8 @@ mod tests {
             allowed_write_paths: Some(vec![wdp("/pub/tokens/")]),
             ..Default::default()
         };
-        UserRepository::set_quota(user.id, &config, &mut db.pool().into())
+        user_service
+            .set_quota_in_tx(user.id, &config, &mut db.pool().into())
             .await
             .unwrap();
         let operator = build_test_operator(&db);

--- a/pubky-homeserver/src/persistence/sql/entities/entry/repository.rs
+++ b/pubky-homeserver/src/persistence/sql/entities/entry/repository.rs
@@ -450,7 +450,8 @@ pub enum EntryIden {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::persistence::sql::{entities::user::UserRepository, SqlDb};
+    use crate::persistence::sql::SqlDb;
+    use crate::services::user_service::UserService;
     use pubky_common::crypto::Keypair;
     use std::collections::HashSet;
 
@@ -461,7 +462,8 @@ mod tests {
         let user_pubkey = Keypair::random().public_key();
 
         // Test create user
-        let user = UserRepository::create(&user_pubkey, &mut db.pool().into())
+        let user = UserService::new(db.clone())
+            .create(&user_pubkey)
             .await
             .unwrap();
 
@@ -516,7 +518,8 @@ mod tests {
     async fn test_file_folder_collision_when_descendant_exists() {
         let db = SqlDb::test().await;
         let user_pubkey = Keypair::random().public_key();
-        let user = UserRepository::create(&user_pubkey, &mut db.pool().into())
+        let user = UserService::new(db.clone())
+            .create(&user_pubkey)
             .await
             .unwrap();
         create_entry_for_path(&db, user.id, "/test/sub1/1.txt").await;
@@ -535,7 +538,8 @@ mod tests {
     async fn test_file_folder_collision_when_ancestor_file_exists() {
         let db = SqlDb::test().await;
         let user_pubkey = Keypair::random().public_key();
-        let user = UserRepository::create(&user_pubkey, &mut db.pool().into())
+        let user = UserService::new(db.clone())
+            .create(&user_pubkey)
             .await
             .unwrap();
         create_entry_for_path(&db, user.id, "/test/sub1").await;
@@ -554,7 +558,8 @@ mod tests {
     async fn test_file_folder_collision_when_writing_directory_over_existing_file() {
         let db = SqlDb::test().await;
         let user_pubkey = Keypair::random().public_key();
-        let user = UserRepository::create(&user_pubkey, &mut db.pool().into())
+        let user = UserService::new(db.clone())
+            .create(&user_pubkey)
             .await
             .unwrap();
         create_entry_for_path(&db, user.id, "/test/sub1").await;
@@ -574,7 +579,8 @@ mod tests {
     async fn test_file_folder_collision_allows_exact_overwrite() {
         let db = SqlDb::test().await;
         let user_pubkey = Keypair::random().public_key();
-        let user = UserRepository::create(&user_pubkey, &mut db.pool().into())
+        let user = UserService::new(db.clone())
+            .create(&user_pubkey)
             .await
             .unwrap();
         create_entry_for_path(&db, user.id, "/test/sub1").await;
@@ -593,7 +599,8 @@ mod tests {
     async fn test_file_folder_collision_does_not_match_siblings() {
         let db = SqlDb::test().await;
         let user_pubkey = Keypair::random().public_key();
-        let user = UserRepository::create(&user_pubkey, &mut db.pool().into())
+        let user = UserService::new(db.clone())
+            .create(&user_pubkey)
             .await
             .unwrap();
         create_entry_for_path(&db, user.id, "/test/sub11/file.txt").await;
@@ -612,11 +619,13 @@ mod tests {
     async fn test_file_folder_collision_is_scoped_to_user() {
         let db = SqlDb::test().await;
         let user_a_pubkey = Keypair::random().public_key();
-        let user_a = UserRepository::create(&user_a_pubkey, &mut db.pool().into())
+        let user_a = UserService::new(db.clone())
+            .create(&user_a_pubkey)
             .await
             .unwrap();
         let user_b_pubkey = Keypair::random().public_key();
-        UserRepository::create(&user_b_pubkey, &mut db.pool().into())
+        UserService::new(db.clone())
+            .create(&user_b_pubkey)
             .await
             .unwrap();
         create_entry_for_path(&db, user_a.id, "/test/sub1").await;
@@ -637,7 +646,8 @@ mod tests {
         let user_pubkey = Keypair::random().public_key();
 
         // Test create user
-        let user = UserRepository::create(&user_pubkey, &mut db.pool().into())
+        let user = UserService::new(db.clone())
+            .create(&user_pubkey)
             .await
             .unwrap();
         // Test create entries
@@ -828,7 +838,8 @@ mod tests {
         let user_pubkey = Keypair::random().public_key();
 
         // Test create user
-        let user = UserRepository::create(&user_pubkey, &mut db.pool().into())
+        let user = UserService::new(db.clone())
+            .create(&user_pubkey)
             .await
             .unwrap();
         // Test create entries
@@ -988,7 +999,8 @@ mod tests {
         let user_pubkey = Keypair::random().public_key();
 
         // Test create user
-        let user = UserRepository::create(&user_pubkey, &mut db.pool().into())
+        let user = UserService::new(db.clone())
+            .create(&user_pubkey)
             .await
             .unwrap();
         // Test create entries
@@ -1147,7 +1159,8 @@ mod tests {
         let user_pubkey = Keypair::random().public_key();
 
         // Test create user
-        let user = UserRepository::create(&user_pubkey, &mut db.pool().into())
+        let user = UserService::new(db.clone())
+            .create(&user_pubkey)
             .await
             .unwrap();
         // Test create entries
@@ -1269,7 +1282,8 @@ mod tests {
         let user_pubkey = Keypair::random().public_key();
 
         // Test create user
-        let user = UserRepository::create(&user_pubkey, &mut db.pool().into())
+        let user = UserService::new(db.clone())
+            .create(&user_pubkey)
             .await
             .unwrap();
 

--- a/pubky-homeserver/src/persistence/sql/entities/signup_code.rs
+++ b/pubky-homeserver/src/persistence/sql/entities/signup_code.rs
@@ -604,7 +604,7 @@ mod tests {
     #[pubky_test_utils::test]
     async fn test_signup_token_limits_applied_to_user() {
         use crate::data_directory::quota_config::BandwidthQuota;
-        use crate::persistence::sql::user::UserRepository;
+        use crate::services::user_service::UserService;
         use crate::shared::user_quota::QuotaOverride;
         use std::str::FromStr;
 
@@ -629,23 +629,24 @@ mod tests {
         // 2) Simulate the signup flow: create user, mark code used, apply limits
         let keypair = Keypair::random();
         let pubkey = keypair.public_key();
+        let user_service = UserService::new(db.clone());
         let mut tx = db.pool().begin().await.unwrap();
-        let user = UserRepository::create(&pubkey, &mut (&mut tx).into())
+        let user = user_service
+            .create_in_tx(&pubkey, &mut (&mut tx).into())
             .await
             .unwrap();
         SignupCodeRepository::mark_as_used(&code_id, &pubkey, &mut (&mut tx).into())
             .await
             .unwrap();
         let token_limits = code.quota();
-        UserRepository::set_quota(user.id, &token_limits, &mut (&mut tx).into())
+        user_service
+            .set_quota_in_tx(user.id, &token_limits, &mut (&mut tx).into())
             .await
             .unwrap();
         tx.commit().await.unwrap();
 
         // 3) Re-read from DB and verify limits were persisted
-        let user = UserRepository::get(&pubkey, &mut db.pool().into())
-            .await
-            .unwrap();
+        let user = user_service.get(&pubkey).await.unwrap();
         let user_quota = user.quota();
         assert_eq!(user_quota.storage_quota_mb, QuotaOverride::Value(1024));
         assert_eq!(user_quota.rate_read, QuotaOverride::Value(bw("200mb/m")));
@@ -656,7 +657,7 @@ mod tests {
     #[tokio::test]
     #[pubky_test_utils::test]
     async fn test_signup_token_write_paths_applied_to_user() {
-        use crate::persistence::sql::user::UserRepository;
+        use crate::services::user_service::UserService;
         use crate::shared::webdav::StoragePath;
 
         let db = SqlDb::test().await;
@@ -687,23 +688,24 @@ mod tests {
         // 2) Simulate signup flow: create user, mark code, apply limits
         let keypair = Keypair::random();
         let pubkey = keypair.public_key();
+        let user_service = UserService::new(db.clone());
         let mut tx = db.pool().begin().await.unwrap();
-        let user = UserRepository::create(&pubkey, &mut (&mut tx).into())
+        let user = user_service
+            .create_in_tx(&pubkey, &mut (&mut tx).into())
             .await
             .unwrap();
         SignupCodeRepository::mark_as_used(&code_id, &pubkey, &mut (&mut tx).into())
             .await
             .unwrap();
         let token_quota = code.quota();
-        UserRepository::set_quota(user.id, &token_quota, &mut (&mut tx).into())
+        user_service
+            .set_quota_in_tx(user.id, &token_quota, &mut (&mut tx).into())
             .await
             .unwrap();
         tx.commit().await.unwrap();
 
         // 3) Verify the user inherited the write path restrictions
-        let user = UserRepository::get(&pubkey, &mut db.pool().into())
-            .await
-            .unwrap();
+        let user = user_service.get(&pubkey).await.unwrap();
         let user_quota = user.quota();
         assert_eq!(
             user_quota.allowed_write_paths,

--- a/pubky-homeserver/src/persistence/sql/entities/user.rs
+++ b/pubky-homeserver/src/persistence/sql/entities/user.rs
@@ -25,7 +25,7 @@ const ALL_USER_COLUMNS: [UserIden; 11] = [
 ];
 
 /// Repository that handles all the queries regarding the UserEntity.
-pub struct UserRepository;
+pub(crate) struct UserRepository;
 
 impl UserRepository {
     /// Create a new user.
@@ -281,27 +281,6 @@ impl UserRepository {
         let con = executor.get_con().await?;
         sqlx::query_with(&query, values).execute(con).await?;
         Ok(())
-    }
-}
-
-#[cfg(test)]
-impl UserRepository {
-    /// Test helper: create a user with a storage quota in MB.
-    pub async fn create_with_quota_mb(
-        db: &crate::persistence::sql::SqlDb,
-        pubkey: &pubky_common::crypto::PublicKey,
-        quota_mb: u64,
-    ) -> UserEntity {
-        use crate::shared::user_quota::QuotaOverride;
-        let user = Self::create(pubkey, &mut db.pool().into()).await.unwrap();
-        let config = UserQuota {
-            storage_quota_mb: QuotaOverride::Value(quota_mb),
-            ..Default::default()
-        };
-        Self::set_quota(user.id, &config, &mut db.pool().into())
-            .await
-            .unwrap();
-        Self::get(pubkey, &mut db.pool().into()).await.unwrap()
     }
 }
 

--- a/pubky-homeserver/src/persistence/sql/mod.rs
+++ b/pubky-homeserver/src/persistence/sql/mod.rs
@@ -15,7 +15,9 @@ mod sql_db;
 mod unified_executor;
 
 pub use connection_string::ConnectionString;
-pub use entities::*;
+pub use entities::entry;
+pub use entities::signup_code;
+pub(crate) use entities::user;
 pub use migrator::Migrator;
 pub(crate) use pg_event_listener::PgEventListener;
 pub use sql_db::SqlDb;

--- a/pubky-homeserver/src/persistence/sql/pg_event_listener.rs
+++ b/pubky-homeserver/src/persistence/sql/pg_event_listener.rs
@@ -287,6 +287,7 @@ mod tests {
     use super::*;
     use crate::persistence::files::events::{EventRepository, EventType, EventsService};
     use crate::persistence::sql::SqlDb;
+    use crate::services::user_service::UserService;
     use crate::shared::webdav::{EntryPath, StoragePath};
     use pubky_common::crypto::{Hash, Keypair};
     use std::time::Duration;
@@ -337,10 +338,7 @@ mod tests {
 
         let keypair = Keypair::random();
         let pubkey = keypair.public_key();
-        let user =
-            crate::persistence::sql::user::UserRepository::create(&pubkey, &mut db.pool().into())
-                .await
-                .unwrap();
+        let user = UserService::new(db.clone()).create(&pubkey).await.unwrap();
 
         let mut rx_a = events_service_a.subscribe();
         let mut rx_b = events_service_b.subscribe();
@@ -404,10 +402,7 @@ mod tests {
 
         let keypair = Keypair::random();
         let pubkey = keypair.public_key();
-        let user =
-            crate::persistence::sql::user::UserRepository::create(&pubkey, &mut db.pool().into())
-                .await
-                .unwrap();
+        let user = UserService::new(db.clone()).create(&pubkey).await.unwrap();
 
         let mut rx = events_service.subscribe();
 
@@ -463,10 +458,7 @@ mod tests {
         // Insert some events
         let keypair = Keypair::random();
         let pubkey = keypair.public_key();
-        let user =
-            crate::persistence::sql::user::UserRepository::create(&pubkey, &mut db.pool().into())
-                .await
-                .unwrap();
+        let user = UserService::new(db.clone()).create(&pubkey).await.unwrap();
 
         let mut last_id = 0;
         for i in 1..=3 {
@@ -492,10 +484,7 @@ mod tests {
 
         let keypair = Keypair::random();
         let pubkey = keypair.public_key();
-        let user =
-            crate::persistence::sql::user::UserRepository::create(&pubkey, &mut db.pool().into())
-                .await
-                .unwrap();
+        let user = UserService::new(db.clone()).create(&pubkey).await.unwrap();
 
         // Phase 1: Start listener, verify it works
         let listener = PgEventListener::start(db.pool(), events_service.clone())
@@ -560,10 +549,7 @@ mod tests {
 
         let keypair = Keypair::random();
         let pubkey = keypair.public_key();
-        let user =
-            crate::persistence::sql::user::UserRepository::create(&pubkey, &mut db.pool().into())
-                .await
-                .unwrap();
+        let user = UserService::new(db.clone()).create(&pubkey).await.unwrap();
 
         let mut rx = events_service.subscribe();
 
@@ -610,10 +596,7 @@ mod tests {
 
         let keypair = Keypair::random();
         let pubkey = keypair.public_key();
-        let user =
-            crate::persistence::sql::user::UserRepository::create(&pubkey, &mut db.pool().into())
-                .await
-                .unwrap();
+        let user = UserService::new(db.clone()).create(&pubkey).await.unwrap();
 
         let mut rx = events_service.subscribe();
 
@@ -697,10 +680,7 @@ mod tests {
 
         let keypair = Keypair::random();
         let pubkey = keypair.public_key();
-        let user =
-            crate::persistence::sql::user::UserRepository::create(&pubkey, &mut db.pool().into())
-                .await
-                .unwrap();
+        let user = UserService::new(db.clone()).create(&pubkey).await.unwrap();
 
         let mut rx = events_service.subscribe();
 
@@ -789,10 +769,7 @@ mod tests {
 
         let keypair = Keypair::random();
         let pubkey = keypair.public_key();
-        let user =
-            crate::persistence::sql::user::UserRepository::create(&pubkey, &mut db.pool().into())
-                .await
-                .unwrap();
+        let user = UserService::new(db.clone()).create(&pubkey).await.unwrap();
 
         // Subscribe but do NOT read — simulate a slow consumer
         let mut rx = events_service.subscribe();

--- a/pubky-homeserver/src/republishers/user_keys_republisher.rs
+++ b/pubky-homeserver/src/republishers/user_keys_republisher.rs
@@ -8,7 +8,7 @@ use tokio::{
 };
 
 use super::pkarr_republisher::{BatchRepublisher, BatchRepublisherSettings, RepublishSummary};
-use crate::persistence::sql::{user::UserRepository, SqlDb};
+use crate::services::user_service::UserService;
 
 const MIN_REPUBLISH_INTERVAL: Duration = Duration::from_secs(30 * 60);
 
@@ -30,7 +30,7 @@ impl UserKeysRepublisherJob {
 
     /// Run the user keys republisher with an initial delay.
     pub fn start(
-        db: SqlDb,
+        user_service: UserService,
         pkarr_builder: pkarr::ClientBuilder,
         homeserver_public_key: PublicKey,
         mut republish_interval: Duration,
@@ -60,7 +60,7 @@ impl UserKeysRepublisherJob {
         }
 
         let republisher = UserKeysRepublisher {
-            db,
+            user_service,
             pkarr_builder,
             homeserver_public_key,
         };
@@ -83,7 +83,7 @@ impl Drop for UserKeysRepublisherJob {
 }
 
 struct UserKeysRepublisher {
-    db: SqlDb,
+    user_service: UserService,
     pkarr_builder: pkarr::ClientBuilder,
     homeserver_public_key: PublicKey,
 }
@@ -125,7 +125,7 @@ impl UserKeysRepublisher {
     }
 
     async fn get_all_user_keys(&self) -> Result<Vec<PublicKey>, sqlx::Error> {
-        let users = UserRepository::get_all(&mut self.db.pool().into()).await?;
+        let users = self.user_service.get_all().await?;
         Ok(users.into_iter().map(|user| user.public_key).collect())
     }
 }
@@ -145,9 +145,9 @@ fn packet_points_to_homeserver(packet: &SignedPacket, homeserver_public_key: &Pu
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::persistence::sql::user::UserRepository;
     use crate::persistence::sql::SqlDb;
     use crate::republishers::pkarr_republisher::test_client_builder;
+    use crate::services::user_service::UserService;
     use pkarr::dns::rdata::SVCB;
     use pubky_common::crypto::Keypair;
 
@@ -173,26 +173,25 @@ mod tests {
             .unwrap()
     }
 
-    async fn init_db_with_users(count: usize) -> SqlDb {
+    async fn init_db_with_users(count: usize) -> (SqlDb, UserService) {
         let db = SqlDb::test().await;
+        let user_service = UserService::new(db.clone());
         for _ in 0..count {
             let public_key = Keypair::random().public_key();
-            UserRepository::create(&public_key, &mut db.pool().into())
-                .await
-                .unwrap();
+            user_service.create(&public_key).await.unwrap();
         }
-        db
+        (db, user_service)
     }
 
     /// Test that the republisher tries to republish all keys passed.
     #[tokio::test]
     #[pubky_test_utils::test]
     async fn test_republish_keys_once() {
-        let db = init_db_with_users(10).await;
+        let (_db, user_service) = init_db_with_users(10).await;
         let dht = mainline::Testnet::builder(1).build().unwrap();
         let pkarr_builder = test_client_builder(&dht);
         let worker = UserKeysRepublisher {
-            db,
+            user_service,
             pkarr_builder,
             homeserver_public_key: Keypair::random().public_key(),
         };
@@ -207,13 +206,12 @@ mod tests {
     #[pubky_test_utils::test]
     async fn user_pointing_to_another_homeserver_is_skipped() {
         let db = SqlDb::test().await;
+        let user_service = UserService::new(db.clone());
         let dht = mainline::Testnet::builder(1).build().unwrap();
         let pkarr_builder = test_client_builder(&dht);
         let pkarr_client = pkarr_builder.clone().build().unwrap();
         let user = Keypair::random();
-        UserRepository::create(&user.public_key(), &mut db.pool().into())
-            .await
-            .unwrap();
+        user_service.create(&user.public_key()).await.unwrap();
 
         let current_homeserver = Keypair::random().public_key();
         let other_homeserver = Keypair::random().public_key();
@@ -221,7 +219,7 @@ mod tests {
         pkarr_client.publish(&packet).await.unwrap();
 
         let worker = UserKeysRepublisher {
-            db,
+            user_service,
             pkarr_builder,
             homeserver_public_key: current_homeserver,
         };

--- a/pubky-homeserver/src/services/user_service/mod.rs
+++ b/pubky-homeserver/src/services/user_service/mod.rs
@@ -5,5 +5,4 @@ mod service;
 
 pub use service::{UserService, FILE_METADATA_SIZE};
 
-// Re-export entity types as the canonical public surface.
 pub use crate::persistence::sql::user::UserEntity;

--- a/pubky-homeserver/src/services/user_service/mod.rs
+++ b/pubky-homeserver/src/services/user_service/mod.rs
@@ -4,3 +4,6 @@ mod quota_cache;
 mod service;
 
 pub use service::{UserService, FILE_METADATA_SIZE};
+
+// Re-export entity types as the canonical public surface.
+pub use crate::persistence::sql::user::UserEntity;

--- a/pubky-homeserver/src/services/user_service/service.rs
+++ b/pubky-homeserver/src/services/user_service/service.rs
@@ -5,7 +5,7 @@
 
 use pubky_common::crypto::PublicKey;
 
-use crate::persistence::sql::user::{UserEntity, UserRepository};
+use crate::persistence::sql::user::{UserEntity, UserOverview, UserRepository};
 use crate::persistence::sql::{uexecutor, SqlDb, UnifiedExecutor};
 use crate::shared::user_quota::{UserQuota, UserQuotaPatch};
 use crate::shared::{HttpError, HttpResult};
@@ -38,36 +38,11 @@ impl UserService {
         }
     }
 
-    /// Access the underlying connection pool.
-    pub fn pool(&self) -> &sqlx::PgPool {
-        self.sql_db.pool()
-    }
+    // ── Reads (use internal pool) ──────────────────────────────────
 
-    /// Fetch a user with a `FOR UPDATE` row lock within an existing transaction.
-    pub async fn get_for_update<'a>(
-        &self,
-        pubkey: &PublicKey,
-        executor: &mut UnifiedExecutor<'a>,
-    ) -> Result<UserEntity, sqlx::Error> {
-        UserRepository::get_for_update(pubkey, executor).await
-    }
-
-    /// Fetch a user with a `FOR NO KEY UPDATE` row lock within an existing transaction.
-    pub async fn get_for_no_key_update<'a>(
-        &self,
-        pubkey: &PublicKey,
-        executor: &mut UnifiedExecutor<'a>,
-    ) -> Result<UserEntity, sqlx::Error> {
-        UserRepository::get_for_no_key_update(pubkey, executor).await
-    }
-
-    /// Persist an updated user entity within an existing transaction.
-    pub async fn update<'a>(
-        &self,
-        user: &UserEntity,
-        executor: &mut UnifiedExecutor<'a>,
-    ) -> Result<UserEntity, sqlx::Error> {
-        UserRepository::update(user, executor).await
+    /// Get a user by their public key.
+    pub async fn get(&self, pubkey: &PublicKey) -> Result<UserEntity, sqlx::Error> {
+        UserRepository::get(pubkey, &mut self.sql_db.pool().into()).await
     }
 
     /// Look up a user by public key, returning HTTP-appropriate errors.
@@ -78,7 +53,7 @@ impl UserService {
         pubkey: &PublicKey,
         err_if_disabled: bool,
     ) -> HttpResult<UserEntity> {
-        let user = match UserRepository::get(pubkey, &mut self.sql_db.pool().into()).await {
+        let user = match self.get(pubkey).await {
             Ok(user) => user,
             Err(sqlx::Error::RowNotFound) => {
                 tracing::warn!("User {} not found. Forbid access.", pubkey);
@@ -94,6 +69,89 @@ impl UserService {
 
         Ok(user)
     }
+
+    /// Get the id of a user by their public key.
+    pub async fn get_id(&self, pubkey: &PublicKey) -> Result<i32, sqlx::Error> {
+        UserRepository::get_id(pubkey, &mut self.sql_db.pool().into()).await
+    }
+
+    /// Get all user entities.
+    pub async fn get_all(&self) -> Result<Vec<UserEntity>, sqlx::Error> {
+        UserRepository::get_all(&mut self.sql_db.pool().into()).await
+    }
+
+    /// Get an overview of all users (counts, total disk usage).
+    pub async fn get_overview(&self) -> Result<UserOverview, sqlx::Error> {
+        UserRepository::get_overview(&mut self.sql_db.pool().into()).await
+    }
+
+    // ── Reads with row lock (caller-owned transaction) ─────────────
+
+    /// Fetch a user with a `FOR NO KEY UPDATE` row lock within an existing transaction.
+    pub async fn get_for_no_key_update<'a>(
+        &self,
+        pubkey: &PublicKey,
+        executor: &mut UnifiedExecutor<'a>,
+    ) -> Result<UserEntity, sqlx::Error> {
+        UserRepository::get_for_no_key_update(pubkey, executor).await
+    }
+
+    // ── Writes ─────────────────────────────────────────────────────
+
+    /// Create a new user inside an existing transaction.
+    pub async fn create_in_tx<'a>(
+        &self,
+        pubkey: &PublicKey,
+        executor: &mut UnifiedExecutor<'a>,
+    ) -> Result<UserEntity, sqlx::Error> {
+        UserRepository::create(pubkey, executor).await
+    }
+
+    /// Persist an updated user entity within an existing transaction.
+    pub async fn update_in_tx<'a>(
+        &self,
+        user: &UserEntity,
+        executor: &mut UnifiedExecutor<'a>,
+    ) -> Result<UserEntity, sqlx::Error> {
+        UserRepository::update(user, executor).await
+    }
+
+    /// Set per-user quota inside an existing transaction.
+    pub async fn set_quota_in_tx<'a>(
+        &self,
+        user_id: i32,
+        config: &UserQuota,
+        executor: &mut UnifiedExecutor<'a>,
+    ) -> Result<UserEntity, sqlx::Error> {
+        UserRepository::set_quota(user_id, config, executor).await
+    }
+
+    // ── Admin operations ─────────────────────────────────────────
+
+    /// Disable a user account.
+    pub async fn admin_disable(&self, pubkey: &PublicKey) -> HttpResult<()> {
+        self.set_disabled(pubkey, true).await
+    }
+
+    /// Enable a user account.
+    pub async fn admin_enable(&self, pubkey: &PublicKey) -> HttpResult<()> {
+        self.set_disabled(pubkey, false).await
+    }
+
+    async fn set_disabled(&self, pubkey: &PublicKey, disabled: bool) -> HttpResult<()> {
+        let mut tx = self.sql_db.pool().begin().await?;
+        let mut user = match UserRepository::get_for_update(pubkey, uexecutor!(tx)).await {
+            Ok(user) => user,
+            Err(sqlx::Error::RowNotFound) => return Err(HttpError::not_found()),
+            Err(e) => return Err(e.into()),
+        };
+        user.disabled = disabled;
+        UserRepository::update(&user, uexecutor!(tx)).await?;
+        tx.commit().await?;
+        Ok(())
+    }
+
+    // ── Quota ──────────────────────────────────────────────────────
 
     /// Resolve the effective quota for a user, checking the cache first and
     /// falling back to the database on a miss.
@@ -112,7 +170,7 @@ impl UserService {
         self.quota_cache.remove(pubkey);
         self.quota_cache.make_room();
 
-        match UserRepository::get(pubkey, &mut self.sql_db.pool().into()).await {
+        match self.get(pubkey).await {
             Ok(user) => {
                 let resolved = user.quota();
                 self.quota_cache
@@ -145,7 +203,7 @@ impl UserService {
     ) -> HttpResult<UserEntity> {
         let mut tx = self.sql_db.pool().begin().await?;
 
-        let user = match self.get_for_update(pubkey, uexecutor!(tx)).await {
+        let user = match UserRepository::get_for_update(pubkey, uexecutor!(tx)).await {
             Ok(user) => user,
             Err(sqlx::Error::RowNotFound) => return Err(HttpError::not_found()),
             Err(e) => return Err(e.into()),
@@ -166,5 +224,173 @@ impl UserService {
         self.quota_cache.remove(pubkey);
 
         Ok(updated)
+    }
+}
+
+#[cfg(test)]
+impl UserService {
+    /// Create a new user using the internal pool.
+    pub async fn create(&self, pubkey: &PublicKey) -> Result<UserEntity, sqlx::Error> {
+        UserRepository::create(pubkey, &mut self.sql_db.pool().into()).await
+    }
+
+    /// Test helper: create a user with a storage quota in MB.
+    pub async fn create_with_quota_mb(&self, pubkey: &PublicKey, quota_mb: u64) -> UserEntity {
+        use crate::shared::user_quota::QuotaOverride;
+        let user = self.create(pubkey).await.unwrap();
+        let config = UserQuota {
+            storage_quota_mb: QuotaOverride::Value(quota_mb),
+            ..Default::default()
+        };
+        self.set_quota_in_tx(user.id, &config, &mut self.sql_db.pool().into())
+            .await
+            .unwrap();
+        self.get(pubkey).await.unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::persistence::sql::SqlDb;
+    use pubky_common::crypto::Keypair;
+
+    async fn service() -> UserService {
+        UserService::new(SqlDb::test().await)
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_create_and_get() {
+        let svc = service().await;
+        let pubkey = Keypair::random().public_key();
+
+        let created = svc.create(&pubkey).await.unwrap();
+        assert_eq!(created.public_key, pubkey);
+        assert!(!created.disabled);
+
+        let fetched = svc.get(&pubkey).await.unwrap();
+        assert_eq!(fetched.id, created.id);
+        assert_eq!(fetched.public_key, pubkey);
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_get_nonexistent_returns_row_not_found() {
+        let svc = service().await;
+        let pubkey = Keypair::random().public_key();
+
+        let err = svc.get(&pubkey).await.unwrap_err();
+        assert!(matches!(err, sqlx::Error::RowNotFound));
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_get_id() {
+        let svc = service().await;
+        let pubkey = Keypair::random().public_key();
+
+        let created = svc.create(&pubkey).await.unwrap();
+        let id = svc.get_id(&pubkey).await.unwrap();
+        assert_eq!(id, created.id);
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_get_or_http_error_not_found() {
+        let svc = service().await;
+        let pubkey = Keypair::random().public_key();
+
+        assert!(svc.get_or_http_error(&pubkey, false).await.is_err());
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_get_or_http_error_disabled() {
+        let svc = service().await;
+        let pubkey = Keypair::random().public_key();
+        svc.create(&pubkey).await.unwrap();
+        svc.admin_disable(&pubkey).await.unwrap();
+
+        // err_if_disabled = false → still returns the user
+        let user = svc.get_or_http_error(&pubkey, false).await.unwrap();
+        assert!(user.disabled);
+
+        // err_if_disabled = true → error
+        assert!(svc.get_or_http_error(&pubkey, true).await.is_err());
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_admin_disable_and_enable() {
+        let svc = service().await;
+        let pubkey = Keypair::random().public_key();
+        svc.create(&pubkey).await.unwrap();
+
+        svc.admin_disable(&pubkey).await.unwrap();
+        assert!(svc.get(&pubkey).await.unwrap().disabled);
+
+        svc.admin_enable(&pubkey).await.unwrap();
+        assert!(!svc.get(&pubkey).await.unwrap().disabled);
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_admin_disable_nonexistent_returns_error() {
+        let svc = service().await;
+        let pubkey = Keypair::random().public_key();
+
+        assert!(svc.admin_disable(&pubkey).await.is_err());
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_get_all_and_get_overview() {
+        let svc = service().await;
+
+        // Empty initially
+        let all = svc.get_all().await.unwrap();
+        assert!(all.is_empty());
+        let overview = svc.get_overview().await.unwrap();
+        assert_eq!(overview.count, 0);
+
+        // Create two users, disable one
+        let pk1 = Keypair::random().public_key();
+        let pk2 = Keypair::random().public_key();
+        svc.create(&pk1).await.unwrap();
+        svc.create(&pk2).await.unwrap();
+        svc.admin_disable(&pk2).await.unwrap();
+
+        let all = svc.get_all().await.unwrap();
+        assert_eq!(all.len(), 2);
+
+        let overview = svc.get_overview().await.unwrap();
+        assert_eq!(overview.count, 2);
+        assert_eq!(overview.disabled_count, 1);
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_resolve_quota_unknown_user_returns_none() {
+        let svc = service().await;
+        let pubkey = Keypair::random().public_key();
+
+        let quota = svc.resolve_quota(&pubkey).await.unwrap();
+        assert!(quota.is_none());
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_resolve_quota_known_user_returns_some() {
+        let svc = service().await;
+        let pubkey = Keypair::random().public_key();
+        svc.create(&pubkey).await.unwrap();
+
+        let quota = svc.resolve_quota(&pubkey).await.unwrap();
+        assert!(quota.is_some());
+
+        // Second call should hit cache and still return Some
+        let quota2 = svc.resolve_quota(&pubkey).await.unwrap();
+        assert!(quota2.is_some());
     }
 }

--- a/pubky-homeserver/src/services/user_service/service.rs
+++ b/pubky-homeserver/src/services/user_service/service.rs
@@ -48,6 +48,7 @@ impl UserService {
     /// Look up a user by public key, returning HTTP-appropriate errors.
     /// - User not found → 404
     /// - User disabled (when `err_if_disabled` is true) → 403
+    // TODO: Replace HttpError return with a domain error enum and map to HTTP in route handlers.
     pub async fn get_or_http_error(
         &self,
         pubkey: &PublicKey,
@@ -239,6 +240,9 @@ impl UserService {
 #[cfg(test)]
 impl UserService {
     /// Create a new user using the internal pool.
+    ///
+    /// Test-only: production signup must go through [`SignupService::create_new_user`]
+    /// to enforce token validation and assign initial quota from the signup code.
     pub async fn create(&self, pubkey: &PublicKey) -> Result<UserEntity, sqlx::Error> {
         UserRepository::create(pubkey, &mut self.sql_db.pool().into()).await
     }
@@ -401,5 +405,30 @@ mod tests {
         // Second call should hit cache and still return Some
         let quota2 = svc.resolve_quota(&pubkey).await.unwrap();
         assert!(quota2.is_some());
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_patch_quota_invalidates_cache() {
+        use crate::shared::user_quota::{QuotaOverride, UserQuotaPatch};
+
+        let svc = service().await;
+        let pubkey = Keypair::random().public_key();
+        svc.create(&pubkey).await.unwrap();
+
+        // Populate cache
+        let before = svc.resolve_quota(&pubkey).await.unwrap().unwrap();
+        assert!(before.storage_quota_mb.is_default());
+
+        // Patch quota
+        let patch = UserQuotaPatch {
+            storage_quota_mb: Some(QuotaOverride::Value(42)),
+            ..Default::default()
+        };
+        svc.patch_quota(&pubkey, &patch).await.unwrap();
+
+        // Cache should be invalidated — next resolve must return the new value
+        let after = svc.resolve_quota(&pubkey).await.unwrap().unwrap();
+        assert_eq!(after.storage_quota_mb, QuotaOverride::Value(42));
     }
 }

--- a/pubky-homeserver/src/services/user_service/service.rs
+++ b/pubky-homeserver/src/services/user_service/service.rs
@@ -85,7 +85,16 @@ impl UserService {
         UserRepository::get_overview(&mut self.sql_db.pool().into()).await
     }
 
-    // ── Reads with row lock (caller-owned transaction) ─────────────
+    // ── Reads (caller-owned transaction) ──────────────────────────
+
+    /// Get a user by public key inside an existing transaction (no row lock).
+    pub async fn get_in_tx<'a>(
+        &self,
+        pubkey: &PublicKey,
+        executor: &mut UnifiedExecutor<'a>,
+    ) -> Result<UserEntity, sqlx::Error> {
+        UserRepository::get(pubkey, executor).await
+    }
 
     /// Fetch a user with a `FOR NO KEY UPDATE` row lock within an existing transaction.
     pub async fn get_for_no_key_update<'a>(


### PR DESCRIPTION
User operations are currently done in a mix of `UserService` operations, direct `UserRepository` db calls and logic in caller functions. Here we route all user-based operations through `UserService`.

- `UserService` is now the single entry point for user CRUD, quota management, and admin operations
- Admin enable/disable logic centralised into `UserService::admin_disable`/`admin_enable`, replacing duplicated get-update-commit sequences in route handlers.
- `Finalizer` holds `SqlDb` separately from `UserService`, keeping non-user database work distinct from the user service's pool. Currently it uses `UserService`'s `pool()`, which is weird.