### PR TITLE
feat: add `Retry-After` header in HTTP 429 responses

### DIFF
--- a/pubky-homeserver/src/client_server/app.rs
+++ b/pubky-homeserver/src/client_server/app.rs
@@ -14,7 +14,7 @@ use std::net::TcpListener;
 use std::path::PathBuf;
 use std::time::Duration;
 
-use axum::{middleware as axum_middleware, routing::get, Router};
+use axum::{http::header::RETRY_AFTER, middleware as axum_middleware, routing::get, Router};
 use axum_server::{
     tls_rustls::{RustlsAcceptor, RustlsConfig},
     Handle,
@@ -255,7 +255,7 @@ pub fn create_app(
     // Keep CORS outermost so tenant-resolution errors are usable by browsers.
     Ok(with_trace_layer(app)
         .layer(axum_middleware::from_fn(RequestTenant::resolve))
-        .layer(CorsLayer::very_permissive()))
+        .layer(CorsLayer::very_permissive().expose_headers([RETRY_AFTER])))
 }
 
 #[cfg(test)]
@@ -303,9 +303,14 @@ mod tests {
             .get("/session")
             .add_header("host", user.public_key().z32())
             .add_header(header::COOKIE, cookie)
+            .add_header(header::ORIGIN, "https://app.example") // Add Origin, to turns this into a CORS request
             .await;
 
         response.assert_status(StatusCode::TOO_MANY_REQUESTS);
+        assert!(response.headers().contains_key(header::RETRY_AFTER));
+
+        // Retry-After is not CORS-safelisted, so browsers need it explicitly exposed.
+        response.assert_header(header::ACCESS_CONTROL_EXPOSE_HEADERS, "retry-after");
     }
 
     async fn signup_cookie(server: &TestServer, keypair: &Keypair) -> String {

--- a/pubky-homeserver/src/client_server/middleware/rate_limiter/request_rate_limit.rs
+++ b/pubky-homeserver/src/client_server/middleware/rate_limiter/request_rate_limit.rs
@@ -3,10 +3,11 @@
 //! Enforces per-path request-count quotas (`[[drive.rate_limits]]` in config).
 //! Each path+method pattern has a governor rate limiter keyed by IP or user.
 
+use axum::http::header::RETRY_AFTER;
 use axum::response::{IntoResponse, Response};
 use axum::{
     body::Body,
-    http::{HeaderName, Request, StatusCode},
+    http::{Request, StatusCode},
 };
 use futures_util::future::BoxFuture;
 use governor::clock::Clock;
@@ -151,13 +152,11 @@ fn rate_limited_response(retry_after: Duration) -> Response {
 
     (
         StatusCode::TOO_MANY_REQUESTS,
-        [(RETRY_AFTER_HEADER, delay_seconds.to_string())],
+        [(RETRY_AFTER, delay_seconds.to_string())],
         "Rate limit exceeded",
     )
         .into_response()
 }
-
-const RETRY_AFTER_HEADER: HeaderName = HeaderName::from_static("retry-after");
 
 #[cfg(test)]
 mod tests {
@@ -360,7 +359,7 @@ mod tests {
 
         let retry_after = second_req
             .headers()
-            .get(RETRY_AFTER_HEADER)
+            .get(RETRY_AFTER)
             .expect("429 response must include a Retry-After header");
         let delay_secs: u64 = String::from_utf8_lossy(retry_after.as_bytes())
             .parse()

--- a/pubky-homeserver/src/client_server/middleware/rate_limiter/request_rate_limit.rs
+++ b/pubky-homeserver/src/client_server/middleware/rate_limiter/request_rate_limit.rs
@@ -6,10 +6,11 @@
 use axum::response::{IntoResponse, Response};
 use axum::{
     body::Body,
-    http::{Request, StatusCode},
+    http::{HeaderName, Request, StatusCode},
 };
 use futures_util::future::BoxFuture;
-use std::{convert::Infallible, task::Poll};
+use governor::clock::Clock;
+use std::{convert::Infallible, task::Poll, time::Duration};
 use tower::{Layer, Service};
 
 use crate::quota_config::PathLimit;
@@ -122,20 +123,41 @@ fn check_request_count_limits(limits: &[LimitTuple], req: &Request<Body>) -> Res
             continue;
         }
         if let Err(e) = limit.limiter.check_key(&key) {
+            let retry_after = e.wait_time_from(limit.limiter.clock().now());
             tracing::debug!(
-                "Rate limit of {} exceeded for {key}: {}",
+                "Rate limit of {} exceeded for {key}: {e}. Retry after {retry_after:?}",
                 limit.limit.quota,
-                e
             );
-            return Err(HttpError::new_with_message(
-                StatusCode::TOO_MANY_REQUESTS,
-                "Rate limit exceeded",
-            )
-            .into_response());
+            return Err(rate_limited_response(retry_after));
         }
     }
     Ok(())
 }
+
+/// Build a `429 Too Many Requests` response carrying a `Retry-After: <seconds>` header.
+///
+/// The value is delta-seconds ([RFC 6585 §4][rfc]), rounded up to the nearest whole second
+/// with a minimum of one, so retrying after it should no longer yield a `429`.
+///
+/// [rfc]: https://www.rfc-editor.org/info/rfc6585/#section-4
+fn rate_limited_response(retry_after: Duration) -> Response {
+    // Round up (ceil) to whole seconds, clamping to a minimum of 1 so the header is always meaningful.
+    let secs = retry_after.as_secs();
+    let delay_seconds = if retry_after.subsec_nanos() > 0 {
+        secs.saturating_add(1)
+    } else {
+        secs.max(1)
+    };
+
+    (
+        StatusCode::TOO_MANY_REQUESTS,
+        [(RETRY_AFTER_HEADER, delay_seconds.to_string())],
+        "Rate limit exceeded",
+    )
+        .into_response()
+}
+
+const RETRY_AFTER_HEADER: HeaderName = HeaderName::from_static("retry-after");
 
 #[cfg(test)]
 mod tests {
@@ -309,6 +331,43 @@ mod tests {
 
         assert_eq!(first.status(), StatusCode::OK);
         assert_eq!(second.status(), StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    /// A `429 Too Many Requests` response must carry a `Retry-After: <seconds>` header whose value
+    /// reflects the configured quota (here `1r/m`, so callers should wait ~60 seconds) and is at
+    /// least one second.
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn rate_limited_response_includes_retry_after_header() {
+        let path_limit = PathLimit {
+            path: GlobPattern::new("/upload"),
+            method: HttpMethod(Method::POST),
+            quota: "1r/m".parse().unwrap(),
+            key: LimitKeyType::Ip,
+            burst: None,
+            whitelist: Vec::new(),
+        };
+        let socket = start_server(vec![path_limit]).await;
+        let path = format!("http://{}/upload", socket);
+
+        // First request consumes the only allowed cell for this minute.
+        let first_req = Client::new().post(&path).send().await.unwrap();
+        assert_eq!(first_req.status(), StatusCode::CREATED);
+
+        // Second request is rate-limited and must report how long to wait.
+        let second_req = Client::new().post(&path).send().await.unwrap();
+        assert_eq!(second_req.status(), StatusCode::TOO_MANY_REQUESTS);
+
+        let retry_after = second_req
+            .headers()
+            .get(RETRY_AFTER_HEADER)
+            .expect("429 response must include a Retry-After header");
+        let delay_secs: u64 = String::from_utf8_lossy(retry_after.as_bytes())
+            .parse()
+            .expect("Retry-After should be an integer number of seconds");
+
+        assert!(delay_secs >= 1, "Retry-After must be at least one second");
+        assert!(delay_secs <= 60, "Retry-After should not exceed the quota");
     }
 
     #[test]

--- a/pubky-homeserver/src/client_server/middleware/rate_limiter/request_rate_limit.rs
+++ b/pubky-homeserver/src/client_server/middleware/rate_limiter/request_rate_limit.rs
@@ -137,22 +137,22 @@ fn check_request_count_limits(limits: &[LimitTuple], req: &Request<Body>) -> Res
 
 /// Build a `429 Too Many Requests` response carrying a `Retry-After: <seconds>` header.
 ///
-/// The value is delta-seconds ([RFC 6585 §4][rfc]), rounded up to the nearest whole second
-/// with a minimum of one, so retrying after it should no longer yield a `429`.
+/// The value is a wait time in seconds, rounded up to the nearest second with a minimum of 1.
 ///
-/// [rfc]: https://www.rfc-editor.org/info/rfc6585/#section-4
+/// See also:
+/// - https://www.rfc-editor.org/info/rfc6585/#section-4
+/// - https://www.rfc-editor.org/info/rfc9110/#section-10.2.3
 fn rate_limited_response(retry_after: Duration) -> Response {
-    // Round up (ceil) to whole seconds, clamping to a minimum of 1 so the header is always meaningful.
-    let secs = retry_after.as_secs();
-    let delay_seconds = if retry_after.subsec_nanos() > 0 {
-        secs.saturating_add(1)
+    let temp_secs = retry_after.as_secs();
+    let delay_secs = if retry_after.subsec_nanos() > 0 {
+        temp_secs.saturating_add(1)
     } else {
-        secs.max(1)
+        temp_secs.max(1)
     };
 
     (
         StatusCode::TOO_MANY_REQUESTS,
-        [(RETRY_AFTER, delay_seconds.to_string())],
+        [(RETRY_AFTER, delay_secs.to_string())],
         "Rate limit exceeded",
     )
         .into_response()
@@ -163,6 +163,7 @@ mod tests {
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
     use axum::http::Method;
+    use axum::response::IntoResponse;
     use axum::{
         middleware,
         routing::{get, post},
@@ -179,7 +180,6 @@ mod tests {
     use crate::shared::HttpResult;
 
     use super::*;
-    use axum::response::IntoResponse;
 
     async fn upload_handler() -> HttpResult<impl IntoResponse> {
         Ok((StatusCode::CREATED, ()))

--- a/pubky-homeserver/src/client_server/middleware/rate_limiter/request_rate_limit.rs
+++ b/pubky-homeserver/src/client_server/middleware/rate_limiter/request_rate_limit.rs
@@ -97,14 +97,8 @@ where
 }
 
 /// Check request-count path limits. Returns an error response if any limit is exceeded.
-///
-/// Several limits may match a single request (overlapping path globs + method). When more than one
-/// is violated at once, the `Retry-After` header must reflect the *furthest* wait among the violated rules.
 #[allow(clippy::result_large_err)]
 fn check_request_count_limits(limits: &[LimitTuple], req: &Request<Body>) -> Result<(), Response> {
-    // The longest wait among every limit that is exceeded for this request, if any.
-    let mut max_retry_after: Option<Duration> = None;
-
     for limit in limits {
         if !limit.is_match(req) {
             continue;
@@ -134,15 +128,10 @@ fn check_request_count_limits(limits: &[LimitTuple], req: &Request<Body>) -> Res
                 "Rate limit of {} exceeded for {key}: {e}. Retry after {retry_after:?}",
                 limit.limit.quota,
             );
-            max_retry_after = Some(max_retry_after.map_or(retry_after, |val| val.max(retry_after)));
+            return Err(rate_limited_response(retry_after));
         }
     }
-
-    // If at least one matching limit was exceeded, reject with the furthest-in-the-future wait
-    match max_retry_after {
-        Some(retry_after) => Err(rate_limited_response(retry_after)),
-        None => Ok(()),
-    }
+    Ok(())
 }
 
 /// Build a `429 Too Many Requests` response carrying a `Retry-After: <seconds>` header.
@@ -379,61 +368,6 @@ mod tests {
 
         assert!(delay_secs >= 1, "Retry-After must be at least one second");
         assert!(delay_secs <= 60, "Retry-After should not exceed the quota");
-    }
-
-    /// When several configured limits match the same request (overlapping path globs) and are *all*
-    /// exceeded at once, `Retry-After` must report the furthest wait among them. Otherwise a client
-    /// that waits the advertised duration is still blocked by another, longer-exceeded rule on its
-    /// next attempt.
-    ///
-    /// We configure two overlapping `POST /upload` limits keyed by IP with identical burst (1) but very
-    /// different windows: `~1s` (`1r/s`) and `~3600s` (`1r/h`). After the first request consumes each
-    /// limiter's single burst token, a second request violates both simultaneously; `Retry-After` must
-    /// be in the ~hour range (the slow limit).
-    #[tokio::test]
-    #[pubky_test_utils::test]
-    async fn retry_after_reflects_furthest_violated_limit_when_multiple_overlap() {
-        let fast = PathLimit {
-            path: GlobPattern::new("/upload"),
-            method: HttpMethod(Method::POST),
-            quota: "1r/s".parse().unwrap(), // burst 1, ~1s window
-            key: LimitKeyType::Ip,
-            burst: None,
-            whitelist: Vec::new(),
-        };
-        let slow = PathLimit {
-            path: GlobPattern::new("/upload"),
-            method: HttpMethod(Method::POST),
-            quota: "1r/h".parse().unwrap(), // burst 1, ~3600s window
-            key: LimitKeyType::Ip,
-            burst: None,
-            whitelist: Vec::new(),
-        };
-        let socket = start_server(vec![fast, slow]).await;
-        let path = format!("http://{}/upload", socket);
-
-        let first_req = Client::new().post(&path).send().await.unwrap();
-        assert_eq!(first_req.status(), StatusCode::CREATED);
-
-        // Second request violates BOTH limits simultaneously (~1s AND ~3600s). Retry-After must reflect
-        // the furthest wait (the slow limit), not merely the first limit encountered in iteration order.
-        let second_req = Client::new().post(&path).send().await.unwrap();
-        assert_eq!(second_req.status(), StatusCode::TOO_MANY_REQUESTS);
-
-        let retry_after = second_req
-            .headers()
-            .get(RETRY_AFTER_HEADER)
-            .expect("429 response must include a Retry-After header");
-        let delay_secs: u64 = String::from_utf8_lossy(retry_after.as_bytes())
-            .parse()
-            .expect("Retry-After should be an integer number of seconds");
-
-        // We expect delay_secs to be ~3600. Due to jitter and test variance, we cannot exactly match it,
-        // but checking for > 60s essentially proves the smaller ~1s limit was not the one in the header.
-        assert!(
-            delay_secs > 60,
-            "Retry-After should reflect the furthest violated limit (~3600s), not the fast one (~1s); got {delay_secs}s"
-        );
     }
 
     #[test]

--- a/pubky-homeserver/src/client_server/middleware/rate_limiter/request_rate_limit.rs
+++ b/pubky-homeserver/src/client_server/middleware/rate_limiter/request_rate_limit.rs
@@ -11,7 +11,7 @@ use axum::{
 };
 use futures_util::future::BoxFuture;
 use governor::clock::Clock;
-use std::{convert::Infallible, task::Poll, time::Duration};
+use std::{convert::Infallible, task::Poll};
 use tower::{Layer, Service};
 
 use crate::quota_config::PathLimit;
@@ -125,37 +125,21 @@ fn check_request_count_limits(limits: &[LimitTuple], req: &Request<Body>) -> Res
         }
         if let Err(e) = limit.limiter.check_key(&key) {
             let retry_after = e.wait_time_from(limit.limiter.clock().now());
+            let retry_after_secs = retry_after.as_secs().max(1);
             tracing::debug!(
-                "Rate limit of {} exceeded for {key}: {e}. Retry after {retry_after:?}",
+                "Rate limit of {} exceeded for {key}: {e}. Retry after {retry_after_secs}s",
                 limit.limit.quota,
             );
-            return Err(rate_limited_response(retry_after));
+
+            let response = (
+                StatusCode::TOO_MANY_REQUESTS,
+                [(RETRY_AFTER, retry_after_secs)],
+                "Rate limit exceeded",
+            );
+            return Err(response.into_response());
         }
     }
     Ok(())
-}
-
-/// Build a `429 Too Many Requests` response carrying a `Retry-After: <seconds>` header.
-///
-/// The value is a wait time in seconds, rounded up to the nearest second with a minimum of 1.
-///
-/// See also:
-/// - https://www.rfc-editor.org/info/rfc6585/#section-4
-/// - https://www.rfc-editor.org/info/rfc9110/#section-10.2.3
-fn rate_limited_response(retry_after: Duration) -> Response {
-    let temp_secs = retry_after.as_secs();
-    let delay_secs = if retry_after.subsec_nanos() > 0 {
-        temp_secs.saturating_add(1)
-    } else {
-        temp_secs.max(1)
-    };
-
-    (
-        StatusCode::TOO_MANY_REQUESTS,
-        [(RETRY_AFTER, delay_secs.to_string())],
-        "Rate limit exceeded",
-    )
-        .into_response()
 }
 
 #[cfg(test)]

--- a/pubky-homeserver/src/client_server/middleware/rate_limiter/request_rate_limit.rs
+++ b/pubky-homeserver/src/client_server/middleware/rate_limiter/request_rate_limit.rs
@@ -97,8 +97,14 @@ where
 }
 
 /// Check request-count path limits. Returns an error response if any limit is exceeded.
+///
+/// Several limits may match a single request (overlapping path globs + method). When more than one
+/// is violated at once, the `Retry-After` header must reflect the *furthest* wait among the violated rules.
 #[allow(clippy::result_large_err)]
 fn check_request_count_limits(limits: &[LimitTuple], req: &Request<Body>) -> Result<(), Response> {
+    // The longest wait among every limit that is exceeded for this request, if any.
+    let mut max_retry_after: Option<Duration> = None;
+
     for limit in limits {
         if !limit.is_match(req) {
             continue;
@@ -128,10 +134,15 @@ fn check_request_count_limits(limits: &[LimitTuple], req: &Request<Body>) -> Res
                 "Rate limit of {} exceeded for {key}: {e}. Retry after {retry_after:?}",
                 limit.limit.quota,
             );
-            return Err(rate_limited_response(retry_after));
+            max_retry_after = Some(max_retry_after.map_or(retry_after, |val| val.max(retry_after)));
         }
     }
-    Ok(())
+
+    // If at least one matching limit was exceeded, reject with the furthest-in-the-future wait
+    match max_retry_after {
+        Some(retry_after) => Err(rate_limited_response(retry_after)),
+        None => Ok(()),
+    }
 }
 
 /// Build a `429 Too Many Requests` response carrying a `Retry-After: <seconds>` header.
@@ -368,6 +379,61 @@ mod tests {
 
         assert!(delay_secs >= 1, "Retry-After must be at least one second");
         assert!(delay_secs <= 60, "Retry-After should not exceed the quota");
+    }
+
+    /// When several configured limits match the same request (overlapping path globs) and are *all*
+    /// exceeded at once, `Retry-After` must report the furthest wait among them. Otherwise a client
+    /// that waits the advertised duration is still blocked by another, longer-exceeded rule on its
+    /// next attempt.
+    ///
+    /// We configure two overlapping `POST /upload` limits keyed by IP with identical burst (1) but very
+    /// different windows: `~1s` (`1r/s`) and `~3600s` (`1r/h`). After the first request consumes each
+    /// limiter's single burst token, a second request violates both simultaneously; `Retry-After` must
+    /// be in the ~hour range (the slow limit).
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn retry_after_reflects_furthest_violated_limit_when_multiple_overlap() {
+        let fast = PathLimit {
+            path: GlobPattern::new("/upload"),
+            method: HttpMethod(Method::POST),
+            quota: "1r/s".parse().unwrap(), // burst 1, ~1s window
+            key: LimitKeyType::Ip,
+            burst: None,
+            whitelist: Vec::new(),
+        };
+        let slow = PathLimit {
+            path: GlobPattern::new("/upload"),
+            method: HttpMethod(Method::POST),
+            quota: "1r/h".parse().unwrap(), // burst 1, ~3600s window
+            key: LimitKeyType::Ip,
+            burst: None,
+            whitelist: Vec::new(),
+        };
+        let socket = start_server(vec![fast, slow]).await;
+        let path = format!("http://{}/upload", socket);
+
+        let first_req = Client::new().post(&path).send().await.unwrap();
+        assert_eq!(first_req.status(), StatusCode::CREATED);
+
+        // Second request violates BOTH limits simultaneously (~1s AND ~3600s). Retry-After must reflect
+        // the furthest wait (the slow limit), not merely the first limit encountered in iteration order.
+        let second_req = Client::new().post(&path).send().await.unwrap();
+        assert_eq!(second_req.status(), StatusCode::TOO_MANY_REQUESTS);
+
+        let retry_after = second_req
+            .headers()
+            .get(RETRY_AFTER_HEADER)
+            .expect("429 response must include a Retry-After header");
+        let delay_secs: u64 = String::from_utf8_lossy(retry_after.as_bytes())
+            .parse()
+            .expect("Retry-After should be an integer number of seconds");
+
+        // We expect delay_secs to be ~3600. Due to jitter and test variance, we cannot exactly match it,
+        // but checking for > 60s essentially proves the smaller ~1s limit was not the one in the header.
+        assert!(
+            delay_secs > 60,
+            "Retry-After should reflect the furthest violated limit (~3600s), not the fast one (~1s); got {delay_secs}s"
+        );
     }
 
     #[test]


### PR DESCRIPTION
This PR adds a `Retry-After` header to HTTP 429 "Too Many Requests" errors, which are thrown when the API reaches a rate-limit.

Fixes #407