### PR TITLE
feat(homeserver): feature discovery endpoint

### DIFF
--- a/pubky-homeserver/README.md
+++ b/pubky-homeserver/README.md
@@ -14,6 +14,13 @@ cargo run -p pubky-homeserver -- --data-dir ~/.pubky
 
 See [config.sample.toml](config.sample.toml) for all configuration options.
 
+### Client compatibility
+
+When an SDK change requires homeserver behavior that older versions do not
+support, such as a new endpoint, add a stable feature identifier to the client
+`GET /info` response. SDKs must check that identifier before using the new
+behavior.
+
 ## API Specifications
 
 - [Client API](openapi-client.yml) — user authentication, tenant storage, and event feeds.

--- a/pubky-homeserver/openapi-client.yml
+++ b/pubky-homeserver/openapi-client.yml
@@ -68,6 +68,29 @@ paths:
               schema:
                 type: string
                 example: Pubky Homeserver
+  "/info":
+    get:
+      tags:
+      - General
+      summary: List supported client features
+      description: |-
+        Returns stable, opaque feature identifiers supported by this homeserver.
+        Clients must ignore unknown identifiers.
+      operationId: getInfo
+      responses:
+        '200':
+          description: Client feature information
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+                example: no-store
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ClientInfoResponse"
+              example:
+                features: []
   "/signup_tokens/{token}":
     get:
       tags:
@@ -1025,6 +1048,17 @@ components:
       schema:
         type: string
   schemas:
+    ClientInfoResponse:
+      type: object
+      required:
+      - features
+      properties:
+        features:
+          type: array
+          items:
+            type: string
+          description: Stable opaque feature identifiers. Clients must ignore unknown values.
+          example: []
     CreateGrantSessionRequest:
       type: object
       required:

--- a/pubky-homeserver/src/client_server/app.rs
+++ b/pubky-homeserver/src/client_server/app.rs
@@ -31,7 +31,7 @@ use super::middleware::{
     request_tenant::RequestTenant,
     trace::with_trace_layer,
 };
-use super::routes::{events, root, signup_tokens, tenants};
+use super::routes::{events, info, root, signup_tokens, tenants};
 
 /// Errors that can occur when building a `HomeserverCore`.
 #[derive(Debug, thiserror::Error)]
@@ -248,7 +248,9 @@ pub fn create_app(
         .with_state(state)
         .merge(auth::base_router(auth_state.clone()))
         .merge(auth::tenant_router(auth_state))
-        .layer(middleware);
+        .layer(middleware)
+        // Keep feature discovery independent of authentication and database-backed quotas.
+        .route("/info", get(info::get));
 
     // Resolve the target before tracing and authentication. Valid `/storage/...`
     // requests are therefore logged using their Pubky URL.
@@ -306,6 +308,32 @@ mod tests {
             .await;
 
         response.assert_status(StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn info_is_public_and_reports_no_features() {
+        let mut config = ConfigToml::minimal_test_config();
+        config.drive.rate_limits = vec![PathLimit {
+            path: GlobPattern::new("/info"),
+            method: HttpMethod(Method::GET),
+            quota: "1r/m".parse().unwrap(),
+            key: LimitKeyType::User,
+            burst: None,
+            whitelist: Vec::new(),
+        }];
+
+        let data_dir = MockDataDir::new(config, None).unwrap();
+        let context = AppContext::read_from(data_dir).await.unwrap();
+        let router = ClientServer::create_router(&context).unwrap();
+        let server = TestServer::new(router).unwrap();
+
+        let response = server.get("/info").await;
+
+        response.assert_status(StatusCode::OK);
+        response.assert_header(header::CONTENT_TYPE, "application/json");
+        response.assert_header(header::CACHE_CONTROL, "no-store");
+        response.assert_json(&serde_json::json!({ "features": [] }));
     }
 
     async fn signup_cookie(server: &TestServer, keypair: &Keypair) -> String {

--- a/pubky-homeserver/src/client_server/routes/info.rs
+++ b/pubky-homeserver/src/client_server/routes/info.rs
@@ -1,0 +1,24 @@
+//! Client-facing homeserver feature information.
+
+use axum::{
+    http::{header, StatusCode},
+    response::IntoResponse,
+    Json,
+};
+use serde::Serialize;
+
+const FEATURES: &[&str] = &[];
+
+#[derive(Serialize)]
+struct InfoResponse {
+    features: &'static [&'static str],
+}
+
+/// Return the client features supported by this homeserver.
+pub async fn get() -> impl IntoResponse {
+    (
+        StatusCode::OK,
+        [(header::CACHE_CONTROL, "no-store")],
+        Json(InfoResponse { features: FEATURES }),
+    )
+}

--- a/pubky-homeserver/src/client_server/routes/mod.rs
+++ b/pubky-homeserver/src/client_server/routes/mod.rs
@@ -1,6 +1,7 @@
 //! HTTP route handlers for the client server.
 //!
 //! - [`events`]: Historical event feed and live SSE stream for file change notifications.
+//! - [`info`]: Homeserver feature discovery.
 //! - [`root`]: Server info endpoint.
 //! - [`signup_tokens`]: Signup token validation.
 //! - [`tenants`]: Per-user data routes (read, write).
@@ -8,6 +9,7 @@
 //! Auth routes (signup, signin, session management) live in [`crate::client_server::auth::routes`].
 
 pub(crate) mod events;
+pub(crate) mod info;
 pub(crate) mod root;
 pub(crate) mod signup_tokens;
 pub(crate) mod tenants;


### PR DESCRIPTION
Closes #549.

### Summary

Adds a public `GET /info` endpoint to the client server:

```json
{
  "features": []
}
```
The endpoint exposes stable, opaque feature identifiers that SDKs can use to detect homeserver capabilities. It initially advertises no features.