### PR TITLE
feat(homeserver): add metrics for tracking cookie auth and pubky host usage

### DIFF
--- a/docs/STORAGE_ADDRESSING_MIGRATION.md
+++ b/docs/STORAGE_ADDRESSING_MIGRATION.md
@@ -1,0 +1,91 @@
+# Storage Addressing Migration
+
+New SDKs will send storage requests to path-addressed routes. Older SDKs use
+owner-relative routes:
+
+```text
+Legacy: GET /pub/example.txt + pubky-host
+Path:   GET /storage/{user-z32}/pub/example.txt
+```
+
+The homeserver will keep legacy storage addressing, `pubky-host`, and cookie
+authentication during the migration. Maintainers may remove them only after
+the minimum migration period and an explicit review.
+
+## Migration metric
+
+The homeserver exports `storage_request_count_total`. Each request that reaches
+a tenant storage route is counted once with these fixed labels:
+
+| Label | Values | Meaning |
+| --- | --- | --- |
+| `addressing_mode` | `path`, `legacy` | Where the homeserver got the owner: `/storage/{user-z32}/...` or legacy request addressing. |
+| `pubky_host_header` | `absent`, `matching`, `other` | The header was absent, matched the resolved owner, or held a different or invalid value. |
+| `pubky_host_query` | `true`, `false` | The request included a `pubky-host` query parameter. |
+| `auth_method` | `none`, `cookie`, `grant` | How the homeserver authenticated the request. `none` includes anonymous requests and unresolved credentials; `grant` means bearer/grant authentication. |
+
+These labels produce at most 36 combinations. No label contains a cookie,
+bearer token, public key, or storage path.
+
+Use these PromQL queries:
+
+```promql
+# Path-addressed versus legacy requests over the last 30 days.
+sum by (addressing_mode) (increase(storage_request_count_total[30d]))
+
+# Remaining pubky-host header usage, split by addressing mode.
+sum by (addressing_mode, pubky_host_header, pubky_host_query) (
+  increase(storage_request_count_total{
+    pubky_host_header!="absent"
+  }[30d])
+)
+
+# Remaining pubky-host query-parameter usage.
+sum by (addressing_mode) (
+  increase(storage_request_count_total{pubky_host_query="true"}[30d])
+)
+
+# Cookie versus grant authentication on storage requests.
+sum by (auth_method) (increase(storage_request_count_total[30d]))
+```
+
+## Collection requirements
+
+Metrics are disabled by default. Counters reset when the homeserver restarts.
+Operators contributing data to the migration review must:
+
+1. Enable `[metrics]` and scrape `GET /metrics` with Prometheus or a compatible
+   collector.
+2. Keep the metrics listener isolated from the public network; it is
+   unauthenticated.
+3. Start collecting before the stable path-addressing SDK is published, and
+   retain the time series for at least the full migration period.
+4. Aggregate all instances of a multi-instance homeserver when comparing
+   adoption.
+
+## Migration clock
+
+The one-year minimum starts on the release date of the first stable SDK that
+uses `/storage/{user-z32}/{storage-path}` by default. A merge, prerelease, or
+homeserver-only release does not start the clock.
+
+| Milestone | SDK version | UTC date |
+| --- | --- | --- |
+| First stable path-addressing SDK release | Not released ([#527](https://github.com/pubky/pubky-homeserver/issues/527)) | Not started |
+| Earliest legacy-removal review | Stable release version | Stable release date + one year |
+
+Update this table as part of publishing that stable SDK release.
+
+## Breaking-release review
+
+After the earliest review date:
+
+1. Collect path/legacy, `pubky-host`, and cookie/grant time-series from
+   participating operators, including recent usage and known coverage gaps.
+2. Record the evidence and maintainer decision in
+   [#529](https://github.com/pubky/pubky-homeserver/issues/529). The elapsed year
+   does not authorize removal automatically.
+3. If removal is approved, ship it as a coordinated breaking homeserver and SDK
+   release with upgrade requirements and release notes.
+4. If removal is not approved, keep compatibility and record the next review
+   date.

--- a/e2e/src/tests/metrics.rs
+++ b/e2e/src/tests/metrics.rs
@@ -1,4 +1,4 @@
-use pubky_testnet::pubky::{Keypair, Method, PubkyHttpClient, StatusCode};
+use pubky_testnet::pubky::{ClientId, Keypair, Method, PubkyHttpClient, StatusCode};
 
 /// Poll metrics endpoint until condition is met or timeout occurs
 async fn wait_for_metric_condition<F>(
@@ -63,7 +63,7 @@ async fn metrics_comprehensive() {
         .unwrap();
 
     // Extract values we need before getting SDK to avoid borrow conflicts
-    let (metrics_url, server_public_key, server_public_key_z32) = {
+    let (metrics_url, server_public_key, server_public_key_z32, icann_http_url) = {
         let server = testnet.homeserver_app();
 
         let metrics_server = server
@@ -73,8 +73,9 @@ async fn metrics_comprehensive() {
         let metrics_url = format!("http://{}/metrics", metrics_socket);
         let public_key = server.public_key().clone();
         let public_key_z32 = public_key.z32();
+        let icann_http_url = server.icann_http_url();
 
-        (metrics_url, public_key, public_key_z32)
+        (metrics_url, public_key, public_key_z32, icann_http_url)
     };
 
     let pubky = testnet.sdk().unwrap();
@@ -129,6 +130,30 @@ async fn metrics_comprehensive() {
         .put("/pub/test2.txt", vec![2])
         .await
         .unwrap();
+
+    // Exercise grant authentication on the canonical path-addressed route.
+    let grant_session = signer1
+        .signin(ClientId::new("metrics.test").unwrap())
+        .await
+        .unwrap();
+    let bearer = grant_session.as_grant().unwrap().current_bearer().await;
+    let grant_storage_path = "/pub/grant-metrics-secret.txt";
+    let response = pubky
+        .client()
+        .request(
+            Method::PUT,
+            &format!(
+                "{icann_http_url}storage/{}{}",
+                user_pubky1.z32(),
+                grant_storage_path
+            ),
+        )
+        .header("Authorization", format!("Bearer {bearer}"))
+        .body(vec![3])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
 
     // 3. Test concurrent stream connections to generate metrics
     let stream_url1 = format!(
@@ -266,4 +291,20 @@ async fn metrics_comprehensive() {
         "Should have exactly 2 signups recorded, metrics:\n{}",
         final_metrics
     );
+
+    let grant_sample = final_metrics
+        .lines()
+        .find(|line| {
+            line.starts_with("storage_request_count_total{")
+                && line.contains("addressing_mode=\"path\"")
+                && line.contains("auth_method=\"grant\"")
+        })
+        .expect("canonical grant storage request should be recorded");
+    assert!(
+        grant_sample.ends_with(" 1"),
+        "unexpected sample: {grant_sample}"
+    );
+    assert!(!final_metrics.contains(&bearer));
+    assert!(!final_metrics.contains(&user_pubky1.z32()));
+    assert!(!final_metrics.contains(grant_storage_path));
 }

--- a/pubky-homeserver/README.md
+++ b/pubky-homeserver/README.md
@@ -29,6 +29,7 @@ behavior.
 ## Architecture
 
 - [PKARR republishing](../docs/REPUBLISHING.md) — cache-first resolution, network fallback, and retry behavior.
+- [Storage-addressing migration](../docs/STORAGE_ADDRESSING_MIGRATION.md) — adoption metrics, migration clock, and legacy-removal review.
 
 ## Library Usage
 

--- a/pubky-homeserver/src/client_server/app.rs
+++ b/pubky-homeserver/src/client_server/app.rs
@@ -244,7 +244,7 @@ pub fn create_app(
         ));
 
     let app = base()
-        .merge(tenants::router())
+        .merge(tenants::router(context.metrics.clone()))
         .with_state(state)
         .merge(auth::base_router(auth_state.clone()))
         .merge(auth::tenant_router(auth_state))
@@ -334,6 +334,81 @@ mod tests {
         response.assert_header(header::CONTENT_TYPE, "application/json");
         response.assert_header(header::CACHE_CONTROL, "no-store");
         response.assert_json(&serde_json::json!({ "features": [] }));
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn storage_metrics_use_low_cardinality_labels_without_request_data() {
+        let data_dir = MockDataDir::new(ConfigToml::minimal_test_config(), None).unwrap();
+        let context = AppContext::read_from(data_dir).await.unwrap();
+        let metrics = context.metrics.clone();
+        let router = ClientServer::create_router(&context).unwrap();
+        let server = TestServer::new(router).unwrap();
+        let user = Keypair::random();
+        let cookie = signup_cookie(&server, &user).await;
+        let public_key = user.public_key().z32();
+        let unrelated_public_key = Keypair::random().public_key().z32();
+        let storage_path = "/pub/metrics-secret.txt";
+
+        server
+            .put(&format!(
+                "/storage/{public_key}{storage_path}?pubky-host={public_key}"
+            ))
+            .add_header("pubky-host", public_key.clone())
+            .add_header(header::COOKIE, cookie.clone())
+            .bytes(vec![1].into())
+            .expect_success()
+            .await;
+        server
+            .get(storage_path)
+            .add_header("pubky-host", public_key.clone())
+            .expect_success()
+            .await;
+        server
+            .get(&format!("/storage/{public_key}{storage_path}"))
+            .add_header("pubky-host", unrelated_public_key.clone())
+            .expect_success()
+            .await;
+        server
+            .get(&format!("{storage_path}?pubky-host={public_key}"))
+            .expect_success()
+            .await;
+
+        let output = metrics.render().unwrap();
+        let samples = output
+            .lines()
+            .filter(|line| line.starts_with("storage_request_count_total{"))
+            .collect::<Vec<_>>();
+
+        assert_eq!(samples.len(), 4, "unexpected metric samples:\n{output}");
+        assert!(samples.iter().any(|sample| {
+            sample.contains("addressing_mode=\"path\"")
+                && sample.contains("auth_method=\"cookie\"")
+                && sample.contains("pubky_host_header=\"matching\"")
+                && sample.contains("pubky_host_query=\"true\"")
+        }));
+        assert!(samples.iter().any(|sample| {
+            sample.contains("addressing_mode=\"legacy\"")
+                && sample.contains("auth_method=\"none\"")
+                && sample.contains("pubky_host_header=\"matching\"")
+                && sample.contains("pubky_host_query=\"false\"")
+        }));
+        assert!(samples.iter().any(|sample| {
+            sample.contains("addressing_mode=\"path\"")
+                && sample.contains("auth_method=\"none\"")
+                && sample.contains("pubky_host_header=\"other\"")
+                && sample.contains("pubky_host_query=\"false\"")
+        }));
+        assert!(samples.iter().any(|sample| {
+            sample.contains("addressing_mode=\"legacy\"")
+                && sample.contains("auth_method=\"none\"")
+                && sample.contains("pubky_host_header=\"absent\"")
+                && sample.contains("pubky_host_query=\"true\"")
+        }));
+        assert!(!output.contains(&public_key));
+        assert!(!output.contains(&unrelated_public_key));
+        assert!(!output.contains(storage_path));
+        assert!(!output.contains(&cookie));
     }
 
     async fn signup_cookie(server: &TestServer, keypair: &Keypair) -> String {

--- a/pubky-homeserver/src/client_server/app.rs
+++ b/pubky-homeserver/src/client_server/app.rs
@@ -338,7 +338,7 @@ mod tests {
 
     #[tokio::test]
     #[pubky_test_utils::test]
-    async fn storage_metrics_use_low_cardinality_labels_without_request_data() {
+    async fn storage_metrics_only_count_resolved_requests_with_low_cardinality_labels() {
         let data_dir = MockDataDir::new(ConfigToml::minimal_test_config(), None).unwrap();
         let context = AppContext::read_from(data_dir).await.unwrap();
         let metrics = context.metrics.clone();
@@ -373,6 +373,10 @@ mod tests {
             .get(&format!("{storage_path}?pubky-host={public_key}"))
             .expect_success()
             .await;
+        server
+            .get("/favicon.ico")
+            .await
+            .assert_status(StatusCode::BAD_REQUEST);
 
         let output = metrics.render().unwrap();
         let samples = output

--- a/pubky-homeserver/src/client_server/middleware/mod.rs
+++ b/pubky-homeserver/src/client_server/middleware/mod.rs
@@ -4,6 +4,7 @@
 //! - [`pubky_host`]: Compatibility resolver for legacy tenant addressing.
 //! - [`rate_limiter`]: Configurable per-path request rate limiting, keyed by IP or user,
 //!   with optional per-user speed overrides resolved from DB.
+//! - [`storage_metrics`]: Records low-cardinality storage migration metrics.
 //! - [`trace`]: Request/response logging via `tracing`.
 //!
 //! Authentication and authorization middleware live in [`crate::client_server::auth::middleware`].
@@ -11,4 +12,5 @@
 pub mod pubky_host;
 pub mod rate_limiter;
 pub mod request_tenant;
+pub mod storage_metrics;
 pub mod trace;

--- a/pubky-homeserver/src/client_server/middleware/storage_metrics.rs
+++ b/pubky-homeserver/src/client_server/middleware/storage_metrics.rs
@@ -1,0 +1,57 @@
+//! Migration metrics for path-addressed and legacy storage requests.
+
+use axum::{
+    extract::{Request, State},
+    middleware::Next,
+    response::Response,
+};
+use pubky_common::crypto::PublicKey;
+use url::form_urlencoded;
+
+use crate::{
+    client_server::{auth::AuthSession, middleware::request_tenant::RequestTenant},
+    observability::{Metrics, PubkyHostHeaderUsage, StorageAddressingMode, StorageAuthMethod},
+};
+
+pub(crate) async fn record_request(
+    State(metrics): State<Metrics>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let tenant = request.extensions().get::<RequestTenant>();
+    let addressing_mode = if tenant.and_then(RequestTenant::storage_path).is_some() {
+        StorageAddressingMode::Path
+    } else {
+        StorageAddressingMode::Legacy
+    };
+    let pubky_host_header = match request.headers().get("pubky-host") {
+        None => PubkyHostHeaderUsage::Absent,
+        Some(value)
+            if value
+                .to_str()
+                .ok()
+                .and_then(|value| PublicKey::try_from_z32(value).ok())
+                .zip(tenant)
+                .is_some_and(|(header, tenant)| &header == tenant.public_key()) =>
+        {
+            PubkyHostHeaderUsage::Matching
+        }
+        Some(_) => PubkyHostHeaderUsage::Other,
+    };
+    let pubky_host_query = request.uri().query().is_some_and(|query| {
+        form_urlencoded::parse(query.as_bytes()).any(|(key, _)| key == "pubky-host")
+    });
+    let auth_method = match request.extensions().get::<AuthSession>() {
+        Some(AuthSession::Cookie(_)) => StorageAuthMethod::Cookie,
+        Some(AuthSession::Grant(_)) => StorageAuthMethod::Grant,
+        None => StorageAuthMethod::None,
+    };
+
+    metrics.record_storage_request(
+        addressing_mode,
+        pubky_host_header,
+        pubky_host_query,
+        auth_method,
+    );
+    next.run(request).await
+}

--- a/pubky-homeserver/src/client_server/middleware/storage_metrics.rs
+++ b/pubky-homeserver/src/client_server/middleware/storage_metrics.rs
@@ -18,8 +18,10 @@ pub(crate) async fn record_request(
     request: Request,
     next: Next,
 ) -> Response {
-    let tenant = request.extensions().get::<RequestTenant>();
-    let addressing_mode = if tenant.and_then(RequestTenant::storage_path).is_some() {
+    let Some(tenant) = request.extensions().get::<RequestTenant>() else {
+        return next.run(request).await;
+    };
+    let addressing_mode = if tenant.storage_path().is_some() {
         StorageAddressingMode::Path
     } else {
         StorageAddressingMode::Legacy
@@ -31,8 +33,7 @@ pub(crate) async fn record_request(
                 .to_str()
                 .ok()
                 .and_then(|value| PublicKey::try_from_z32(value).ok())
-                .zip(tenant)
-                .is_some_and(|(header, tenant)| &header == tenant.public_key()) =>
+                .is_some_and(|header| &header == tenant.public_key()) =>
         {
             PubkyHostHeaderUsage::Matching
         }

--- a/pubky-homeserver/src/client_server/routes/tenants/mod.rs
+++ b/pubky-homeserver/src/client_server/routes/tenants/mod.rs
@@ -11,12 +11,15 @@
 
 use axum::{extract::DefaultBodyLimit, middleware, routing::get, Router};
 
-use crate::client_server::{cache_policy::private_cache_policy, AppState};
+use crate::client_server::{
+    cache_policy::private_cache_policy, middleware::storage_metrics, AppState,
+};
+use crate::observability::Metrics;
 
 pub mod read;
 pub mod write;
 
-pub fn router() -> Router<AppState> {
+pub fn router(metrics: Metrics) -> Router<AppState> {
     Router::new()
         .route(
             "/storage/{user_z32}/{*path}",
@@ -35,4 +38,8 @@ pub fn router() -> Router<AppState> {
         // TODO: different max size for sessions and other routes?
         .layer(DefaultBodyLimit::max(100 * 1024 * 1024))
         .layer(middleware::from_fn(private_cache_policy))
+        .layer(middleware::from_fn_with_state(
+            metrics,
+            storage_metrics::record_request,
+        ))
 }

--- a/pubky-homeserver/src/observability.rs
+++ b/pubky-homeserver/src/observability.rs
@@ -5,7 +5,10 @@
 //! server route. The `metrics_server` *serves* this over HTTP; subsystems (`persistence`,
 //! `client_server`, …) only *record* into it.
 
-use opentelemetry::metrics::{Counter, Histogram, Meter, MeterProvider, UpDownCounter};
+use opentelemetry::{
+    metrics::{Counter, Histogram, Meter, MeterProvider, UpDownCounter},
+    KeyValue,
+};
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use prometheus::{Encoder, Registry, TextEncoder};
 use std::sync::Arc;
@@ -25,6 +28,27 @@ pub const EVENT_STREAM_BROADCAST_HALF_FULL_COUNT: &str = "event_stream_broadcast
 pub const EVENT_STREAM_ACTIVE_CONNECTIONS: &str = "event_stream_active_connections";
 pub const EVENT_STREAM_CONNECTION_DURATION: &str = "event_stream_connection_duration_ms";
 pub const SIGNUP_COUNT: &str = "signup_count";
+pub const STORAGE_REQUEST_COUNT: &str = "storage_request_count";
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum StorageAddressingMode {
+    Path,
+    Legacy,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum PubkyHostHeaderUsage {
+    Absent,
+    Matching,
+    Other,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum StorageAuthMethod {
+    None,
+    Cookie,
+    Grant,
+}
 
 #[derive(Clone, Debug)]
 pub struct Metrics {
@@ -37,6 +61,7 @@ pub struct Metrics {
     event_stream_active_connections: UpDownCounter<i64>,
     event_stream_connection_duration: Histogram<f64>,
     signup_count: Counter<u64>,
+    storage_request_count: Counter<u64>,
 }
 
 impl Metrics {
@@ -81,6 +106,11 @@ impl Metrics {
             .with_description("Total number of successful signups")
             .build();
 
+        let storage_request_count = meter
+            .u64_counter(STORAGE_REQUEST_COUNT)
+            .with_description("Number of client storage requests by migration mode")
+            .build();
+
         Ok(Self {
             registry: Arc::new(registry),
             _provider: Arc::new(provider),
@@ -91,6 +121,7 @@ impl Metrics {
             event_stream_active_connections,
             event_stream_connection_duration,
             signup_count,
+            storage_request_count,
         })
     }
 
@@ -133,6 +164,41 @@ impl Metrics {
 
     pub fn record_signup(&self) {
         self.signup_count.add(1, &[]);
+    }
+
+    // === storage migration metrics ===
+
+    pub(crate) fn record_storage_request(
+        &self,
+        addressing_mode: StorageAddressingMode,
+        pubky_host_header: PubkyHostHeaderUsage,
+        pubky_host_query: bool,
+        auth_method: StorageAuthMethod,
+    ) {
+        let addressing_mode = match addressing_mode {
+            StorageAddressingMode::Path => "path",
+            StorageAddressingMode::Legacy => "legacy",
+        };
+        let pubky_host_header = match pubky_host_header {
+            PubkyHostHeaderUsage::Absent => "absent",
+            PubkyHostHeaderUsage::Matching => "matching",
+            PubkyHostHeaderUsage::Other => "other",
+        };
+        let auth_method = match auth_method {
+            StorageAuthMethod::None => "none",
+            StorageAuthMethod::Cookie => "cookie",
+            StorageAuthMethod::Grant => "grant",
+        };
+
+        self.storage_request_count.add(
+            1,
+            &[
+                KeyValue::new("addressing_mode", addressing_mode),
+                KeyValue::new("pubky_host_header", pubky_host_header),
+                KeyValue::new("pubky_host_query", pubky_host_query),
+                KeyValue::new("auth_method", auth_method),
+            ],
+        );
     }
 
     /// Render Prometheus metrics in text format
@@ -295,6 +361,12 @@ mod tests {
         metrics.record_broadcast_half_full();
         metrics.record_connection_closed(30);
         metrics.record_signup();
+        metrics.record_storage_request(
+            StorageAddressingMode::Path,
+            PubkyHostHeaderUsage::Matching,
+            true,
+            StorageAuthMethod::Cookie,
+        );
 
         let output = metrics.render().expect("Failed to render metrics");
 
@@ -344,5 +416,15 @@ mod tests {
             SIGNUP_COUNT,
             output
         );
+        assert!(
+            output.contains(STORAGE_REQUEST_COUNT),
+            "Missing {} in: {}",
+            STORAGE_REQUEST_COUNT,
+            output
+        );
+        assert!(output.contains("addressing_mode=\"path\""));
+        assert!(output.contains("auth_method=\"cookie\""));
+        assert!(output.contains("pubky_host_header=\"matching\""));
+        assert!(output.contains("pubky_host_query=\"true\""));
     }
 }


### PR DESCRIPTION
Closes #528.

### Summary

Adds `storage_request_count_total`, a counter for tracking the migration from legacy storage routes to `/storage/{user}/{path}`.

Each storage request is classified by:

| Label | Values |
|---|---|
| `addressing_mode` | `path`, `legacy` |
| `pubky_host_header` | `absent`, `matching`, `other` |
| `pubky_host_query` | `true`, `false` |
| `auth_method` | `none`, `cookie`, `grant` |

Metrics are recorded after tenant and authentication resolution, allowing matching `pubky-host` usage and cookie/grant authentication to be distinguished.

Adds an operator guide with PromQL examples, collection and retention requirements, and the breaking-release review process.

### Acceptance criteria

- [x] Path-addressed and legacy storage requests are counted separately.
- [x] `pubky-host` header usage is classified as absent, matching, or other.
- [x] `pubky-host` query-parameter usage is counted.
- [x] Cookie and grant authentication are measured separately.
- [x] Metrics contain only fixed, low-cardinality labels.
- [x] Tests verify that credentials, public keys, and storage paths are not exported.
- [x] Operators have queries for comparing migration adoption over time.
- [x] The migration clock and its dependency on #527 are documented.
- [x] The migration and breaking-release review process is documented.