### PR TITLE
refactor(homeserver): Services own their construction from `AppContext`

### DIFF
--- a/pubky-homeserver/src/admin_server/app.rs
+++ b/pubky-homeserver/src/admin_server/app.rs
@@ -48,7 +48,7 @@ fn create_public_router() -> Router<AppState> {
 
 /// Create the app
 pub(crate) fn create_app(state: AppState) -> axum::routing::IntoMakeService<Router> {
-    let admin_router = create_protected_router(&state.admin_password);
+    let admin_router = create_protected_router(state.admin_password());
     let public_router = create_public_router();
     let app = Router::new()
         .merge(admin_router)

--- a/pubky-homeserver/src/admin_server/app.rs
+++ b/pubky-homeserver/src/admin_server/app.rs
@@ -188,8 +188,7 @@ mod tests {
     }
 
     fn create_test_server(context: &AppContext) -> TestServer {
-        TestServer::new(create_app(AppState::new(context)))
-        .unwrap()
+        AppState::test_server(context)
     }
 
     /// Seed `paths` as PUT events for a fresh random user, returning that user's pubkey.
@@ -508,8 +507,7 @@ mod tests {
     async fn test_dav_put_quota_overflow_returns_500() {
         use pubky_common::crypto::Keypair;
 
-        let context =
-            AppContext::test_with_config(|c| c.storage.default_quota_mb = Some(1)).await;
+        let context = AppContext::test_with_config(|c| c.storage.default_quota_mb = Some(1)).await;
         let server = create_test_server(&context);
         let auth_value = auth_header();
 

--- a/pubky-homeserver/src/admin_server/app.rs
+++ b/pubky-homeserver/src/admin_server/app.rs
@@ -1,5 +1,6 @@
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 
 use super::routes::{
@@ -90,7 +91,7 @@ impl AdminServer {
         let context = AppContext::read_from(data_dir)
             .await
             .map_err(AdminServerBuildError::DataDir)?;
-        Self::start(&context).await
+        Self::start(Arc::new(context)).await
     }
 
     /// Create a new admin server from a data directory path.
@@ -105,12 +106,12 @@ impl AdminServer {
         let context = AppContext::read_from(mock_dir)
             .await
             .map_err(AdminServerBuildError::DataDir)?;
-        Self::start(&context).await
+        Self::start(Arc::new(context)).await
     }
 
     /// Run the admin server.
-    pub async fn start(context: &AppContext) -> Result<Self, AdminServerBuildError> {
-        let state = AppState::new(context);
+    pub async fn start(context: Arc<AppContext>) -> Result<Self, AdminServerBuildError> {
+        let state = AppState::new(Arc::clone(&context));
         let socket = context.config_toml.admin.listen_socket;
         let app = create_app(state);
         let listener = std::net::TcpListener::bind(socket)
@@ -188,7 +189,7 @@ mod tests {
         BandwidthQuota::from_str(s).unwrap()
     }
 
-    fn create_test_server(context: &AppContext) -> TestServer {
+    fn create_test_server(context: &Arc<AppContext>) -> TestServer {
         AppState::test_server(context)
     }
 

--- a/pubky-homeserver/src/admin_server/app.rs
+++ b/pubky-homeserver/src/admin_server/app.rs
@@ -177,6 +177,7 @@ mod tests {
     use base64::Engine;
     use pubky_common::crypto::Keypair;
 
+    use crate::admin_server::AdminAuthExt;
     use crate::data_directory::quota_config::BandwidthQuota;
     use crate::persistence::sql::signup_code::{SignupCode, SignupCodeRepository};
     use crate::shared::user_quota::UserQuota;
@@ -227,7 +228,7 @@ mod tests {
     async fn admin_stream_body(server: &TestServer, query: &str) -> String {
         let response = server
             .get(&format!("/events-stream{query}"))
-            .add_header("X-Admin-Password", "test")
+            .admin_auth()
             .expect_success()
             .await;
         response.assert_status_ok();
@@ -292,14 +293,14 @@ mod tests {
 
         let response = server
             .get("/generate_signup_token")
-            .add_header("X-Admin-Password", "test")
+            .admin_auth()
             .expect_success()
             .await;
         let token = response.text();
 
         let response = server
             .get("/signup_tokens")
-            .add_header("X-Admin-Password", "test")
+            .admin_auth()
             .expect_success()
             .await;
         response.assert_status_ok();
@@ -344,7 +345,7 @@ mod tests {
         // returns the last item in the page as the cursor.
         let response = server
             .get("/signup_tokens?state=unused&limit=1")
-            .add_header("X-Admin-Password", "test")
+            .admin_auth()
             .expect_success()
             .await;
         response.assert_status_ok();
@@ -358,7 +359,7 @@ mod tests {
         // Increasing the limit changes the page size and advances the cursor.
         let response = server
             .get("/signup_tokens?state=unused&limit=2")
-            .add_header("X-Admin-Password", "test")
+            .admin_auth()
             .expect_success()
             .await;
         response.assert_status_ok();
@@ -373,7 +374,7 @@ mod tests {
         // When the limit reaches all remaining unused tokens, there is no next page.
         let response = server
             .get("/signup_tokens?state=unused&limit=3")
-            .add_header("X-Admin-Password", "test")
+            .admin_auth()
             .expect_success()
             .await;
         response.assert_status_ok();
@@ -391,7 +392,7 @@ mod tests {
             .get(&format!(
                 "/signup_tokens?state=unused&limit=2&cursor={token2}"
             ))
-            .add_header("X-Admin-Password", "test")
+            .admin_auth()
             .expect_success()
             .await;
         response.assert_status_ok();
@@ -405,7 +406,7 @@ mod tests {
     }
 
     fn auth_header() -> String {
-        let auth = base64::engine::general_purpose::STANDARD.encode("admin:test");
+        let auth = base64::engine::general_purpose::STANDARD.encode("admin:admin");
         format!("Basic {auth}")
     }
 
@@ -553,7 +554,7 @@ mod tests {
         });
         let response = server
             .post("/generate_signup_token")
-            .add_header("X-Admin-Password", "test")
+            .admin_auth()
             .content_type("application/json")
             .bytes(serde_json::to_vec(&body).unwrap().into())
             .expect_success()
@@ -600,7 +601,7 @@ mod tests {
         ] {
             let response = server
                 .get(&format!("/events-stream{query}"))
-                .add_header("X-Admin-Password", "test")
+                .admin_auth()
                 .expect_failure()
                 .await;
             response.assert_status_bad_request();

--- a/pubky-homeserver/src/admin_server/app.rs
+++ b/pubky-homeserver/src/admin_server/app.rs
@@ -47,11 +47,8 @@ fn create_public_router() -> Router<AppState> {
 }
 
 /// Create the app
-pub(crate) fn create_app(
-    state: AppState,
-    password: &str,
-) -> axum::routing::IntoMakeService<Router> {
-    let admin_router = create_protected_router(password);
+pub(crate) fn create_app(state: AppState) -> axum::routing::IntoMakeService<Router> {
+    let admin_router = create_protected_router(&state.admin_password);
     let public_router = create_public_router();
     let app = Router::new()
         .merge(admin_router)
@@ -113,22 +110,9 @@ impl AdminServer {
 
     /// Run the admin server.
     pub async fn start(context: &AppContext) -> Result<Self, AdminServerBuildError> {
-        let password = context.config_toml.admin.admin_password.clone();
-        let state = AppState::new(
-            context.sql_db.clone(),
-            context.file_service.clone(),
-            &password,
-            context.user_service.clone(),
-            context.events_service.clone(),
-            context.metrics.clone(),
-        )
-        .with_metadata_from_config(
-            context.keypair.public_key().z32(),
-            &context.config_toml,
-            env!("CARGO_PKG_VERSION"),
-        );
+        let state = AppState::new(context);
         let socket = context.config_toml.admin.listen_socket;
-        let app = create_app(state, password.as_str());
+        let app = create_app(state);
         let listener = std::net::TcpListener::bind(socket)
             .map_err(|e| AdminServerBuildError::Server(e.into()))?;
         listener
@@ -152,7 +136,7 @@ impl AdminServer {
             http_handle,
             socket,
             join_handle,
-            password,
+            password: context.config_toml.admin.admin_password.clone(),
         })
     }
 
@@ -194,7 +178,6 @@ mod tests {
     use pubky_common::crypto::Keypair;
 
     use crate::data_directory::quota_config::BandwidthQuota;
-    use crate::persistence::files::FileService;
     use crate::persistence::sql::signup_code::{SignupCode, SignupCodeRepository};
     use crate::shared::user_quota::UserQuota;
 
@@ -205,17 +188,7 @@ mod tests {
     }
 
     fn create_test_server(context: &AppContext) -> TestServer {
-        TestServer::new(create_app(
-            AppState::new(
-                context.sql_db.clone(),
-                FileService::new_from_context(context).unwrap(),
-                "",
-                context.user_service.clone(),
-                context.events_service.clone(),
-                context.metrics.clone(),
-            ),
-            "test",
-        ))
+        TestServer::new(create_app(AppState::new(context)))
         .unwrap()
     }
 
@@ -433,8 +406,7 @@ mod tests {
     }
 
     fn auth_header() -> String {
-        // AppState is created with password "" in create_test_server
-        let auth = base64::engine::general_purpose::STANDARD.encode("admin:");
+        let auth = base64::engine::general_purpose::STANDARD.encode("admin:test");
         format!("Basic {auth}")
     }
 
@@ -536,8 +508,8 @@ mod tests {
     async fn test_dav_put_quota_overflow_returns_500() {
         use pubky_common::crypto::Keypair;
 
-        let mut context = AppContext::test().await;
-        context.config_toml.storage.default_quota_mb = Some(1);
+        let context =
+            AppContext::test_with_config(|c| c.storage.default_quota_mb = Some(1)).await;
         let server = create_test_server(&context);
         let auth_value = auth_header();
 

--- a/pubky-homeserver/src/admin_server/app_state.rs
+++ b/pubky-homeserver/src/admin_server/app_state.rs
@@ -4,20 +4,10 @@ use dav_server_opendalfs::OpendalFs;
 use crate::AppContext;
 use crate::ConfigToml;
 
-#[derive(Clone, Default)]
-pub(crate) struct AdminMetadata {
-    pub(crate) public_key: String,
-    pub(crate) pkarr_pubky_address: Option<String>,
-    pub(crate) pkarr_icann_domain: Option<String>,
-    pub(crate) version: String,
-}
-
 #[derive(Clone)]
 pub(crate) struct AppState {
     pub(crate) context: AppContext,
-    pub(crate) admin_password: String,
     pub(crate) inner_dav_handler: DavHandler,
-    pub(crate) metadata: AdminMetadata,
 }
 
 impl AppState {
@@ -30,16 +20,29 @@ impl AppState {
             .autoindex(true)
             .build_handler();
         Self {
-            admin_password: context.config_toml.admin.admin_password.clone(),
             inner_dav_handler,
-            metadata: AdminMetadata {
-                public_key: context.keypair.public_key().z32(),
-                pkarr_pubky_address: pkarr_pubky_tls_address(&context.config_toml),
-                pkarr_icann_domain: pkarr_icann_domain(&context.config_toml),
-                version: env!("CARGO_PKG_VERSION").to_string(),
-            },
             context: context.clone(),
         }
+    }
+
+    pub(crate) fn admin_password(&self) -> &str {
+        &self.context.config_toml.admin.admin_password
+    }
+
+    pub(crate) fn public_key(&self) -> String {
+        self.context.keypair.public_key().z32()
+    }
+
+    pub(crate) fn pkarr_pubky_address(&self) -> Option<String> {
+        pkarr_pubky_tls_address(&self.context.config_toml)
+    }
+
+    pub(crate) fn pkarr_icann_domain(&self) -> Option<String> {
+        pkarr_icann_domain(&self.context.config_toml)
+    }
+
+    pub(crate) fn version(&self) -> &'static str {
+        env!("CARGO_PKG_VERSION")
     }
 
     #[cfg(test)]

--- a/pubky-homeserver/src/admin_server/app_state.rs
+++ b/pubky-homeserver/src/admin_server/app_state.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use dav_server::{fakels::FakeLs, DavHandler};
 use dav_server_opendalfs::OpendalFs;
 
@@ -6,12 +8,12 @@ use crate::ConfigToml;
 
 #[derive(Clone)]
 pub(crate) struct AppState {
-    pub(crate) context: AppContext,
+    pub(crate) context: Arc<AppContext>,
     pub(crate) inner_dav_handler: DavHandler,
 }
 
 impl AppState {
-    pub fn new(context: &AppContext) -> Self {
+    pub fn new(context: Arc<AppContext>) -> Self {
         let webdavfs = OpendalFs::new(context.file_service.opendal.admin_operator.clone());
         let inner_dav_handler = DavHandler::builder()
             .filesystem(webdavfs)
@@ -21,7 +23,7 @@ impl AppState {
             .build_handler();
         Self {
             inner_dav_handler,
-            context: context.clone(),
+            context,
         }
     }
 
@@ -46,8 +48,8 @@ impl AppState {
     }
 
     #[cfg(test)]
-    pub(crate) fn test_server(context: &AppContext) -> axum_test::TestServer {
-        axum_test::TestServer::new(super::app::create_app(Self::new(context))).unwrap()
+    pub(crate) fn test_server(context: &Arc<AppContext>) -> axum_test::TestServer {
+        axum_test::TestServer::new(super::app::create_app(Self::new(Arc::clone(context)))).unwrap()
     }
 }
 

--- a/pubky-homeserver/src/admin_server/app_state.rs
+++ b/pubky-homeserver/src/admin_server/app_state.rs
@@ -1,13 +1,7 @@
 use dav_server::{fakels::FakeLs, DavHandler};
 use dav_server_opendalfs::OpendalFs;
 
-use crate::data_directory::DefaultQuotasToml;
-use crate::observability::Metrics;
-use crate::persistence::{
-    files::{events::EventsService, FileService},
-    sql::SqlDb,
-};
-use crate::services::user_service::UserService;
+use crate::AppContext;
 use crate::ConfigToml;
 
 #[derive(Clone, Default)]
@@ -20,25 +14,15 @@ pub(crate) struct AdminMetadata {
 
 #[derive(Clone)]
 pub(crate) struct AppState {
-    pub(crate) sql_db: SqlDb,
-    pub(crate) file_service: FileService,
+    pub(crate) context: AppContext,
     pub(crate) admin_password: String,
     pub(crate) inner_dav_handler: DavHandler,
     pub(crate) metadata: AdminMetadata,
-    pub(crate) user_service: UserService,
-    /// Event service for the admin all-events stream.
-    pub(crate) events_service: EventsService,
-    /// Metrics shared with the rest of the homeserver.
-    pub(crate) metrics: Metrics,
-    /// System-wide default quotas for resolving effective values.
-    pub(crate) default_storage_mb: Option<u64>,
-    pub(crate) default_quotas: DefaultQuotasToml,
 }
 
 impl AppState {
-    pub fn new(context: &crate::AppContext) -> Self {
-        let file_service = context.file_service.clone();
-        let webdavfs = OpendalFs::new(file_service.opendal.admin_operator.clone());
+    pub fn new(context: &AppContext) -> Self {
+        let webdavfs = OpendalFs::new(context.file_service.opendal.admin_operator.clone());
         let inner_dav_handler = DavHandler::builder()
             .filesystem(webdavfs)
             .locksystem(FakeLs::new())
@@ -46,8 +30,6 @@ impl AppState {
             .autoindex(true)
             .build_handler();
         Self {
-            sql_db: context.sql_db.clone(),
-            file_service,
             admin_password: context.config_toml.admin.admin_password.clone(),
             inner_dav_handler,
             metadata: AdminMetadata {
@@ -56,16 +38,12 @@ impl AppState {
                 pkarr_icann_domain: pkarr_icann_domain(&context.config_toml),
                 version: env!("CARGO_PKG_VERSION").to_string(),
             },
-            user_service: context.user_service.clone(),
-            events_service: context.events_service.clone(),
-            metrics: context.metrics.clone(),
-            default_storage_mb: context.config_toml.storage.default_quota_mb,
-            default_quotas: context.config_toml.default_quotas.clone(),
+            context: context.clone(),
         }
     }
 
     #[cfg(test)]
-    pub(crate) fn test_server(context: &crate::AppContext) -> axum_test::TestServer {
+    pub(crate) fn test_server(context: &AppContext) -> axum_test::TestServer {
         axum_test::TestServer::new(super::app::create_app(Self::new(context))).unwrap()
     }
 }

--- a/pubky-homeserver/src/admin_server/app_state.rs
+++ b/pubky-homeserver/src/admin_server/app_state.rs
@@ -36,14 +36,8 @@ pub(crate) struct AppState {
 }
 
 impl AppState {
-    pub fn new(
-        sql_db: SqlDb,
-        file_service: FileService,
-        admin_password: &str,
-        user_service: UserService,
-        events_service: EventsService,
-        metrics: Metrics,
-    ) -> Self {
+    pub fn new(context: &crate::AppContext) -> Self {
+        let file_service = context.file_service.clone();
         let webdavfs = OpendalFs::new(file_service.opendal.admin_operator.clone());
         let inner_dav_handler = DavHandler::builder()
             .filesystem(webdavfs)
@@ -52,35 +46,24 @@ impl AppState {
             .autoindex(true)
             .build_handler();
         Self {
-            sql_db,
+            sql_db: context.sql_db.clone(),
             file_service,
-            admin_password: admin_password.to_string(),
+            admin_password: context.config_toml.admin.admin_password.clone(),
             inner_dav_handler,
-            metadata: AdminMetadata::default(),
-            user_service,
-            events_service,
-            metrics,
-            default_storage_mb: None,
-            default_quotas: DefaultQuotasToml::default(),
+            metadata: AdminMetadata {
+                public_key: context.keypair.public_key().z32(),
+                pkarr_pubky_address: pkarr_pubky_tls_address(&context.config_toml),
+                pkarr_icann_domain: pkarr_icann_domain(&context.config_toml),
+                version: env!("CARGO_PKG_VERSION").to_string(),
+            },
+            user_service: context.user_service.clone(),
+            events_service: context.events_service.clone(),
+            metrics: context.metrics.clone(),
+            default_storage_mb: context.config_toml.storage.default_quota_mb,
+            default_quotas: context.config_toml.default_quotas.clone(),
         }
     }
 
-    pub fn with_metadata_from_config(
-        mut self,
-        public_key: String,
-        config: &ConfigToml,
-        version: &str,
-    ) -> Self {
-        self.metadata = AdminMetadata {
-            public_key,
-            pkarr_pubky_address: pkarr_pubky_tls_address(config),
-            pkarr_icann_domain: pkarr_icann_domain(config),
-            version: version.to_string(),
-        };
-        self.default_storage_mb = config.storage.default_quota_mb;
-        self.default_quotas = config.default_quotas.clone();
-        self
-    }
 }
 
 fn pkarr_pubky_tls_address(config: &ConfigToml) -> Option<String> {

--- a/pubky-homeserver/src/admin_server/app_state.rs
+++ b/pubky-homeserver/src/admin_server/app_state.rs
@@ -64,6 +64,10 @@ impl AppState {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn test_server(context: &crate::AppContext) -> axum_test::TestServer {
+        axum_test::TestServer::new(super::app::create_app(Self::new(context))).unwrap()
+    }
 }
 
 fn pkarr_pubky_tls_address(config: &ConfigToml) -> Option<String> {

--- a/pubky-homeserver/src/admin_server/mod.rs
+++ b/pubky-homeserver/src/admin_server/mod.rs
@@ -11,3 +11,16 @@ mod routes;
 mod trace;
 
 pub use app::{AdminServer, AdminServerBuildError};
+
+/// Extension trait to add the default admin password header to test requests.
+#[cfg(test)]
+pub(crate) trait AdminAuthExt {
+    fn admin_auth(self) -> Self;
+}
+
+#[cfg(test)]
+impl AdminAuthExt for axum_test::TestRequest {
+    fn admin_auth(self) -> Self {
+        self.add_header("X-Admin-Password", "admin")
+    }
+}

--- a/pubky-homeserver/src/admin_server/routes/admin_events.rs
+++ b/pubky-homeserver/src/admin_server/routes/admin_events.rs
@@ -141,10 +141,15 @@ async fn resolve_filter(
     } else {
         let mut ids = Vec::with_capacity(params.users.len());
         for pk in &params.users {
-            let id = state.user_service.get_id(pk).await.map_err(|e| match e {
-                sqlx::Error::RowNotFound => HttpError::not_found(),
-                e => HttpError::from(e),
-            })?;
+            let id = state
+                .context
+                .user_service
+                .get_id(pk)
+                .await
+                .map_err(|e| match e {
+                    sqlx::Error::RowNotFound => HttpError::not_found(),
+                    e => HttpError::from(e),
+                })?;
             ids.push(id);
         }
         Some(ids)
@@ -153,8 +158,9 @@ async fn resolve_filter(
     let start_cursor = match params.cursor.as_deref() {
         Some(c) => Some(
             state
+                .context
                 .events_service
-                .parse_cursor(c, &mut state.sql_db.pool().into())
+                .parse_cursor(c, &mut state.context.sql_db.pool().into())
                 .await
                 .map_err(|_| HttpError::bad_request("Invalid cursor"))?,
         ),
@@ -182,8 +188,13 @@ pub async fn feed_stream(
 
     let sse = Sse::new(
         state
+            .context
             .events_service
-            .all_events_stream(state.sql_db.clone(), state.metrics.clone(), filter)
+            .all_events_stream(
+                state.context.sql_db.clone(),
+                state.context.metrics.clone(),
+                filter,
+            )
             .map(|event| {
                 Ok::<_, Infallible>(
                     Event::default()

--- a/pubky-homeserver/src/admin_server/routes/dav_handler.rs
+++ b/pubky-homeserver/src/admin_server/routes/dav_handler.rs
@@ -15,7 +15,7 @@ pub async fn dav_handler(
     State(state): State<AppState>,
     req: Request<Body>,
 ) -> HttpResult<impl IntoResponse> {
-    if !is_valid_authorization_header(req.headers(), &state.admin_password) {
+    if !is_valid_authorization_header(req.headers(), state.admin_password()) {
         return Ok(Response::builder()
             .status(401)
             .header("WWW-Authenticate", "Basic") // This header will trigger the browser to show the login dialog

--- a/pubky-homeserver/src/admin_server/routes/delete_entry.rs
+++ b/pubky-homeserver/src/admin_server/routes/delete_entry.rs
@@ -45,15 +45,8 @@ mod tests {
         let pubkey = keypair.public_key();
         let file_path = "my_file.txt";
         let db = context.sql_db.clone();
-        let file_service = FileService::new_from_context(&context).unwrap();
-        let app_state = AppState::new(
-            context.sql_db.clone(),
-            file_service.clone(),
-            "",
-            context.user_service.clone(),
-            context.events_service.clone(),
-            context.metrics.clone(),
-        );
+        let file_service = context.file_service.clone();
+        let app_state = AppState::new(&context);
         let router = Router::new()
             .route("/webdav/{*entry_path}", delete(delete_entry))
             .with_state(app_state);
@@ -108,14 +101,7 @@ mod tests {
         let keypair = Keypair::from_secret(&[0; 32]);
         let pubkey = keypair.public_key();
         let file_path = "my_file.txt";
-        let app_state = AppState::new(
-            context.sql_db.clone(),
-            FileService::new_from_context(&context).unwrap(),
-            "",
-            context.user_service.clone(),
-            context.events_service.clone(),
-            context.metrics.clone(),
-        );
+        let app_state = AppState::new(&context);
         let router = Router::new()
             .route("/webdav/{*entry_path}", delete(delete_entry))
             .with_state(app_state);
@@ -133,15 +119,7 @@ mod tests {
         // Set everything up
         let context = AppContext::test().await;
 
-        let sql_db = context.sql_db.clone();
-        let app_state = AppState::new(
-            sql_db.clone(),
-            FileService::new_from_context(&context).unwrap(),
-            "",
-            context.user_service.clone(),
-            context.events_service.clone(),
-            context.metrics.clone(),
-        );
+        let app_state = AppState::new(&context);
         let router = Router::new()
             .route("/webdav/{*entry_path}", delete(delete_entry))
             .with_state(app_state);

--- a/pubky-homeserver/src/admin_server/routes/delete_entry.rs
+++ b/pubky-homeserver/src/admin_server/routes/delete_entry.rs
@@ -11,7 +11,11 @@ pub async fn delete_entry(
     State(state): State<AppState>,
     Path(entry_path): Path<EntryPathPub>,
 ) -> HttpResult<impl IntoResponse> {
-    state.file_service.admin_delete(entry_path.inner()).await?;
+    state
+        .context
+        .file_service
+        .admin_delete(entry_path.inner())
+        .await?;
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/pubky-homeserver/src/admin_server/routes/delete_entry.rs
+++ b/pubky-homeserver/src/admin_server/routes/delete_entry.rs
@@ -21,6 +21,8 @@ pub async fn delete_entry(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::super::super::app_state::AppState;
     use super::*;
     use crate::persistence::files::{
@@ -50,7 +52,7 @@ mod tests {
         let file_path = "my_file.txt";
         let db = context.sql_db.clone();
         let file_service = context.file_service.clone();
-        let app_state = AppState::new(&context);
+        let app_state = AppState::new(Arc::clone(&context));
         let router = Router::new()
             .route("/webdav/{*entry_path}", delete(delete_entry))
             .with_state(app_state);
@@ -105,7 +107,7 @@ mod tests {
         let keypair = Keypair::from_secret(&[0; 32]);
         let pubkey = keypair.public_key();
         let file_path = "my_file.txt";
-        let app_state = AppState::new(&context);
+        let app_state = AppState::new(Arc::clone(&context));
         let router = Router::new()
             .route("/webdav/{*entry_path}", delete(delete_entry))
             .with_state(app_state);
@@ -123,7 +125,7 @@ mod tests {
         // Set everything up
         let context = AppContext::test().await;
 
-        let app_state = AppState::new(&context);
+        let app_state = AppState::new(Arc::clone(&context));
         let router = Router::new()
             .route("/webdav/{*entry_path}", delete(delete_entry))
             .with_state(app_state);

--- a/pubky-homeserver/src/admin_server/routes/disable_users.rs
+++ b/pubky-homeserver/src/admin_server/routes/disable_users.rs
@@ -17,7 +17,7 @@ pub async fn disable_user(
     State(state): State<AppState>,
     Path(pubkey): Path<Z32Pubkey>,
 ) -> HttpResult<impl IntoResponse> {
-    state.user_service.admin_disable(&pubkey.0).await?;
+    state.context.user_service.admin_disable(&pubkey.0).await?;
     Ok((StatusCode::OK, "Ok"))
 }
 
@@ -32,7 +32,7 @@ pub async fn enable_user(
     State(state): State<AppState>,
     Path(pubkey): Path<Z32Pubkey>,
 ) -> HttpResult<impl IntoResponse> {
-    state.user_service.admin_enable(&pubkey.0).await?;
+    state.context.user_service.admin_enable(&pubkey.0).await?;
     Ok((StatusCode::OK, "Ok"))
 }
 

--- a/pubky-homeserver/src/admin_server/routes/disable_users.rs
+++ b/pubky-homeserver/src/admin_server/routes/disable_users.rs
@@ -40,7 +40,7 @@ pub async fn enable_user(
 mod tests {
     use super::super::super::app_state::AppState;
     use super::*;
-    use crate::{persistence::files::FileService, AppContext};
+    use crate::AppContext;
     use axum::routing::post;
     use axum::Router;
     use pubky_common::crypto::Keypair;
@@ -59,14 +59,7 @@ mod tests {
         assert!(!user.disabled);
 
         // Setup server
-        let app_state = AppState::new(
-            context.sql_db.clone(),
-            FileService::new_from_context(&context).unwrap(),
-            "",
-            context.user_service.clone(),
-            context.events_service.clone(),
-            context.metrics.clone(),
-        );
+        let app_state = AppState::new(&context);
         let router = Router::new()
             .route("/users/{pubkey}/disable", post(disable_user))
             .route("/users/{pubkey}/enable", post(enable_user))

--- a/pubky-homeserver/src/admin_server/routes/disable_users.rs
+++ b/pubky-homeserver/src/admin_server/routes/disable_users.rs
@@ -38,6 +38,8 @@ pub async fn enable_user(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::super::super::app_state::AppState;
     use super::*;
     use crate::AppContext;
@@ -59,7 +61,7 @@ mod tests {
         assert!(!user.disabled);
 
         // Setup server
-        let app_state = AppState::new(&context);
+        let app_state = AppState::new(Arc::clone(&context));
         let router = Router::new()
             .route("/users/{pubkey}/disable", post(disable_user))
             .route("/users/{pubkey}/enable", post(enable_user))

--- a/pubky-homeserver/src/admin_server/routes/generate_signup_token.rs
+++ b/pubky-homeserver/src/admin_server/routes/generate_signup_token.rs
@@ -12,7 +12,7 @@ async fn create_signup_code(state: &AppState, limits: &UserQuota) -> HttpResult<
     let code = SignupCodeRepository::create(
         &SignupCode::random(),
         limits,
-        &mut state.sql_db.pool().into(),
+        &mut state.context.sql_db.pool().into(),
     )
     .await?;
     Ok((StatusCode::OK, code.id.0))

--- a/pubky-homeserver/src/admin_server/routes/info.rs
+++ b/pubky-homeserver/src/admin_server/routes/info.rs
@@ -30,10 +30,10 @@ pub async fn info(State(state): State<AppState>) -> HttpResult<(StatusCode, Json
         total_disk_used_mb: user_overview.total_used_mb,
         num_signup_codes: signup_code_overview.num_signup_codes,
         num_unused_signup_codes: signup_code_overview.num_unused_signup_codes,
-        public_key: state.metadata.public_key.clone(),
-        pkarr_pubky_address: state.metadata.pkarr_pubky_address.clone(),
-        pkarr_icann_domain: state.metadata.pkarr_icann_domain.clone(),
-        version: state.metadata.version.clone(),
+        public_key: state.public_key(),
+        pkarr_pubky_address: state.pkarr_pubky_address(),
+        pkarr_icann_domain: state.pkarr_icann_domain(),
+        version: state.version().to_string(),
     };
 
     Ok((StatusCode::OK, Json(body)))

--- a/pubky-homeserver/src/admin_server/routes/info.rs
+++ b/pubky-homeserver/src/admin_server/routes/info.rs
@@ -14,7 +14,7 @@ pub(crate) struct InfoResponse {
     public_key: String,
     pkarr_pubky_address: Option<String>,
     pkarr_icann_domain: Option<String>,
-    version: String,
+    version: &'static str,
 }
 
 /// Return summary statistics about the homeserver.
@@ -33,7 +33,7 @@ pub async fn info(State(state): State<AppState>) -> HttpResult<(StatusCode, Json
         public_key: state.public_key(),
         pkarr_pubky_address: state.pkarr_pubky_address(),
         pkarr_icann_domain: state.pkarr_icann_domain(),
-        version: state.version().to_string(),
+        version: state.version(),
     };
 
     Ok((StatusCode::OK, Json(body)))

--- a/pubky-homeserver/src/admin_server/routes/info.rs
+++ b/pubky-homeserver/src/admin_server/routes/info.rs
@@ -19,9 +19,9 @@ pub(crate) struct InfoResponse {
 
 /// Return summary statistics about the homeserver.
 pub async fn info(State(state): State<AppState>) -> HttpResult<(StatusCode, Json<InfoResponse>)> {
-    let user_overview = state.user_service.get_overview().await?;
+    let user_overview = state.context.user_service.get_overview().await?;
     let signup_code_overview =
-        SignupCodeRepository::get_overview(&mut state.sql_db.pool().into()).await?;
+        SignupCodeRepository::get_overview(&mut state.context.sql_db.pool().into()).await?;
 
     // Build response
     let body = InfoResponse {

--- a/pubky-homeserver/src/admin_server/routes/signup_tokens.rs
+++ b/pubky-homeserver/src/admin_server/routes/signup_tokens.rs
@@ -82,6 +82,7 @@ mod tests {
     use axum_test::TestServer;
 
     use super::*;
+    use crate::admin_server::AdminAuthExt;
     use crate::{
         persistence::sql::signup_code::{SignupCode, SignupCodeRepository},
         shared::user_quota::UserQuota,
@@ -102,7 +103,7 @@ mod tests {
 
         let response = server
             .get("/generate_signup_token")
-            .add_header("X-Admin-Password", "test")
+            .admin_auth()
             .expect_success()
             .await;
         let token = response.text();
@@ -115,7 +116,7 @@ mod tests {
 
         let response = server
             .get("/signup_tokens")
-            .add_header("X-Admin-Password", "test")
+            .admin_auth()
             .expect_success()
             .await;
         response.assert_status_ok();
@@ -138,13 +139,13 @@ mod tests {
 
         let used_token = server
             .get("/generate_signup_token")
-            .add_header("X-Admin-Password", "test")
+            .admin_auth()
             .expect_success()
             .await
             .text();
         let unused_token = server
             .get("/generate_signup_token")
-            .add_header("X-Admin-Password", "test")
+            .admin_auth()
             .expect_success()
             .await
             .text();
@@ -161,7 +162,7 @@ mod tests {
 
         let response = server
             .get("/signup_tokens?state=used")
-            .add_header("X-Admin-Password", "test")
+            .admin_auth()
             .expect_success()
             .await;
         let body: serde_json::Value = response.json();
@@ -171,7 +172,7 @@ mod tests {
 
         let response = server
             .get("/signup_tokens?state=unused")
-            .add_header("X-Admin-Password", "test")
+            .admin_auth()
             .expect_success()
             .await;
         let body: serde_json::Value = response.json();
@@ -181,7 +182,7 @@ mod tests {
 
         let response = server
             .get("/signup_tokens?state=all")
-            .add_header("X-Admin-Password", "test")
+            .admin_auth()
             .expect_success()
             .await;
         let body: serde_json::Value = response.json();
@@ -209,7 +210,7 @@ mod tests {
 
         let response = server
             .get("/signup_tokens?limit=2")
-            .add_header("X-Admin-Password", "test")
+            .admin_auth()
             .expect_success()
             .await;
         let body: serde_json::Value = response.json();
@@ -221,7 +222,7 @@ mod tests {
 
         let response = server
             .get(&format!("/signup_tokens?limit=2&cursor={token2}"))
-            .add_header("X-Admin-Password", "test")
+            .admin_auth()
             .expect_success()
             .await;
         let body: serde_json::Value = response.json();
@@ -239,21 +240,21 @@ mod tests {
 
         let response = server
             .get("/signup_tokens?state=unknown")
-            .add_header("X-Admin-Password", "test")
+            .admin_auth()
             .expect_failure()
             .await;
         response.assert_status_bad_request();
 
         let response = server
             .get("/signup_tokens?cursor=invalid")
-            .add_header("X-Admin-Password", "test")
+            .admin_auth()
             .expect_failure()
             .await;
         response.assert_status_bad_request();
 
         let response = server
             .get("/signup_tokens?limit=0")
-            .add_header("X-Admin-Password", "test")
+            .admin_auth()
             .expect_failure()
             .await;
         response.assert_status_bad_request();

--- a/pubky-homeserver/src/admin_server/routes/signup_tokens.rs
+++ b/pubky-homeserver/src/admin_server/routes/signup_tokens.rs
@@ -64,7 +64,8 @@ pub async fn list_signup_tokens(
     Query(params): Query<SignupTokensQuery>,
 ) -> HttpResult<(StatusCode, Json<SignupTokensResponse>)> {
     let page =
-        SignupCodeRepository::list(params.list_query(), &mut state.sql_db.pool().into()).await?;
+        SignupCodeRepository::list(params.list_query(), &mut state.context.sql_db.pool().into())
+            .await?;
     let items = page.items.into_iter().map(SignupTokenItem::from).collect();
 
     Ok((

--- a/pubky-homeserver/src/admin_server/routes/signup_tokens.rs
+++ b/pubky-homeserver/src/admin_server/routes/signup_tokens.rs
@@ -82,14 +82,13 @@ mod tests {
 
     use super::*;
     use crate::{
-        admin_server::app::create_app,
         persistence::sql::signup_code::{SignupCode, SignupCodeRepository},
         shared::user_quota::UserQuota,
         AppContext,
     };
 
     fn create_test_server(context: &AppContext) -> TestServer {
-        TestServer::new(create_app(AppState::new(context))).unwrap()
+        AppState::test_server(context)
     }
 
     #[tokio::test]

--- a/pubky-homeserver/src/admin_server/routes/signup_tokens.rs
+++ b/pubky-homeserver/src/admin_server/routes/signup_tokens.rs
@@ -83,27 +83,13 @@ mod tests {
     use super::*;
     use crate::{
         admin_server::app::create_app,
-        persistence::{
-            files::FileService,
-            sql::signup_code::{SignupCode, SignupCodeRepository},
-        },
+        persistence::sql::signup_code::{SignupCode, SignupCodeRepository},
         shared::user_quota::UserQuota,
         AppContext,
     };
 
     fn create_test_server(context: &AppContext) -> TestServer {
-        TestServer::new(create_app(
-            AppState::new(
-                context.sql_db.clone(),
-                FileService::new_from_context(context).unwrap(),
-                "",
-                context.user_service.clone(),
-                context.events_service.clone(),
-                context.metrics.clone(),
-            ),
-            "test",
-        ))
-        .unwrap()
+        TestServer::new(create_app(AppState::new(context))).unwrap()
     }
 
     #[tokio::test]

--- a/pubky-homeserver/src/admin_server/routes/signup_tokens.rs
+++ b/pubky-homeserver/src/admin_server/routes/signup_tokens.rs
@@ -79,6 +79,8 @@ pub async fn list_signup_tokens(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use axum_test::TestServer;
 
     use super::*;
@@ -89,7 +91,7 @@ mod tests {
         AppContext,
     };
 
-    fn create_test_server(context: &AppContext) -> TestServer {
+    fn create_test_server(context: &Arc<AppContext>) -> TestServer {
         AppState::test_server(context)
     }
 

--- a/pubky-homeserver/src/admin_server/routes/user_quota.rs
+++ b/pubky-homeserver/src/admin_server/routes/user_quota.rs
@@ -85,6 +85,7 @@ mod tests {
     use pubky_common::crypto::Keypair;
 
     use super::*;
+    use crate::admin_server::AdminAuthExt;
     use crate::data_directory::quota_config::BandwidthQuota;
     use crate::AppContext;
 
@@ -104,11 +105,7 @@ mod tests {
         let url = format!("/users/{}/quota", pubkey.z32());
 
         // GET fresh user: overrides empty, effective all "unlimited" (no system defaults)
-        let response = server
-            .get(&url)
-            .add_header("X-Admin-Password", "test")
-            .expect_success()
-            .await;
+        let response = server.get(&url).admin_auth().expect_success().await;
         response.assert_status_ok();
         let json: serde_json::Value = response.json();
         assert_eq!(json["overrides"], serde_json::json!({}));
@@ -123,18 +120,14 @@ mod tests {
         });
         server
             .patch(&url)
-            .add_header("X-Admin-Password", "test")
+            .admin_auth()
             .content_type("application/json")
             .bytes(serde_json::to_vec(&body).unwrap().into())
             .expect_success()
             .await;
 
         // GET after PATCH: effective shows overrides + defaults, overrides shows only patched
-        let response = server
-            .get(&url)
-            .add_header("X-Admin-Password", "test")
-            .expect_success()
-            .await;
+        let response = server.get(&url).admin_auth().expect_success().await;
         let json: serde_json::Value = response.json();
         assert_eq!(json["effective"]["storage_quota_mb"], 500);
         assert_eq!(json["effective"]["rate_read"], "100mb/m");
@@ -151,18 +144,14 @@ mod tests {
         });
         server
             .patch(&url)
-            .add_header("X-Admin-Password", "test")
+            .admin_auth()
             .content_type("application/json")
             .bytes(serde_json::to_vec(&body).unwrap().into())
             .expect_success()
             .await;
 
         // GET after reset: overrides empty again
-        let response = server
-            .get(&url)
-            .add_header("X-Admin-Password", "test")
-            .expect_success()
-            .await;
+        let response = server.get(&url).admin_auth().expect_success().await;
         let json: serde_json::Value = response.json();
         assert_eq!(json["overrides"], serde_json::json!({}));
     }
@@ -185,11 +174,7 @@ mod tests {
         let url = format!("/users/{}/quota", pubkey.z32());
 
         // Fresh user: effective shows system defaults, overrides empty
-        let response = server
-            .get(&url)
-            .add_header("X-Admin-Password", "test")
-            .expect_success()
-            .await;
+        let response = server.get(&url).admin_auth().expect_success().await;
         let json: serde_json::Value = response.json();
         assert_eq!(json["effective"]["storage_quota_mb"], 100);
         assert_eq!(json["effective"]["rate_read"], "10mb/s");
@@ -200,18 +185,14 @@ mod tests {
         let body = serde_json::json!({"storage_quota_mb": 500});
         server
             .patch(&url)
-            .add_header("X-Admin-Password", "test")
+            .admin_auth()
             .content_type("application/json")
             .bytes(serde_json::to_vec(&body).unwrap().into())
             .expect_success()
             .await;
 
         // effective: storage overridden, rates still show system defaults
-        let response = server
-            .get(&url)
-            .add_header("X-Admin-Password", "test")
-            .expect_success()
-            .await;
+        let response = server.get(&url).admin_auth().expect_success().await;
         let json: serde_json::Value = response.json();
         assert_eq!(json["effective"]["storage_quota_mb"], 500);
         assert_eq!(json["effective"]["rate_read"], "10mb/s");
@@ -223,18 +204,14 @@ mod tests {
         let body = serde_json::json!({"rate_read": "unlimited"});
         server
             .patch(&url)
-            .add_header("X-Admin-Password", "test")
+            .admin_auth()
             .content_type("application/json")
             .bytes(serde_json::to_vec(&body).unwrap().into())
             .expect_success()
             .await;
 
         // effective: unlimited overrides the system default
-        let response = server
-            .get(&url)
-            .add_header("X-Admin-Password", "test")
-            .expect_success()
-            .await;
+        let response = server.get(&url).admin_auth().expect_success().await;
         let json: serde_json::Value = response.json();
         assert_eq!(json["effective"]["storage_quota_mb"], 500);
         assert_eq!(json["effective"]["rate_read"], "unlimited");
@@ -261,7 +238,7 @@ mod tests {
         });
         let response = server
             .patch(&url)
-            .add_header("X-Admin-Password", "test")
+            .admin_auth()
             .content_type("application/json")
             .bytes(serde_json::to_vec(&body).unwrap().into())
             .expect_failure()
@@ -278,11 +255,7 @@ mod tests {
 
         let url = format!("/users/{}/quota", pubkey.z32());
 
-        let response = server
-            .get(&url)
-            .add_header("X-Admin-Password", "test")
-            .expect_failure()
-            .await;
+        let response = server.get(&url).admin_auth().expect_failure().await;
         response.assert_status(axum::http::StatusCode::NOT_FOUND);
     }
 
@@ -304,17 +277,13 @@ mod tests {
         });
         server
             .patch(&url)
-            .add_header("X-Admin-Password", "test")
+            .admin_auth()
             .content_type("application/json")
             .bytes(serde_json::to_vec(&body).unwrap().into())
             .expect_success()
             .await;
 
-        let response = server
-            .get(&url)
-            .add_header("X-Admin-Password", "test")
-            .expect_success()
-            .await;
+        let response = server.get(&url).admin_auth().expect_success().await;
         let json: serde_json::Value = response.json();
         // Unlimited → present as "unlimited" in overrides
         assert_eq!(json["overrides"]["rate_read"], "unlimited");
@@ -343,7 +312,7 @@ mod tests {
         });
         server
             .patch(&url)
-            .add_header("X-Admin-Password", "test")
+            .admin_auth()
             .content_type("application/json")
             .bytes(serde_json::to_vec(&body).unwrap().into())
             .expect_success()
@@ -355,18 +324,14 @@ mod tests {
         });
         server
             .patch(&url)
-            .add_header("X-Admin-Password", "test")
+            .admin_auth()
             .content_type("application/json")
             .bytes(serde_json::to_vec(&patch).unwrap().into())
             .expect_success()
             .await;
 
         // 3) Verify overrides: storage_quota_mb changed, all others preserved
-        let response = server
-            .get(&url)
-            .add_header("X-Admin-Password", "test")
-            .expect_success()
-            .await;
+        let response = server.get(&url).admin_auth().expect_success().await;
         let json: serde_json::Value = response.json();
         assert_eq!(json["overrides"]["storage_quota_mb"], 200);
         assert_eq!(json["overrides"]["rate_read"], "100mb/m");
@@ -378,17 +343,13 @@ mod tests {
         });
         server
             .patch(&url)
-            .add_header("X-Admin-Password", "test")
+            .admin_auth()
             .content_type("application/json")
             .bytes(serde_json::to_vec(&patch).unwrap().into())
             .expect_success()
             .await;
 
-        let response = server
-            .get(&url)
-            .add_header("X-Admin-Password", "test")
-            .expect_success()
-            .await;
+        let response = server.get(&url).admin_auth().expect_success().await;
         let json: serde_json::Value = response.json();
         assert_eq!(json["overrides"]["storage_quota_mb"], 200);
         assert_eq!(json["overrides"]["rate_read"], "100mb/m");
@@ -398,17 +359,13 @@ mod tests {
         let patch = serde_json::json!({});
         server
             .patch(&url)
-            .add_header("X-Admin-Password", "test")
+            .admin_auth()
             .content_type("application/json")
             .bytes(serde_json::to_vec(&patch).unwrap().into())
             .expect_success()
             .await;
 
-        let response = server
-            .get(&url)
-            .add_header("X-Admin-Password", "test")
-            .expect_success()
-            .await;
+        let response = server.get(&url).admin_auth().expect_success().await;
         let json: serde_json::Value = response.json();
         assert_eq!(json["overrides"]["storage_quota_mb"], 200);
         assert_eq!(json["overrides"]["rate_read"], "100mb/m");
@@ -431,7 +388,7 @@ mod tests {
         });
         let response = server
             .patch(&url)
-            .add_header("X-Admin-Password", "test")
+            .admin_auth()
             .content_type("application/json")
             .bytes(serde_json::to_vec(&patch).unwrap().into())
             .expect_failure()

--- a/pubky-homeserver/src/admin_server/routes/user_quota.rs
+++ b/pubky-homeserver/src/admin_server/routes/user_quota.rs
@@ -80,43 +80,25 @@ mod tests {
     use super::*;
     use crate::admin_server::app::create_app;
     use crate::data_directory::quota_config::BandwidthQuota;
-    use crate::persistence::files::FileService;
+
     use crate::AppContext;
 
     fn create_test_server(context: &AppContext) -> TestServer {
-        TestServer::new(create_app(
-            AppState::new(
-                context.sql_db.clone(),
-                FileService::new_from_context(context).unwrap(),
-                "",
-                context.user_service.clone(),
-                context.events_service.clone(),
-                context.metrics.clone(),
-            ),
-            "test",
-        ))
-        .unwrap()
+        TestServer::new(create_app(AppState::new(context))).unwrap()
     }
 
     /// Create a test server with system-wide defaults configured.
     fn create_test_server_with_defaults(context: &AppContext) -> TestServer {
         use crate::data_directory::DefaultQuotasToml;
 
-        let mut state = AppState::new(
-            context.sql_db.clone(),
-            FileService::new_from_context(context).unwrap(),
-            "",
-            context.user_service.clone(),
-            context.events_service.clone(),
-            context.metrics.clone(),
-        );
+        let mut state = AppState::new(context);
         state.default_storage_mb = Some(100);
         state.default_quotas = DefaultQuotasToml {
             rate_read: Some(BandwidthQuota::from_str("10mb/s").unwrap()),
             rate_write: Some(BandwidthQuota::from_str("5mb/s").unwrap()),
             ..Default::default()
         };
-        TestServer::new(create_app(state, "test")).unwrap()
+        TestServer::new(create_app(state)).unwrap()
     }
 
     #[tokio::test]

--- a/pubky-homeserver/src/admin_server/routes/user_quota.rs
+++ b/pubky-homeserver/src/admin_server/routes/user_quota.rs
@@ -33,13 +33,16 @@ pub async fn get_user_quota(
     Path(pubkey): Path<Z32Pubkey>,
 ) -> HttpResult<impl IntoResponse> {
     let user = state
+        .context
         .user_service
         .get_or_http_error(&pubkey.0, false)
         .await?;
 
     let overrides = user.quota();
-    let effective =
-        overrides.resolve_with_defaults(state.default_storage_mb, &state.default_quotas);
+    let effective = overrides.resolve_with_defaults(
+        state.context.config_toml.storage.default_quota_mb,
+        &state.context.config_toml.default_quotas,
+    );
 
     Ok(Json(UserQuotaResponse {
         effective,
@@ -64,7 +67,11 @@ pub async fn patch_user_quota(
         .validate()
         .map_err(|e| HttpError::new_with_message(StatusCode::UNPROCESSABLE_ENTITY, e))?;
 
-    state.user_service.patch_quota(&pubkey.0, &patch).await?;
+    state
+        .context
+        .user_service
+        .patch_quota(&pubkey.0, &patch)
+        .await?;
 
     Ok(StatusCode::OK)
 }

--- a/pubky-homeserver/src/admin_server/routes/user_quota.rs
+++ b/pubky-homeserver/src/admin_server/routes/user_quota.rs
@@ -79,6 +79,7 @@ pub async fn patch_user_quota(
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
+    use std::sync::Arc;
 
     use axum_test::TestServer;
 
@@ -89,7 +90,7 @@ mod tests {
     use crate::data_directory::quota_config::BandwidthQuota;
     use crate::AppContext;
 
-    fn create_test_server(context: &AppContext) -> TestServer {
+    fn create_test_server(context: &Arc<AppContext>) -> TestServer {
         AppState::test_server(context)
     }
 

--- a/pubky-homeserver/src/admin_server/routes/user_quota.rs
+++ b/pubky-homeserver/src/admin_server/routes/user_quota.rs
@@ -78,27 +78,11 @@ mod tests {
     use pubky_common::crypto::Keypair;
 
     use super::*;
-    use crate::admin_server::app::create_app;
     use crate::data_directory::quota_config::BandwidthQuota;
-
     use crate::AppContext;
 
     fn create_test_server(context: &AppContext) -> TestServer {
-        TestServer::new(create_app(AppState::new(context))).unwrap()
-    }
-
-    /// Create a test server with system-wide defaults configured.
-    fn create_test_server_with_defaults(context: &AppContext) -> TestServer {
-        use crate::data_directory::DefaultQuotasToml;
-
-        let mut state = AppState::new(context);
-        state.default_storage_mb = Some(100);
-        state.default_quotas = DefaultQuotasToml {
-            rate_read: Some(BandwidthQuota::from_str("10mb/s").unwrap()),
-            rate_write: Some(BandwidthQuota::from_str("5mb/s").unwrap()),
-            ..Default::default()
-        };
-        TestServer::new(create_app(state)).unwrap()
+        AppState::test_server(context)
     }
 
     #[tokio::test]
@@ -180,8 +164,13 @@ mod tests {
     #[tokio::test]
     #[pubky_test_utils::test]
     async fn test_get_effective_resolves_defaults() {
-        let context = AppContext::test().await;
-        let server = create_test_server_with_defaults(&context);
+        let context = AppContext::test_with_config(|c| {
+            c.storage.default_quota_mb = Some(100);
+            c.default_quotas.rate_read = Some(BandwidthQuota::from_str("10mb/s").unwrap());
+            c.default_quotas.rate_write = Some(BandwidthQuota::from_str("5mb/s").unwrap());
+        })
+        .await;
+        let server = create_test_server(&context);
         let pubkey = Keypair::random().public_key();
 
         context.user_service.create(&pubkey).await.unwrap();

--- a/pubky-homeserver/src/app_context.rs
+++ b/pubky-homeserver/src/app_context.rs
@@ -59,7 +59,10 @@ pub enum AppContextConversionError {
 /// The application context shared between all components.
 /// Think of it as a simple Dependency Injection container.
 ///
-/// Create with a `DataDir` instance: `AppContext::try_from(data_dir)`
+/// Cloning is cheap: fields are internally Arc-wrapped handles or
+/// small value types.
+///
+/// Create with a `DataDir` instance: `AppContext::read_from(data_dir)`
 ///
 #[derive(Clone)]
 pub struct AppContext {

--- a/pubky-homeserver/src/app_context.rs
+++ b/pubky-homeserver/src/app_context.rs
@@ -102,6 +102,17 @@ impl AppContext {
             .expect("failed to build AppContext from DataDirMock")
     }
 
+    /// Create a new AppContext for testing with custom config overrides.
+    #[cfg(any(test, feature = "testing"))]
+    pub async fn test_with_config(f: impl FnOnce(&mut ConfigToml)) -> Self {
+        let mut config = ConfigToml::default_test_config();
+        f(&mut config);
+        let data_dir = MockDataDir::new(config, None).expect("failed to create MockDataDir");
+        Self::read_from(data_dir)
+            .await
+            .expect("failed to build AppContext from DataDirMock")
+    }
+
     /// Create a new AppContext from a data directory.
     pub async fn read_from<D: DataDir + 'static>(
         dir: D,

--- a/pubky-homeserver/src/app_context.rs
+++ b/pubky-homeserver/src/app_context.rs
@@ -59,11 +59,10 @@ pub enum AppContextConversionError {
 /// The application context shared between all components.
 /// Think of it as a simple Dependency Injection container.
 ///
-/// Cloning is cheap: fields are internally Arc-wrapped handles or
-/// small value types.
-///
 /// Create with a `DataDir` instance: `AppContext::read_from(data_dir)`
 ///
+/// Implements `Clone` but prefer wrapping in `Arc<AppContext>` for
+/// hot paths like axum state (avoids deep-copying config strings).
 #[derive(Clone)]
 pub struct AppContext {
     /// The SQL database connection.
@@ -96,24 +95,47 @@ pub struct AppContext {
 }
 
 impl AppContext {
-    /// Create a new AppContext for testing.
-    #[cfg(any(test, feature = "testing"))]
-    pub async fn test() -> Self {
-        let data_dir = MockDataDir::test();
-        Self::read_from(data_dir)
-            .await
-            .expect("failed to build AppContext from DataDirMock")
+    /// Replace the pkarr client and builder (e.g. to point at a test DHT).
+    #[cfg(test)]
+    pub(crate) fn with_pkarr(
+        mut self,
+        client: pkarr::Client,
+        builder: pkarr::ClientBuilder,
+    ) -> Self {
+        self.pkarr_client = client;
+        self.pkarr_builder = builder;
+        self
     }
 
-    /// Create a new AppContext for testing with custom config overrides.
+    /// Replace the keypair (e.g. to test with a specific identity).
+    #[cfg(test)]
+    pub(crate) fn with_keypair(mut self, keypair: Keypair) -> Self {
+        self.keypair = keypair;
+        self
+    }
+
+    /// Create a new AppContext for testing, wrapped in Arc for use in AppState.
     #[cfg(any(test, feature = "testing"))]
-    pub async fn test_with_config(f: impl FnOnce(&mut ConfigToml)) -> Self {
+    pub async fn test() -> Arc<Self> {
+        let data_dir = MockDataDir::test();
+        Arc::new(
+            Self::read_from(data_dir)
+                .await
+                .expect("failed to build AppContext from DataDirMock"),
+        )
+    }
+
+    /// Create a new AppContext for testing with custom config overrides, wrapped in Arc.
+    #[cfg(any(test, feature = "testing"))]
+    pub async fn test_with_config(f: impl FnOnce(&mut ConfigToml)) -> Arc<Self> {
         let mut config = ConfigToml::default_test_config();
         f(&mut config);
         let data_dir = MockDataDir::new(config, None).expect("failed to create MockDataDir");
-        Self::read_from(data_dir)
-            .await
-            .expect("failed to build AppContext from DataDirMock")
+        Arc::new(
+            Self::read_from(data_dir)
+                .await
+                .expect("failed to build AppContext from DataDirMock"),
+        )
     }
 
     /// Create a new AppContext from a data directory.

--- a/pubky-homeserver/src/client_server/app.rs
+++ b/pubky-homeserver/src/client_server/app.rs
@@ -52,7 +52,7 @@ pub enum ClientServerBuildError {
 /// A Pubky homeserver with ICANN HTTP and Pubky TLS servers.
 pub struct ClientServer {
     /// Keep context alive.
-    context: AppContext,
+    context: Arc<AppContext>,
 
     pub(crate) icann_http_handle: Handle<SocketAddr>,
     pub(crate) icann_http_socket: SocketAddr,
@@ -68,7 +68,7 @@ impl ClientServer {
     ) -> Result<Self, ClientServerBuildError> {
         let data_dir = PersistentDataDir::new(dir_path);
         let context = AppContext::read_from(data_dir).await?;
-        Self::start(context).await
+        Self::start(Arc::new(context)).await
     }
 
     /// Run the homeserver with configurations from a data directory.
@@ -76,7 +76,7 @@ impl ClientServer {
         dir: PersistentDataDir,
     ) -> Result<Self, ClientServerBuildError> {
         let context = AppContext::read_from(dir).await?;
-        Self::start(context).await
+        Self::start(Arc::new(context)).await
     }
 
     /// Run the homeserver with configurations from a data directory mock.
@@ -85,12 +85,14 @@ impl ClientServer {
         dir: MockDataDir,
     ) -> Result<Self, ClientServerBuildError> {
         let context = AppContext::read_from(dir).await?;
-        Self::start(context).await
+        Self::start(Arc::new(context)).await
     }
 
     /// Start homeserver services with the given application context.
-    pub async fn start(context: AppContext) -> std::result::Result<Self, ClientServerBuildError> {
-        let router = Self::create_router(&context)?;
+    pub async fn start(
+        context: Arc<AppContext>,
+    ) -> std::result::Result<Self, ClientServerBuildError> {
+        let router = Self::create_router(Arc::clone(&context))?;
 
         let (icann_http_handle, icann_http_socket) =
             Self::start_icann_http_server(&context, router.clone())
@@ -110,7 +112,7 @@ impl ClientServer {
     }
 
     pub(crate) fn create_router(
-        context: &AppContext,
+        context: Arc<AppContext>,
     ) -> std::result::Result<Router, ClientServerBuildError> {
         let state = AppState::new(context);
         super::create_app(state)
@@ -248,6 +250,8 @@ pub fn create_app(state: AppState) -> std::result::Result<Router, ClientServerBu
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use axum::http::{header, Method, StatusCode};
     use axum_test::TestServer;
     use pubky_common::{auth::AuthToken, capabilities::Capability, crypto::Keypair};
@@ -272,7 +276,7 @@ mod tests {
             }];
         })
         .await;
-        let router = ClientServer::create_router(&context).unwrap();
+        let router = ClientServer::create_router(Arc::clone(&context)).unwrap();
         let server = TestServer::new(router).unwrap();
         let user = Keypair::random();
 
@@ -308,7 +312,7 @@ mod tests {
             }];
         })
         .await;
-        let router = ClientServer::create_router(&context).unwrap();
+        let router = ClientServer::create_router(Arc::clone(&context)).unwrap();
         let server = TestServer::new(router).unwrap();
 
         let response = server.get("/info").await;

--- a/pubky-homeserver/src/client_server/app.rs
+++ b/pubky-homeserver/src/client_server/app.rs
@@ -227,10 +227,7 @@ pub fn create_app(state: AppState) -> std::result::Result<Router, ClientServerBu
         .layer(CookieManagerLayer::new())
         .layer(request_rate_limit_layer)
         .layer(AuthenticationLayer::new(auth_state.clone()))
-        .layer(BandwidthQuotaLimitLayer::new(
-            state.context.user_service.clone(),
-            state.context.config_toml.default_quotas.clone(),
-        ));
+        .layer(BandwidthQuotaLimitLayer::from_context(&state.context));
 
     let app = base()
         .merge(tenants::router())
@@ -300,18 +297,17 @@ mod tests {
     #[tokio::test]
     #[pubky_test_utils::test]
     async fn info_is_public_and_reports_no_features() {
-        let mut config = ConfigToml::minimal_test_config();
-        config.drive.rate_limits = vec![PathLimit {
-            path: GlobPattern::new("/info"),
-            method: HttpMethod(Method::GET),
-            quota: "1r/m".parse().unwrap(),
-            key: LimitKeyType::User,
-            burst: None,
-            whitelist: Vec::new(),
-        }];
-
-        let data_dir = MockDataDir::new(config, None).unwrap();
-        let context = AppContext::read_from(data_dir).await.unwrap();
+        let context = AppContext::test_with_config(|c| {
+            c.drive.rate_limits = vec![PathLimit {
+                path: GlobPattern::new("/info"),
+                method: HttpMethod(Method::GET),
+                quota: "1r/m".parse().unwrap(),
+                key: LimitKeyType::User,
+                burst: None,
+                whitelist: Vec::new(),
+            }];
+        })
+        .await;
         let router = ClientServer::create_router(&context).unwrap();
         let server = TestServer::new(router).unwrap();
 

--- a/pubky-homeserver/src/client_server/app.rs
+++ b/pubky-homeserver/src/client_server/app.rs
@@ -113,7 +113,7 @@ impl ClientServer {
         context: &AppContext,
     ) -> std::result::Result<Router, ClientServerBuildError> {
         let state = AppState::new(context);
-        super::create_app(state.clone(), context)
+        super::create_app(state)
     }
 
     /// Start the ICANN HTTP server
@@ -213,14 +213,12 @@ fn base() -> Router<AppState> {
     // TODO: maybe add to a separate router (drive router?).
 }
 
-pub fn create_app(
-    state: AppState,
-    context: &AppContext,
-) -> std::result::Result<Router, ClientServerBuildError> {
+pub fn create_app(state: AppState) -> std::result::Result<Router, ClientServerBuildError> {
     let auth_state = state.auth_state.clone();
-    let request_rate_limit_layer =
-        RequestRateLimitLayer::from_path_limits(context.config_toml.drive.rate_limits.clone())
-            .map_err(ClientServerBuildError::RequestRateLimits)?;
+    let request_rate_limit_layer = RequestRateLimitLayer::from_path_limits(
+        state.context.config_toml.drive.rate_limits.clone(),
+    )
+    .map_err(ClientServerBuildError::RequestRateLimits)?;
 
     let middleware = ServiceBuilder::new()
         // Request order matters: auth needs CookieManager, and bandwidth limits
@@ -230,8 +228,8 @@ pub fn create_app(
         .layer(request_rate_limit_layer)
         .layer(AuthenticationLayer::new(auth_state.clone()))
         .layer(BandwidthQuotaLimitLayer::new(
-            context.user_service.clone(),
-            context.config_toml.default_quotas.clone(),
+            state.context.user_service.clone(),
+            state.context.config_toml.default_quotas.clone(),
         ));
 
     let app = base()

--- a/pubky-homeserver/src/client_server/app.rs
+++ b/pubky-homeserver/src/client_server/app.rs
@@ -112,16 +112,7 @@ impl ClientServer {
     pub(crate) fn create_router(
         context: &AppContext,
     ) -> std::result::Result<Router, ClientServerBuildError> {
-        let state = AppState {
-            auth_state: auth::AuthState::new(context),
-            sql_db: context.sql_db.clone(),
-            file_service: context.file_service.clone(),
-            signup_mode: context.config_toml.general.signup_mode.clone(),
-            metrics: context.metrics.clone(),
-            events_service: context.events_service.clone(),
-            user_service: context.user_service.clone(),
-            default_storage_mb: context.config_toml.storage.default_quota_mb,
-        };
+        let state = AppState::new(context);
         super::create_app(state.clone(), context)
     }
 
@@ -270,24 +261,22 @@ mod tests {
         app_context::AppContext,
         client_server::ClientServer,
         quota_config::{GlobPattern, HttpMethod, LimitKeyType, PathLimit},
-        ConfigToml, MockDataDir,
     };
 
     #[tokio::test]
     #[pubky_test_utils::test]
     async fn middleware_dependencies_support_cookie_auth_and_user_rate_limits() {
-        let mut config = ConfigToml::minimal_test_config();
-        config.drive.rate_limits = vec![PathLimit {
-            path: GlobPattern::new("/session"),
-            method: HttpMethod(Method::GET),
-            quota: "1r/m".parse().unwrap(),
-            key: LimitKeyType::User,
-            burst: None,
-            whitelist: Vec::new(),
-        }];
-
-        let data_dir = MockDataDir::new(config, None).unwrap();
-        let context = AppContext::read_from(data_dir).await.unwrap();
+        let context = AppContext::test_with_config(|c| {
+            c.drive.rate_limits = vec![PathLimit {
+                path: GlobPattern::new("/session"),
+                method: HttpMethod(Method::GET),
+                quota: "1r/m".parse().unwrap(),
+                key: LimitKeyType::User,
+                burst: None,
+                whitelist: Vec::new(),
+            }];
+        })
+        .await;
         let router = ClientServer::create_router(&context).unwrap();
         let server = TestServer::new(router).unwrap();
         let user = Keypair::random();

--- a/pubky-homeserver/src/client_server/app_state.rs
+++ b/pubky-homeserver/src/client_server/app_state.rs
@@ -1,40 +1,20 @@
 use axum::extract::FromRef;
 
 use crate::client_server::auth::AuthState;
-use crate::observability::Metrics;
-use crate::persistence::files::events::EventsService;
-use crate::persistence::files::FileService;
-use crate::persistence::sql::SqlDb;
-use crate::services::user_service::UserService;
-use crate::SignupMode;
+use crate::AppContext;
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub(crate) struct AppState {
     /// Auth sub-state (extracted via `FromRef` by auth handlers).
     pub(crate) auth_state: AuthState,
-    /// The SQL database connection.
-    pub(crate) sql_db: SqlDb,
-    pub(crate) file_service: FileService,
-    pub(crate) signup_mode: SignupMode,
-    pub(crate) events_service: EventsService,
-    pub(crate) metrics: Metrics,
-    /// User service for user lookups, creation, and cache access.
-    pub(crate) user_service: UserService,
-    /// Default per-user storage quota in MB (from `[storage].default_quota_mb`).
-    pub(crate) default_storage_mb: Option<u64>,
+    pub(crate) context: AppContext,
 }
 
 impl AppState {
-    pub(crate) fn new(context: &crate::AppContext) -> Self {
+    pub(crate) fn new(context: &AppContext) -> Self {
         Self {
             auth_state: super::auth::AuthState::new(context),
-            sql_db: context.sql_db.clone(),
-            file_service: context.file_service.clone(),
-            signup_mode: context.config_toml.general.signup_mode.clone(),
-            metrics: context.metrics.clone(),
-            events_service: context.events_service.clone(),
-            user_service: context.user_service.clone(),
-            default_storage_mb: context.config_toml.storage.default_quota_mb,
+            context: context.clone(),
         }
     }
 }

--- a/pubky-homeserver/src/client_server/app_state.rs
+++ b/pubky-homeserver/src/client_server/app_state.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use axum::extract::FromRef;
 
 use crate::client_server::auth::AuthState;
@@ -7,14 +9,14 @@ use crate::AppContext;
 pub(crate) struct AppState {
     /// Auth sub-state (extracted via `FromRef` by auth handlers).
     pub(crate) auth_state: AuthState,
-    pub(crate) context: AppContext,
+    pub(crate) context: Arc<AppContext>,
 }
 
 impl AppState {
-    pub(crate) fn new(context: &AppContext) -> Self {
+    pub(crate) fn new(context: Arc<AppContext>) -> Self {
         Self {
-            auth_state: super::auth::AuthState::new(context),
-            context: context.clone(),
+            auth_state: super::auth::AuthState::new(&context),
+            context,
         }
     }
 }

--- a/pubky-homeserver/src/client_server/app_state.rs
+++ b/pubky-homeserver/src/client_server/app_state.rs
@@ -24,6 +24,21 @@ pub(crate) struct AppState {
     pub(crate) default_storage_mb: Option<u64>,
 }
 
+impl AppState {
+    pub(crate) fn new(context: &crate::AppContext) -> Self {
+        Self {
+            auth_state: super::auth::AuthState::new(context),
+            sql_db: context.sql_db.clone(),
+            file_service: context.file_service.clone(),
+            signup_mode: context.config_toml.general.signup_mode.clone(),
+            metrics: context.metrics.clone(),
+            events_service: context.events_service.clone(),
+            user_service: context.user_service.clone(),
+            default_storage_mb: context.config_toml.storage.default_quota_mb,
+        }
+    }
+}
+
 impl FromRef<AppState> for AuthState {
     fn from_ref(state: &AppState) -> Self {
         state.auth_state.clone()

--- a/pubky-homeserver/src/client_server/auth/cookie/service.rs
+++ b/pubky-homeserver/src/client_server/auth/cookie/service.rs
@@ -21,16 +21,12 @@ pub(crate) struct CookieAuthService {
 }
 
 impl CookieAuthService {
-    pub(crate) fn new(
-        sql_db: SqlDb,
-        user_service: UserService,
-        verifier: CookieAuthVerifier,
-        signup_service: SignupService,
-    ) -> Self {
+    /// Creates the service from the application context.
+    pub(crate) fn from_context(context: &crate::AppContext, signup_service: SignupService) -> Self {
         Self {
-            sql_db,
-            user_service,
-            verifier,
+            sql_db: context.sql_db.clone(),
+            user_service: context.user_service.clone(),
+            verifier: CookieAuthVerifier::default(),
             signup_service,
         }
     }

--- a/pubky-homeserver/src/client_server/auth/cookie/service.rs
+++ b/pubky-homeserver/src/client_server/auth/cookie/service.rs
@@ -22,12 +22,12 @@ pub(crate) struct CookieAuthService {
 
 impl CookieAuthService {
     /// Creates the service from the application context.
-    pub(crate) fn from_context(context: &crate::AppContext, signup_service: SignupService) -> Self {
+    pub(crate) fn from_context(context: &crate::AppContext) -> Self {
         Self {
             sql_db: context.sql_db.clone(),
             user_service: context.user_service.clone(),
             verifier: CookieAuthVerifier::default(),
-            signup_service,
+            signup_service: SignupService::from_context(context),
         }
     }
 

--- a/pubky-homeserver/src/client_server/auth/grant/service.rs
+++ b/pubky-homeserver/src/client_server/auth/grant/service.rs
@@ -53,11 +53,11 @@ pub struct GrantAuthService {
 
 impl GrantAuthService {
     /// Creates the service from the application context.
-    pub fn from_context(context: &crate::AppContext, signup_service: SignupService) -> Self {
+    pub fn from_context(context: &crate::AppContext) -> Self {
         Self {
             sql_db: context.sql_db.clone(),
             homeserver_public_key: context.keypair.public_key(),
-            signup_service,
+            signup_service: SignupService::from_context(context),
             user_service: context.user_service.clone(),
         }
     }

--- a/pubky-homeserver/src/client_server/auth/grant/service.rs
+++ b/pubky-homeserver/src/client_server/auth/grant/service.rs
@@ -52,7 +52,18 @@ pub struct GrantAuthService {
 }
 
 impl GrantAuthService {
-    /// Create a new auth service with the given database and homeserver public key.
+    /// Creates the service from the application context.
+    pub fn from_context(context: &crate::AppContext, signup_service: SignupService) -> Self {
+        Self {
+            sql_db: context.sql_db.clone(),
+            homeserver_public_key: context.keypair.public_key(),
+            signup_service,
+            user_service: context.user_service.clone(),
+        }
+    }
+
+    /// Creates the service with explicit dependencies (test-only).
+    #[cfg(test)]
     pub fn new(
         sql_db: SqlDb,
         homeserver_public_key: PublicKey,

--- a/pubky-homeserver/src/client_server/auth/signup_service.rs
+++ b/pubky-homeserver/src/client_server/auth/signup_service.rs
@@ -6,7 +6,7 @@ use crate::persistence::sql::{
 };
 use crate::services::user_service::{UserEntity, UserService};
 use crate::shared::user_quota::UserQuota;
-use crate::SignupMode;
+use crate::{AppContext, SignupMode};
 use pubky_common::crypto::PublicKey;
 
 /// Domain errors from signup operations.
@@ -41,7 +41,17 @@ pub struct SignupService {
 }
 
 impl SignupService {
-    /// Creates a signup service with the configured signup policy.
+    /// Creates a signup service from the application context.
+    pub fn from_context(context: &AppContext) -> Self {
+        Self {
+            sql_db: context.sql_db.clone(),
+            signup_mode: context.config_toml.general.signup_mode.clone(),
+            user_service: context.user_service.clone(),
+        }
+    }
+
+    /// Creates a signup service with the configured signup policy (test-only).
+    #[cfg(test)]
     pub fn new(sql_db: SqlDb, signup_mode: SignupMode, user_service: UserService) -> Self {
         Self {
             sql_db,

--- a/pubky-homeserver/src/client_server/auth/signup_service.rs
+++ b/pubky-homeserver/src/client_server/auth/signup_service.rs
@@ -6,7 +6,7 @@ use crate::persistence::sql::{
 };
 use crate::services::user_service::{UserEntity, UserService};
 use crate::shared::user_quota::UserQuota;
-use crate::{AppContext, SignupMode};
+use crate::SignupMode;
 use pubky_common::crypto::PublicKey;
 
 /// Domain errors from signup operations.
@@ -42,7 +42,7 @@ pub struct SignupService {
 
 impl SignupService {
     /// Creates a signup service from the application context.
-    pub fn from_context(context: &AppContext) -> Self {
+    pub(crate) fn from_context(context: &crate::AppContext) -> Self {
         Self {
             sql_db: context.sql_db.clone(),
             signup_mode: context.config_toml.general.signup_mode.clone(),

--- a/pubky-homeserver/src/client_server/auth/state.rs
+++ b/pubky-homeserver/src/client_server/auth/state.rs
@@ -5,7 +5,7 @@ use crate::observability::Metrics;
 use crate::shared::HttpResult;
 
 use super::cookie::service::CookieAuthService;
-use super::{AuthSession, GrantAuthService, RevocationListener, SignupService};
+use super::{AuthSession, GrantAuthService, RevocationListener};
 
 /// Auth-specific state. Auth route handlers extract this instead of the
 /// global `AppState`, keeping the auth module fully self-contained.
@@ -20,11 +20,9 @@ pub struct AuthState {
 
 impl AuthState {
     pub fn new(context: &AppContext) -> Self {
-        let signup_service = SignupService::from_context(context);
-
         Self {
-            grant_auth_service: GrantAuthService::from_context(context, signup_service.clone()),
-            cookie_auth_service: CookieAuthService::from_context(context, signup_service),
+            grant_auth_service: GrantAuthService::from_context(context),
+            cookie_auth_service: CookieAuthService::from_context(context),
             metrics: context.metrics.clone(),
             revocation_listener: context.revocation_listener.clone(),
         }

--- a/pubky-homeserver/src/client_server/auth/state.rs
+++ b/pubky-homeserver/src/client_server/auth/state.rs
@@ -21,11 +21,7 @@ pub struct AuthState {
 
 impl AuthState {
     pub fn new(context: &AppContext) -> Self {
-        let signup_service = SignupService::new(
-            context.sql_db.clone(),
-            context.config_toml.general.signup_mode.clone(),
-            context.user_service.clone(),
-        );
+        let signup_service = SignupService::from_context(context);
 
         Self {
             grant_auth_service: GrantAuthService::new(

--- a/pubky-homeserver/src/client_server/auth/state.rs
+++ b/pubky-homeserver/src/client_server/auth/state.rs
@@ -1,6 +1,5 @@
 //! Auth-specific sub-state for the auth module.
 
-use super::cookie::verifier::CookieAuthVerifier;
 use crate::app_context::AppContext;
 use crate::observability::Metrics;
 use crate::shared::HttpResult;
@@ -24,18 +23,8 @@ impl AuthState {
         let signup_service = SignupService::from_context(context);
 
         Self {
-            grant_auth_service: GrantAuthService::new(
-                context.sql_db.clone(),
-                context.keypair.public_key(),
-                signup_service.clone(),
-                context.user_service.clone(),
-            ),
-            cookie_auth_service: CookieAuthService::new(
-                context.sql_db.clone(),
-                context.user_service.clone(),
-                CookieAuthVerifier::default(),
-                signup_service,
-            ),
+            grant_auth_service: GrantAuthService::from_context(context, signup_service.clone()),
+            cookie_auth_service: CookieAuthService::from_context(context, signup_service),
             metrics: context.metrics.clone(),
             revocation_listener: context.revocation_listener.clone(),
         }

--- a/pubky-homeserver/src/client_server/middleware/rate_limiter/bandwidth_rate_limit.rs
+++ b/pubky-homeserver/src/client_server/middleware/rate_limiter/bandwidth_rate_limit.rs
@@ -43,6 +43,16 @@ pub struct BandwidthQuotaLimitLayer {
 }
 
 impl BandwidthQuotaLimitLayer {
+    /// Creates the layer from the application context.
+    pub fn from_context(context: &crate::AppContext) -> Self {
+        Self {
+            user_service: context.user_service.clone(),
+            defaults: context.config_toml.default_quotas.clone(),
+        }
+    }
+
+    /// Creates the layer with explicit services (test-only).
+    #[cfg(test)]
     pub fn new(user_service: UserService, defaults: DefaultQuotasToml) -> Self {
         Self {
             user_service,

--- a/pubky-homeserver/src/client_server/routes/events.rs
+++ b/pubky-homeserver/src/client_server/routes/events.rs
@@ -428,7 +428,8 @@ pub async fn feed_stream(
 
             let query_start = Instant::now();
             let events = match state
-                .context.events_service
+                .context
+                .events_service
                 .get_by_user_cursors(
                     current_user_cursors,
                     params.reverse,

--- a/pubky-homeserver/src/client_server/routes/events.rs
+++ b/pubky-homeserver/src/client_server/routes/events.rs
@@ -296,8 +296,9 @@ pub async fn feed(
     };
 
     let cursor = match state
+        .context
         .events_service
-        .parse_cursor(cursor.as_str(), &mut state.sql_db.pool().into())
+        .parse_cursor(cursor.as_str(), &mut state.context.sql_db.pool().into())
         .await
     {
         Ok(cursor) => cursor,
@@ -306,10 +307,16 @@ pub async fn feed(
 
     let query_start = Instant::now();
     let events = state
+        .context
         .events_service
-        .get_public_by_cursor(Some(cursor), params.limit, &mut state.sql_db.pool().into())
+        .get_public_by_cursor(
+            Some(cursor),
+            params.limit,
+            &mut state.context.sql_db.pool().into(),
+        )
         .await?;
     state
+        .context
         .metrics
         .record_events_db_query(query_start.elapsed().as_millis());
 
@@ -391,9 +398,9 @@ pub async fn feed_stream(
 
     let mut user_cursor_map = resolve_user_cursors(
         &params.user_cursors,
-        &state.events_service,
-        &state.sql_db,
-        &state.user_service,
+        &state.context.events_service,
+        &state.context.sql_db,
+        &state.context.user_service,
     )
     .await
     .map_err(HttpError::from)?;
@@ -401,11 +408,11 @@ pub async fn feed_stream(
     let mut total_sent: usize = 0;
     let stream = async_stream::stream! {
          // Create guard to ensure cleanup on any exit path (increments on creation, decrements on drop)
-        let _guard = ConnectionGuard::new(state.metrics.clone());
+        let _guard = ConnectionGuard::new(state.context.metrics.clone());
 
         // Subscribe to broadcast channel immediately to prevent race condition
         // Events that occur during Phase 1 will be buffered in the channel
-        let mut rx = state.events_service.subscribe();
+        let mut rx = state.context.events_service.subscribe();
 
         // Phase 1: Batch Mode
         loop {
@@ -421,12 +428,12 @@ pub async fn feed_stream(
 
             let query_start = Instant::now();
             let events = match state
-                .events_service
+                .context.events_service
                 .get_by_user_cursors(
                     current_user_cursors,
                     params.reverse,
                     &allowed_paths,
-                    &mut state.sql_db.pool().into(),
+                    &mut state.context.sql_db.pool().into(),
                 )
                 .await
             {
@@ -436,7 +443,7 @@ pub async fn feed_stream(
                     break;
                 }
             };
-            state.metrics.record_event_stream_db_query(query_start.elapsed().as_millis());
+            state.context.metrics.record_event_stream_db_query(query_start.elapsed().as_millis());
 
             let event_count = events.len();
 
@@ -480,7 +487,7 @@ pub async fn feed_stream(
         // Phase 2: Live mode
         if params.live {
             let user_ids: Vec<i32> = user_cursor_map.keys().copied().collect();
-            let half_capacity = state.events_service.channel_capacity() / 2;
+            let half_capacity = state.context.events_service.channel_capacity() / 2;
 
             loop {
                 tokio::select! {
@@ -494,7 +501,7 @@ pub async fn feed_stream(
                         Ok(event) => {
                         // Check if receiver queue is at half capacity (early warning of slow clients)
                         if rx.len() >= half_capacity {
-                            state.metrics.record_broadcast_half_full();
+                            state.context.metrics.record_broadcast_half_full();
                         }
                         // Filter events based on user_ids, cursors, and path
                         if !should_include_live_event(&event, &user_ids, &user_cursor_map, &allowed_paths) {
@@ -518,7 +525,7 @@ pub async fn feed_stream(
                         }
                     }
                         Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
-                            state.metrics.record_broadcast_lagged();
+                            state.context.metrics.record_broadcast_lagged();
                             tracing::warn!(
                                 "Slow client detected: broadcast channel lagged by {} events. Closing connection.",
                                 skipped

--- a/pubky-homeserver/src/client_server/routes/signup_tokens.rs
+++ b/pubky-homeserver/src/client_server/routes/signup_tokens.rs
@@ -35,7 +35,7 @@ pub async fn get(
     State(state): State<AppState>,
     Path(token): Path<String>,
 ) -> HttpResult<impl IntoResponse> {
-    if state.signup_mode != SignupMode::TokenRequired {
+    if state.context.config_toml.general.signup_mode != SignupMode::TokenRequired {
         return Err(HttpError::new_with_message(
             StatusCode::BAD_REQUEST,
             "Signup tokens not required",
@@ -50,7 +50,9 @@ pub async fn get(
     })?;
 
     let code =
-        match SignupCodeRepository::get(&signup_code_id, &mut state.sql_db.pool().into()).await {
+        match SignupCodeRepository::get(&signup_code_id, &mut state.context.sql_db.pool().into())
+            .await
+        {
             Ok(code) => code,
             Err(sqlx::Error::RowNotFound) => {
                 return Err(HttpError::new_with_message(

--- a/pubky-homeserver/src/client_server/routes/tenants/read.rs
+++ b/pubky-homeserver/src/client_server/routes/tenants/read.rs
@@ -275,6 +275,8 @@ impl EntryEntity {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use axum::http::{header, HeaderMap, Method, StatusCode};
     use axum::Router;
     use axum_test::TestServer;
@@ -341,9 +343,9 @@ mod tests {
     }
 
     async fn create_environment_with_keypair(
-    ) -> anyhow::Result<(AppContext, Router, TestServer, Keypair, String)> {
+    ) -> anyhow::Result<(Arc<AppContext>, Router, TestServer, Keypair, String)> {
         let context = AppContext::test().await;
-        let router = ClientServer::create_router(&context)?;
+        let router = ClientServer::create_router(Arc::clone(&context))?;
         let server = axum_test::TestServer::new(router.clone()).unwrap();
 
         let keypair = Keypair::random();
@@ -353,7 +355,7 @@ mod tests {
     }
 
     pub async fn create_environment(
-    ) -> anyhow::Result<(AppContext, Router, TestServer, PublicKey, String)> {
+    ) -> anyhow::Result<(Arc<AppContext>, Router, TestServer, PublicKey, String)> {
         let (context, router, server, keypair, cookie) = create_environment_with_keypair().await?;
         let public_key = keypair.public_key();
 

--- a/pubky-homeserver/src/client_server/routes/tenants/read.rs
+++ b/pubky-homeserver/src/client_server/routes/tenants/read.rs
@@ -46,13 +46,15 @@ pub async fn head(
     )?;
 
     state
+        .context
         .user_service
         .get_or_http_error(entry_path.pubkey(), false)
         .await?;
 
     let entry = state
+        .context
         .file_service
-        .get_info(&entry_path, &mut state.sql_db.pool().into())
+        .get_info(&entry_path, &mut state.context.sql_db.pool().into())
         .await?;
     let response = entry.to_response_headers().into_response();
     Ok(response)
@@ -94,8 +96,9 @@ pub async fn get(
     }
 
     let entry = state
+        .context
         .file_service
-        .get_info(&entry_path, &mut state.sql_db.pool().into())
+        .get_info(&entry_path, &mut state.context.sql_db.pool().into())
         .await?;
 
     // Per RFC 7232 §3: If-None-Match has precedence over If-Modified-Since.
@@ -129,7 +132,7 @@ pub async fn get(
         }
     }
 
-    let stream = state.file_service.get_stream(&entry_path).await?;
+    let stream = state.context.file_service.get_stream(&entry_path).await?;
     let body_stream = Body::from_stream(stream);
     let mut response = entry.to_response_headers().into_response();
     *response.body_mut() = body_stream;
@@ -142,7 +145,8 @@ async fn list(
     params: ListQueryParams,
 ) -> HttpResult<Response<Body>> {
     let contains_dir =
-        EntryRepository::contains_directory(entry_path, &mut state.sql_db.pool().into()).await?;
+        EntryRepository::contains_directory(entry_path, &mut state.context.sql_db.pool().into())
+            .await?;
     if !contains_dir {
         return Err(HttpError::new_with_message(
             StatusCode::NOT_FOUND,
@@ -166,7 +170,7 @@ async fn list(
             params.limit,
             parsed_cursor,
             params.reverse,
-            &mut state.sql_db.pool().into(),
+            &mut state.context.sql_db.pool().into(),
         )
         .await?
     } else {
@@ -175,7 +179,7 @@ async fn list(
             params.limit,
             parsed_cursor,
             params.reverse,
-            &mut state.sql_db.pool().into(),
+            &mut state.context.sql_db.pool().into(),
         )
         .await?
     };

--- a/pubky-homeserver/src/client_server/routes/tenants/write.rs
+++ b/pubky-homeserver/src/client_server/routes/tenants/write.rs
@@ -48,11 +48,12 @@ pub async fn delete(
     has_write_permission(&session, entry_path.pubkey(), entry_path.path())?;
 
     state
+        .context
         .user_service
         .get_or_http_error(entry_path.pubkey(), false)
         .await?;
 
-    state.file_service.delete(&entry_path).await?;
+    state.context.file_service.delete(&entry_path).await?;
     Ok((StatusCode::NO_CONTENT, ()))
 }
 
@@ -81,6 +82,7 @@ pub async fn put(
     has_write_permission(&session, entry_path.pubkey(), entry_path.path())?;
 
     let user = state
+        .context
         .user_service
         .get_or_http_error(entry_path.pubkey(), true)
         .await?;
@@ -94,9 +96,9 @@ pub async fn put(
     fail_if_size_hint_exceeds_quota(
         content_length,
         &user,
-        state.default_storage_mb,
+        state.context.config_toml.storage.default_quota_mb,
         &entry_path,
-        &mut state.sql_db.pool().into(),
+        &mut state.context.sql_db.pool().into(),
     )
     .await?;
 
@@ -106,6 +108,7 @@ pub async fn put(
         body_stream.map(|chunk_result| chunk_result.map_err(WriteStreamError::Axum));
 
     state
+        .context
         .file_service
         .write_stream(&entry_path, converted_stream)
         .await?;

--- a/pubky-homeserver/src/data_directory/config_toml.rs
+++ b/pubky-homeserver/src/data_directory/config_toml.rs
@@ -253,6 +253,7 @@ impl ConfigToml {
         config.drive.pubky_listen_socket = SocketAddr::from(([127, 0, 0, 1], 0));
         config.admin.enabled = true; // Enabled for backward compat
         config.admin.listen_socket = SocketAddr::from(([127, 0, 0, 1], 0));
+        config.admin.admin_password = "test".to_string();
         config.pkdns.icann_domain =
             Some(Domain::from_str("localhost").expect("localhost is a valid domain"));
         config.pkdns.dht_relay_nodes = None;

--- a/pubky-homeserver/src/data_directory/config_toml.rs
+++ b/pubky-homeserver/src/data_directory/config_toml.rs
@@ -253,7 +253,6 @@ impl ConfigToml {
         config.drive.pubky_listen_socket = SocketAddr::from(([127, 0, 0, 1], 0));
         config.admin.enabled = true; // Enabled for backward compat
         config.admin.listen_socket = SocketAddr::from(([127, 0, 0, 1], 0));
-        config.admin.admin_password = "test".to_string();
         config.pkdns.icann_domain =
             Some(Domain::from_str("localhost").expect("localhost is a valid domain"));
         config.pkdns.dht_relay_nodes = None;

--- a/pubky-homeserver/src/homeserver_app.rs
+++ b/pubky-homeserver/src/homeserver_app.rs
@@ -18,6 +18,7 @@ use crate::{app_context::AppContext, data_directory::PersistentDataDir};
 use anyhow::Result;
 use pubky_common::crypto::PublicKey;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 
 /// Errors that can occur when building a `HomeserverApp`.
@@ -39,7 +40,7 @@ pub enum HomeserverAppBuildError {
 ///
 /// When dropped, the homeserver will stop.
 pub struct HomeserverApp {
-    context: AppContext,
+    context: Arc<AppContext>,
 
     #[allow(dead_code)] // Keep this alive. When dropped, the homeserver will stop.
     client_server: ClientServer,
@@ -82,6 +83,7 @@ impl HomeserverApp {
     pub async fn start(context: AppContext) -> Result<Self> {
         // Tracing Subscriber initialization based on the config file.
         let _ = init_tracing_logs_with_config_if_set(&context.config_toml);
+        let context = Arc::new(context);
 
         tracing::debug!("Homeserver data dir: {}", context.data_dir.path().display());
 
@@ -97,7 +99,7 @@ impl HomeserverApp {
         );
 
         let admin_server = if context.config_toml.admin.enabled {
-            Some(AdminServer::start(&context).await?)
+            Some(AdminServer::start(Arc::clone(&context)).await?)
         } else {
             None
         };
@@ -106,7 +108,7 @@ impl HomeserverApp {
         } else {
             None
         };
-        let client_server = ClientServer::start(context.clone()).await?;
+        let client_server = ClientServer::start(Arc::clone(&context)).await?;
 
         let key_republisher = HomeserverKeyRepublisher::start(
             &context,

--- a/pubky-homeserver/src/persistence/files/opendal/opendal_service.rs
+++ b/pubky-homeserver/src/persistence/files/opendal/opendal_service.rs
@@ -266,8 +266,10 @@ mod tests {
     #[tokio::test]
     #[pubky_test_utils::test]
     async fn test_build_storage_operator_from_config_file_system() {
-        let mut context = AppContext::test().await;
-        context.config_toml.storage.backend = StorageConfigToml::FileSystem;
+        let context = AppContext::test_with_config(|c| {
+            c.storage.backend = StorageConfigToml::FileSystem;
+        })
+        .await;
 
         let service =
             OpendalService::new(&context).expect("Failed to create OpenDAL service for testing");

--- a/pubky-homeserver/src/republishers/key_republisher.rs
+++ b/pubky-homeserver/src/republishers/key_republisher.rs
@@ -169,6 +169,7 @@ mod tests {
     use futures_lite::StreamExt;
     use pkarr::{extra::endpoints::Endpoint, ResolvePolicy};
     use std::net::{Ipv4Addr, SocketAddr};
+    use std::sync::Arc;
 
     use super::*;
     use crate::republishers::pkarr_republisher::test_client_builder;
@@ -176,9 +177,10 @@ mod tests {
     async fn test_context() -> (AppContext, mainline::Testnet) {
         let dht = mainline::Testnet::builder(1).build().unwrap();
         let pkarr_builder = test_client_builder(&dht);
-        let mut context = AppContext::test().await;
-        context.pkarr_client = pkarr_builder.clone().build().unwrap();
-        context.pkarr_builder = pkarr_builder;
+        let context = Arc::try_unwrap(AppContext::test().await)
+            .ok()
+            .expect("unique Arc")
+            .with_pkarr(pkarr_builder.clone().build().unwrap(), pkarr_builder);
         (context, dht)
     }
 
@@ -211,8 +213,8 @@ mod tests {
     #[tokio::test]
     #[pubky_test_utils::test]
     async fn test_endpoints() {
-        let (mut context, _dht) = test_context().await;
-        context.keypair = pubky_common::crypto::Keypair::random();
+        let (context, _dht) = test_context().await;
+        let context = context.with_keypair(pubky_common::crypto::Keypair::random());
         let _republisher = HomeserverKeyRepublisher::start(&context, 8080, 8080)
             .await
             .unwrap();


### PR DESCRIPTION
Services that depend on `AppContext` now construct themselves via `from_context(&AppContext)` instead of callers manually extracting and passing individual fields. I've found the whole `AppContext` and `AppState` pattern slightly confusing in the past, i hope that this will make things clearer:
- `AppContext` holds shared-state services which require a single shared instance
- Each `AppState` holds all of `AppContext` plus any extra services/functionality which only that particular server needs
- Services without state are instantiated by their parent service  

This means that a service can be added without having to wire it through each layer, config can be accessible directly from `state` and a `*Service::from_context()` pattern can be standardised throughout.

I'm ultimately attempting to simplify at the cost of making service dependencies less explicit. 

Also adds convenience `test_with_config()` for creating `AppContext` with config overrides. 