### PR TITLE
chore: v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,7 +1598,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e2e"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3996,7 +3996,7 @@ checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
 name = "pubky"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4028,7 +4028,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-common"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "argon2",
  "base64 0.22.1",
@@ -4048,7 +4048,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-homeserver"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-dropper",
@@ -4114,7 +4114,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-homeserver-examples"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4133,7 +4133,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-testnet"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4172,7 +4172,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-wasm"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "base64 0.22.1",
  "console_log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 rust-version = "1.89"
 edition = "2021"
 authors = [
@@ -56,10 +56,10 @@ mainline = "8"
 pkarr = { version = "8", default-features = false }
 pkarr-relay = { version = "2", default-features = false }
 percent-encoding = "2"
-pubky = { path = "pubky-sdk", version = "0.10", default-features = false }
-pubky-common = { path = "pubky-common", version = "0.10" }
-pubky-homeserver = { path = "pubky-homeserver", version = "0.10", default-features = false }
-pubky-testnet = { path = "pubky-testnet", version = "0.10" }
+pubky = { path = "pubky-sdk", version = "0.11", default-features = false }
+pubky-common = { path = "pubky-common", version = "0.11" }
+pubky-homeserver = { path = "pubky-homeserver", version = "0.11", default-features = false }
+pubky-testnet = { path = "pubky-testnet", version = "0.11" }
 pubky_test_utils = { path = "test_utils/pubky_test", version = "0.1" }
 rand = "0.10"
 reqwest = { version = "0.13", default-features = false }

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -27,7 +27,7 @@ Commands and package names assume a Debian-based system (Ubuntu, Debian, etc.), 
 Pick a version and platform from the [releases page](https://github.com/pubky/pubky-homeserver/releases). The commands below use these variables, so set them first:
 
 ```bash
-PUBKY_VERSION=0.x
+PUBKY_VERSION=0.11
 PUBKY_PLATFORM=linux-amd64  # or linux-arm64. Alternatively: osx-arm64, osx-amd64, windows-amd64
 ```
 

--- a/pubky-sdk/bindings/js/pkg/package-lock.json
+++ b/pubky-sdk/bindings/js/pkg/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@synonymdev/pubky",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@synonymdev/pubky",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "fetch-cookie": "^3.0.1"

--- a/pubky-sdk/bindings/js/pkg/package.json
+++ b/pubky-sdk/bindings/js/pkg/package.json
@@ -2,7 +2,7 @@
   "name": "@synonymdev/pubky",
   "type": "module",
   "description": "Decentralized identity, auth flows, and user-owned storage",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Also Suggest default homeserver version download to be `v0.11` to reduce the changes of someone attempting to pull `pubky-core`-named artefacts (ie, those in `v0.10`)