### PR TITLE
fix: bump `tsfy`, migrate deprecated ABI boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6369,9 +6369,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tsify"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ec5505497c87f1c050b4392d3f11b49a04537fcb9dc0da57bc0af168a6331f2"
+checksum = "7a1a69a9adf75b6573e392dda05bbda166c7675006f6f77c20150751df4efad0"
 dependencies = [
  "gloo-utils",
  "serde",
@@ -6382,9 +6382,9 @@ dependencies = [
 
 [[package]]
 name = "tsify-macros"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc2c44dc9fe4baf55b88e032621b7a11b215a1f0a7de8d0aa04367207d915bc"
+checksum = "ef1e2e93369379d0a527c7d6632b58c55d52db7a106d8afbde3b354f3a57a9f1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/pubky-sdk/bindings/js/src/actors/auth_flow.rs
+++ b/pubky-sdk/bindings/js/src/actors/auth_flow.rs
@@ -7,6 +7,7 @@ use pubky::PubkyCookieAuthFlow;
 use std::{cell::RefCell, rc::Rc};
 use url::Url;
 
+use tsify::Ts;
 use wasm_bindgen::JsValue;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
@@ -14,7 +15,7 @@ use wasm_bindgen_futures::JsFuture;
 use super::deep_links::XCallbackParams;
 use super::{in_flight::InFlightGuard, session::Session};
 use crate::{
-    js_error::{JsResult, PubkyError, PubkyErrorName},
+    js_error::{JsResult, PubkyError, PubkyErrorName, deserialize_ts},
     wrappers::{auth_token::AuthToken, capabilities::parse_capabilities, keys::PublicKey},
 };
 
@@ -76,8 +77,9 @@ impl AuthFlow {
         #[wasm_bindgen(unchecked_param_type = "Capabilities")] capabilities: String,
         kind: AuthFlowKind,
         relay: Option<String>,
-        x_callback: Option<XCallbackParams>,
+        x_callback: Option<Ts<XCallbackParams>>,
     ) -> JsResult<AuthFlow> {
+        let x_callback = x_callback.as_ref().map(deserialize_ts).transpose()?;
         Self::start_with_client(capabilities, kind, relay, x_callback, None)
     }
 

--- a/pubky-sdk/bindings/js/src/actors/deep_links/direct_signup.rs
+++ b/pubky-sdk/bindings/js/src/actors/deep_links/direct_signup.rs
@@ -1,9 +1,10 @@
 use std::str::FromStr;
 
+use tsify::Ts;
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    js_error::{JsResult, PubkyError, PubkyErrorName},
+    js_error::{JsResult, PubkyError, PubkyErrorName, serialize_ts},
     wrappers::keys::PublicKey,
 };
 
@@ -42,8 +43,8 @@ impl DirectSignupDeepLink {
 
     /// Optional x-callback-url metadata carried by this deep link.
     #[wasm_bindgen(js_name = "xCallback", getter)]
-    pub fn x_callback(&self) -> XCallbackParams {
-        self.0.x_callback().into()
+    pub fn x_callback(&self) -> JsResult<Ts<XCallbackParams>> {
+        serialize_ts(&XCallbackParams::from(self.0.x_callback()))
     }
 
     #[allow(

--- a/pubky-sdk/bindings/js/src/actors/deep_links/seed_export.rs
+++ b/pubky-sdk/bindings/js/src/actors/deep_links/seed_export.rs
@@ -1,9 +1,10 @@
 use std::str::FromStr;
 
 use js_sys::Uint8Array;
+use tsify::Ts;
 use wasm_bindgen::prelude::*;
 
-use crate::js_error::{JsResult, PubkyError, PubkyErrorName};
+use crate::js_error::{JsResult, PubkyError, PubkyErrorName, serialize_ts};
 
 use super::XCallbackParams;
 
@@ -31,8 +32,8 @@ impl SeedExportDeepLink {
 
     /// Optional x-callback-url metadata carried by this deep link.
     #[wasm_bindgen(js_name = "xCallback", getter)]
-    pub fn x_callback(&self) -> XCallbackParams {
-        self.0.x_callback().into()
+    pub fn x_callback(&self) -> JsResult<Ts<XCallbackParams>> {
+        serialize_ts(&XCallbackParams::from(self.0.x_callback()))
     }
 
     #[allow(

--- a/pubky-sdk/bindings/js/src/actors/deep_links/signin.rs
+++ b/pubky-sdk/bindings/js/src/actors/deep_links/signin.rs
@@ -1,9 +1,10 @@
 use std::str::FromStr;
 
 use js_sys::Uint8Array;
+use tsify::Ts;
 use wasm_bindgen::prelude::*;
 
-use crate::js_error::{JsResult, PubkyError, PubkyErrorName};
+use crate::js_error::{JsResult, PubkyError, PubkyErrorName, serialize_ts};
 
 use super::XCallbackParams;
 
@@ -41,8 +42,8 @@ impl SigninDeepLink {
 
     /// Optional x-callback-url metadata carried by this deep link.
     #[wasm_bindgen(js_name = "xCallback", getter)]
-    pub fn x_callback(&self) -> XCallbackParams {
-        self.0.x_callback().into()
+    pub fn x_callback(&self) -> JsResult<Ts<XCallbackParams>> {
+        serialize_ts(&XCallbackParams::from(self.0.x_callback()))
     }
 
     #[allow(

--- a/pubky-sdk/bindings/js/src/actors/deep_links/signin_grant.rs
+++ b/pubky-sdk/bindings/js/src/actors/deep_links/signin_grant.rs
@@ -1,10 +1,11 @@
 use std::str::FromStr;
 
 use js_sys::Uint8Array;
+use tsify::Ts;
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    js_error::{JsResult, PubkyError, PubkyErrorName},
+    js_error::{JsResult, PubkyError, PubkyErrorName, serialize_ts},
     wrappers::keys::PublicKey,
 };
 
@@ -80,8 +81,8 @@ impl SigninGrantDeepLink {
 
     /// Optional x-callback-url metadata carried by this deep link.
     #[wasm_bindgen(js_name = "xCallback", getter)]
-    pub fn x_callback(&self) -> XCallbackParams {
-        self.0.x_callback().into()
+    pub fn x_callback(&self) -> JsResult<Ts<XCallbackParams>> {
+        serialize_ts(&XCallbackParams::from(self.0.x_callback()))
     }
 
     #[allow(

--- a/pubky-sdk/bindings/js/src/actors/deep_links/signup.rs
+++ b/pubky-sdk/bindings/js/src/actors/deep_links/signup.rs
@@ -1,10 +1,11 @@
 use std::str::FromStr;
 
 use js_sys::Uint8Array;
+use tsify::Ts;
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    js_error::{JsResult, PubkyError, PubkyErrorName},
+    js_error::{JsResult, PubkyError, PubkyErrorName, serialize_ts},
     wrappers::keys::PublicKey,
 };
 
@@ -54,8 +55,8 @@ impl SignupDeepLink {
 
     /// Optional x-callback-url metadata carried by this deep link.
     #[wasm_bindgen(js_name = "xCallback", getter)]
-    pub fn x_callback(&self) -> XCallbackParams {
-        self.0.x_callback().into()
+    pub fn x_callback(&self) -> JsResult<Ts<XCallbackParams>> {
+        serialize_ts(&XCallbackParams::from(self.0.x_callback()))
     }
 
     #[allow(

--- a/pubky-sdk/bindings/js/src/actors/deep_links/signup_grant.rs
+++ b/pubky-sdk/bindings/js/src/actors/deep_links/signup_grant.rs
@@ -1,10 +1,11 @@
 use std::str::FromStr;
 
 use js_sys::Uint8Array;
+use tsify::Ts;
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    js_error::{JsResult, PubkyError, PubkyErrorName},
+    js_error::{JsResult, PubkyError, PubkyErrorName, serialize_ts},
     wrappers::keys::PublicKey,
 };
 
@@ -96,8 +97,8 @@ impl SignupGrantDeepLink {
 
     /// Optional x-callback-url metadata carried by this deep link.
     #[wasm_bindgen(js_name = "xCallback", getter)]
-    pub fn x_callback(&self) -> XCallbackParams {
-        self.0.x_callback().into()
+    pub fn x_callback(&self) -> JsResult<Ts<XCallbackParams>> {
+        serialize_ts(&XCallbackParams::from(self.0.x_callback()))
     }
 
     #[allow(

--- a/pubky-sdk/bindings/js/src/actors/deep_links/x_callback.rs
+++ b/pubky-sdk/bindings/js/src/actors/deep_links/x_callback.rs
@@ -6,7 +6,6 @@ use tsify::Tsify;
 /// Callback destinations are untrusted navigation hints. Authentication still
 /// completes through the encrypted relay.
 #[derive(Tsify, Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 pub struct XCallbackParams {
     /// Human-readable name of the requesting application.

--- a/pubky-sdk/bindings/js/src/actors/grant_auth_flow.rs
+++ b/pubky-sdk/bindings/js/src/actors/grant_auth_flow.rs
@@ -2,7 +2,7 @@ use pubky::{DelegatedGrantAuthFlowState, GrantAuthFlowState, PubkyGrantAuthFlow}
 use pubky_common::auth::jws::ClientId;
 use serde::{Deserialize, Serialize};
 use std::{cell::RefCell, rc::Rc};
-use tsify::Tsify;
+use tsify::{Ts, Tsify};
 use url::Url;
 
 use wasm_bindgen::JsValue;
@@ -14,13 +14,12 @@ use super::{
     deep_links::XCallbackParams, in_flight::InFlightGuard, session::Session,
 };
 use crate::{
-    js_error::{JsResult, PubkyError, PubkyErrorName},
+    js_error::{JsResult, PubkyError, PubkyErrorName, deserialize_ts},
     wrappers::capabilities::parse_capabilities,
 };
 
 /// Options for starting a grant-backed pubkyauth flow.
 #[derive(Tsify, Serialize, Deserialize, Debug, Clone)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 pub struct GrantAuthFlowOptions {
     /// App identifier shown in the user's grant/session list, typically a domain.
@@ -79,8 +78,9 @@ impl GrantAuthFlow {
     pub fn start(
         #[wasm_bindgen(unchecked_param_type = "Capabilities")] capabilities: String,
         kind: AuthFlowKind,
-        options: GrantAuthFlowOptions,
+        options: Ts<GrantAuthFlowOptions>,
     ) -> JsResult<GrantAuthFlow> {
+        let options = deserialize_ts(&options)?;
         Self::start_with_client(capabilities, kind, options, None)
     }
 
@@ -130,8 +130,9 @@ impl GrantAuthFlow {
     pub async fn start_delegated(
         #[wasm_bindgen(unchecked_param_type = "Capabilities")] capabilities: String,
         kind: AuthFlowKind,
-        options: GrantAuthFlowOptions,
+        options: Ts<GrantAuthFlowOptions>,
     ) -> JsResult<GrantAuthFlow> {
+        let options = deserialize_ts(&options)?;
         Self::start_delegated_with_client(capabilities, kind, options, None).await
     }
 

--- a/pubky-sdk/bindings/js/src/actors/storage/public.rs
+++ b/pubky-sdk/bindings/js/src/actors/storage/public.rs
@@ -2,10 +2,11 @@
 use super::stats::ResourceStats;
 use js_sys::Uint8Array;
 use serde::Serialize;
+use tsify::Ts;
 use wasm_bindgen::prelude::*;
 use web_sys::Response;
 
-use crate::js_error::JsResult;
+use crate::js_error::{JsResult, serialize_ts};
 
 #[wasm_bindgen(typescript_custom_section)]
 const TS_ADDRESS: &'static str =
@@ -119,9 +120,9 @@ impl PublicStorage {
     pub async fn stats(
         &self,
         #[wasm_bindgen(unchecked_param_type = "Address")] address: String,
-    ) -> JsResult<Option<ResourceStats>> {
+    ) -> JsResult<Option<Ts<ResourceStats>>> {
         match self.0.stats(address).await? {
-            Some(stats) => Ok(Some(ResourceStats::from(stats))),
+            Some(stats) => Ok(Some(serialize_ts(&ResourceStats::from(stats))?)),
             None => Ok(None),
         }
     }

--- a/pubky-sdk/bindings/js/src/actors/storage/session.rs
+++ b/pubky-sdk/bindings/js/src/actors/storage/session.rs
@@ -1,11 +1,12 @@
 // js/src/client/storage/session.rs
 use js_sys::Uint8Array;
 use serde::Serialize;
+use tsify::Ts;
 use wasm_bindgen::prelude::*;
 use web_sys::Response;
 
 use super::stats::ResourceStats;
-use crate::js_error::JsResult;
+use crate::js_error::{JsResult, serialize_ts};
 
 #[wasm_bindgen(typescript_custom_section)]
 const TS_PATH: &'static str = r#"export type Path = `/pub/${string}` | `/priv/${string}`;"#;
@@ -112,9 +113,9 @@ impl SessionStorage {
     pub async fn stats(
         &self,
         #[wasm_bindgen(unchecked_param_type = "Path")] path: String,
-    ) -> JsResult<Option<ResourceStats>> {
+    ) -> JsResult<Option<Ts<ResourceStats>>> {
         match self.0.stats(path).await? {
-            Some(stats) => Ok(Some(ResourceStats::from(stats))),
+            Some(stats) => Ok(Some(serialize_ts(&ResourceStats::from(stats))?)),
             None => Ok(None),
         }
     }

--- a/pubky-sdk/bindings/js/src/actors/storage/stats.rs
+++ b/pubky-sdk/bindings/js/src/actors/storage/stats.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 use tsify::Tsify;
-use wasm_bindgen::prelude::*;
 
 /// Resource metadata returned by `SessionStorage.stats()` and `PublicStorage.stats()`.
 ///
@@ -21,7 +20,6 @@ use wasm_bindgen::prelude::*;
 /// - `etag` may be absent and is opaque; compare values to detect updates.
 /// - `lastModifiedMs` increases when the resource is updated.
 #[derive(Tsify, Serialize, Deserialize)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 pub struct ResourceStats {
     /// Size in bytes of the stored object.

--- a/pubky-sdk/bindings/js/src/client/constructor.rs
+++ b/pubky-sdk/bindings/js/src/client/constructor.rs
@@ -2,10 +2,10 @@
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
-use tsify::Tsify;
+use tsify::{Ts, Tsify};
 use wasm_bindgen::prelude::*;
 
-use crate::js_error::{JsResult, PubkyError, PubkyErrorName};
+use crate::js_error::{JsResult, PubkyError, PubkyErrorName, deserialize_ts};
 
 // ------------------------------------------------------------------------------------------------
 // JS style config objects for the client.
@@ -13,7 +13,6 @@ use crate::js_error::{JsResult, PubkyError, PubkyErrorName};
 
 /// Pkarr Config
 #[derive(Tsify, Serialize, Deserialize, Debug)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 pub struct PkarrConfig {
     /// The list of relays to access the DHT with.
@@ -27,7 +26,6 @@ pub struct PkarrConfig {
 
 /// Pubky Client Config
 #[derive(Tsify, Serialize, Deserialize, Debug)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 pub struct PubkyClientConfig {
     /// Configuration on how to access pkarr packets on the mainline DHT.
@@ -70,7 +68,8 @@ impl Client {
     /// });
     /// const pubky = Pubky.withClient(client);
     #[wasm_bindgen(constructor)]
-    pub fn new(config_opt: Option<PubkyClientConfig>) -> JsResult<Self> {
+    pub fn new(config_opt: Option<Ts<PubkyClientConfig>>) -> JsResult<Self> {
+        let config_opt = config_opt.as_ref().map(deserialize_ts).transpose()?;
         let mut builder = pubky::PubkyHttpClient::builder();
 
         if let Some(config) = config_opt

--- a/pubky-sdk/bindings/js/src/js_error.rs
+++ b/pubky-sdk/bindings/js/src/js_error.rs
@@ -1,10 +1,10 @@
 use std::fmt::Display;
 
 use js_sys::{Error as JsError, Reflect};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::{Value, json};
 use serde_wasm_bindgen::Serializer;
-use tsify::Tsify;
+use tsify::{Ts, Tsify};
 use wasm_bindgen::convert::IntoWasmAbi;
 use wasm_bindgen::describe::WasmDescribe;
 use wasm_bindgen::prelude::*;
@@ -21,6 +21,23 @@ use pubky_common::recovery_file::Error as RecoveryFileError;
 /// that can be caught on the JS side.
 pub type JsResult<T> = Result<T, PubkyError>;
 
+pub(crate) fn deserialize_ts<T>(value: &Ts<T>) -> JsResult<T>
+where
+    T: Tsify + DeserializeOwned,
+    T::JsType: Clone,
+{
+    value
+        .to_rust()
+        .map_err(|error| PubkyError::new(PubkyErrorName::InvalidInput, error))
+}
+
+pub(crate) fn serialize_ts<T>(value: &T) -> JsResult<Ts<T>>
+where
+    T: Tsify + Serialize,
+{
+    Ts::from_rust(value).map_err(|error| PubkyError::new(PubkyErrorName::InternalError, error))
+}
+
 // --- TypeScript Documentation & Schema ---
 
 /// A union type of all possible machine-readable codes for the `name` property
@@ -29,7 +46,6 @@ pub type JsResult<T> = Result<T, PubkyError>;
 /// Provides a simplified, actionable set of error categories for developers
 /// to handle in their code.
 #[derive(Tsify, Serialize, Deserialize, Debug, Clone)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "PascalCase")]
 pub enum PubkyErrorName {
     /// A network or server request failed. Check the network connection or retry.

--- a/pubky-sdk/bindings/js/src/pubky.rs
+++ b/pubky-sdk/bindings/js/src/pubky.rs
@@ -3,6 +3,7 @@
     reason = "JS bindings preserve deprecated cookie compatibility APIs"
 )]
 
+use tsify::Ts;
 use wasm_bindgen::prelude::*;
 
 use crate::actors::{
@@ -17,7 +18,11 @@ use crate::actors::{
     storage::PublicStorage,
 };
 use crate::wrappers::keys::PublicKey;
-use crate::{client::constructor::Client, js_error::JsResult, wrappers::keys::Keypair};
+use crate::{
+    client::constructor::Client,
+    js_error::{JsResult, deserialize_ts},
+    wrappers::keys::Keypair,
+};
 
 /// High-level entrypoint to the Pubky SDK.
 #[wasm_bindgen]
@@ -113,8 +118,9 @@ impl Pubky {
         #[wasm_bindgen(unchecked_param_type = "Capabilities")] capabilities: String,
         kind: AuthFlowKind,
         relay: Option<String>,
-        x_callback: Option<XCallbackParams>,
+        x_callback: Option<Ts<XCallbackParams>>,
     ) -> JsResult<AuthFlow> {
+        let x_callback = x_callback.as_ref().map(deserialize_ts).transpose()?;
         let flow = AuthFlow::start_with_client(
             capabilities,
             kind,
@@ -149,8 +155,9 @@ impl Pubky {
         &self,
         #[wasm_bindgen(unchecked_param_type = "Capabilities")] capabilities: String,
         kind: AuthFlowKind,
-        options: GrantAuthFlowOptions,
+        options: Ts<GrantAuthFlowOptions>,
     ) -> JsResult<GrantAuthFlow> {
+        let options = deserialize_ts(&options)?;
         if BrowserGrantKeyStore::can_use_delegation().await {
             let delegated = GrantAuthFlow::start_delegated_with_client(
                 capabilities.clone(),


### PR DESCRIPTION
#567 tried to bump `tsify` and `tsify-macros`, but the newer versions deprecate certain attributes we used:

```
#[tsify(into_wasm_abi, from_wasm_abi)]
```

causing our WASM Clippy CI task to fail.

This PR replaces the deprecated `tsify` attributes with the new `Ts<T>` wrapper:

- Bump `tsify` to `0.5.7` and `tsify-macros` to `0.5.8`.
- Replace deprecated `tsify` ABI attributes with `tsify::Ts<T>` at WASM boundaries.
- Perform fallible serialization and deserialization inside exported functions.
- Add shared helpers to consistently map conversion errors.
- Preserve existing TypeScript API signatures.