### PR TITLE
refactor(sdk)!: remove pubky-prefixed displaying public keys

### DIFF
--- a/e2e/src/tests/private_data.rs
+++ b/e2e/src/tests/private_data.rs
@@ -41,7 +41,7 @@ async fn grant_session(
 
 /// Transport URL for `path` in `owner`'s namespace.
 fn owner_url(owner: &PublicKey, path: &str) -> String {
-    format!("{}/{}", owner, path.trim_start_matches('/'))
+    format!("pubky://{owner}/{}", path.trim_start_matches('/'))
         .into_pubky_resource()
         .unwrap()
         .to_transport_url()

--- a/e2e/src/tests/storage/authorization.rs
+++ b/e2e/src/tests/storage/authorization.rs
@@ -18,7 +18,7 @@ async fn unauthorized_put_delete() {
 
     // Someone tries to write to owner's namespace -> 401 Unauthorized
     let owner_url = format!(
-        "{}/{}",
+        "pubky://{}/{}",
         owner_session.info().public_key(),
         path.trim_start_matches('/')
     );

--- a/e2e/src/tests/storage/listing.rs
+++ b/e2e/src/tests/storage/listing.rs
@@ -43,19 +43,19 @@ async fn list_deep() {
         assert_eq!(
             list,
             vec![
-                format!("{public_key}/pub/example.com/a.txt")
+                format!("pubky://{public_key}/pub/example.com/a.txt")
                     .parse()
                     .unwrap(),
-                format!("{public_key}/pub/example.com/b.txt")
+                format!("pubky://{public_key}/pub/example.com/b.txt")
                     .parse()
                     .unwrap(),
-                format!("{public_key}/pub/example.com/c.txt")
+                format!("pubky://{public_key}/pub/example.com/c.txt")
                     .parse()
                     .unwrap(),
-                format!("{public_key}/pub/example.com/cc-nested/z.txt")
+                format!("pubky://{public_key}/pub/example.com/cc-nested/z.txt")
                     .parse()
                     .unwrap(),
-                format!("{public_key}/pub/example.com/d.txt")
+                format!("pubky://{public_key}/pub/example.com/d.txt")
                     .parse()
                     .unwrap(),
             ],
@@ -76,10 +76,10 @@ async fn list_deep() {
         assert_eq!(
             list,
             vec![
-                format!("{public_key}/pub/example.com/a.txt")
+                format!("pubky://{public_key}/pub/example.com/a.txt")
                     .parse()
                     .unwrap(),
-                format!("{public_key}/pub/example.com/b.txt")
+                format!("pubky://{public_key}/pub/example.com/b.txt")
                     .parse()
                     .unwrap(),
             ],
@@ -102,10 +102,10 @@ async fn list_deep() {
         assert_eq!(
             list,
             vec![
-                format!("{public_key}/pub/example.com/b.txt")
+                format!("pubky://{public_key}/pub/example.com/b.txt")
                     .parse()
                     .unwrap(),
-                format!("{public_key}/pub/example.com/c.txt")
+                format!("pubky://{public_key}/pub/example.com/c.txt")
                     .parse()
                     .unwrap(),
             ],
@@ -127,10 +127,10 @@ async fn list_deep() {
         assert_eq!(
             list,
             vec![
-                format!("{public_key}/pub/example.com/b.txt")
+                format!("pubky://{public_key}/pub/example.com/b.txt")
                     .parse()
                     .unwrap(),
-                format!("{public_key}/pub/example.com/c.txt")
+                format!("pubky://{public_key}/pub/example.com/c.txt")
                     .parse()
                     .unwrap(),
             ],
@@ -187,15 +187,19 @@ async fn list_shallow() {
         assert_eq!(
             list,
             vec![
-                format!("{public_key}/pub/a.com/").parse().unwrap(),
-                format!("{public_key}/pub/example.com/").parse().unwrap(),
-                format!("{public_key}/pub/example.con-file")
+                format!("pubky://{public_key}/pub/a.com/").parse().unwrap(),
+                format!("pubky://{public_key}/pub/example.com/")
                     .parse()
                     .unwrap(),
-                format!("{public_key}/pub/example.con/").parse().unwrap(),
-                format!("{public_key}/pub/file").parse().unwrap(),
-                format!("{public_key}/pub/file2").parse().unwrap(),
-                format!("{public_key}/pub/z.com/").parse().unwrap(),
+                format!("pubky://{public_key}/pub/example.con-file")
+                    .parse()
+                    .unwrap(),
+                format!("pubky://{public_key}/pub/example.con/")
+                    .parse()
+                    .unwrap(),
+                format!("pubky://{public_key}/pub/file").parse().unwrap(),
+                format!("pubky://{public_key}/pub/file2").parse().unwrap(),
+                format!("pubky://{public_key}/pub/z.com/").parse().unwrap(),
             ],
             "normal list shallow"
         );
@@ -216,8 +220,10 @@ async fn list_shallow() {
         assert_eq!(
             list,
             vec![
-                format!("{public_key}/pub/a.com/").parse().unwrap(),
-                format!("{public_key}/pub/example.com/").parse().unwrap(),
+                format!("pubky://{public_key}/pub/a.com/").parse().unwrap(),
+                format!("pubky://{public_key}/pub/example.com/")
+                    .parse()
+                    .unwrap(),
             ],
             "normal list shallow with limit but no cursor"
         );
@@ -238,14 +244,16 @@ async fn list_shallow() {
     assert_eq!(
         list1,
         vec![
-            format!("{public_key}/pub/example.con-file")
+            format!("pubky://{public_key}/pub/example.con-file")
                 .parse()
                 .unwrap(),
-            format!("{public_key}/pub/example.con/").parse().unwrap(),
+            format!("pubky://{public_key}/pub/example.con/")
+                .parse()
+                .unwrap(),
         ],
         "normal list shallow with limit and a file cursor"
     );
-    // Do the same again but without the pubky:// prefix
+    // Do the same again with a bare cursor.
     let list2 = owner_session
         .storage()
         .list(&url)
@@ -278,11 +286,13 @@ async fn list_shallow() {
         assert_eq!(
             list,
             vec![
-                format!("{public_key}/pub/example.con-file")
+                format!("pubky://{public_key}/pub/example.con-file")
                     .parse()
                     .unwrap(),
-                format!("{public_key}/pub/example.con/").parse().unwrap(),
-                format!("{public_key}/pub/file").parse().unwrap(),
+                format!("pubky://{public_key}/pub/example.con/")
+                    .parse()
+                    .unwrap(),
+                format!("pubky://{public_key}/pub/file").parse().unwrap(),
             ],
             "normal list shallow with limit and a directory cursor"
         );

--- a/e2e/src/tests/storage/objects.rs
+++ b/e2e/src/tests/storage/objects.rs
@@ -298,7 +298,7 @@ async fn put_then_get_json_roundtrip() {
     // Read back as strongly-typed JSON and assert equality.
     let got: Payload = pubky
         .public_storage()
-        .get_json(format!("{public_key}/{path}"))
+        .get_json(format!("pubky://{public_key}/{path}"))
         .await
         .unwrap();
     assert_eq!(got, expected);

--- a/examples/javascript/3-storage.mjs
+++ b/examples/javascript/3-storage.mjs
@@ -5,10 +5,10 @@ import { args } from "./_cli.mjs";
 
 const usage = `
 Usage:
-  node 3-storage.mjs pubky<user>/<absolute-path> [--testnet]
+  node 3-storage.mjs pubky://<user>/<absolute-path> [--testnet]
 
 Example:
-  node 3-storage.mjs pubkyq5oo7majwe3mbkj6p49osws8o748b186bbojdxdn3asnn63enk6y/pub/my-cool-app/hello.txt --testnet
+  node 3-storage.mjs pubky://q5oo7majwe3mbkj6p49osws8o748b186bbojdxdn3asnn63enk6y/pub/my-cool-app/hello.txt --testnet
   node 3-storage.mjs pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/posts/0033X02JAN0SG
 `;
 
@@ -21,7 +21,7 @@ if (!resource) {
 
 const pubky = a.testnet ? Pubky.testnet() : new Pubky();
 
-// PublicStorage reads from addressed `pubky<pk>/<abs-path>` or `pubky://<pk>/<abs-path>` values
+// PublicStorage reads from `pubky://<pk>/<abs-path>` values.
 const exists = await pubky.publicStorage.exists(resource);
 console.log(`Exists: ${exists ? "yes" : "no"}`);
 

--- a/examples/javascript/README.md
+++ b/examples/javascript/README.md
@@ -113,15 +113,15 @@ See [**2-auth-flow**](./2-auth-flow/README.md) for the browser app details. The 
 
 ### 3) Public storage read (no auth)
 
-Reads a public resource via the **addressed** form: `pubky<z32>/pub/my-cool-app/path/to/file.txt`.
+Reads a public resource via the Pubky URL form: `pubky://<z32>/pub/my-cool-app/path/to/file.txt`.
 This requires a public resource whose Pubky key is already resolvable. It is not the best first smoke test for a fresh local testnet user because PKDNS publication can lag or fail independently of authenticated storage.
 
 ```bash
 node 3-storage.mjs <pubky>/<absolute-path> [--testnet]
 
 # examples
-node 3-storage.mjs pubkyq5oo7ma.../pub/my-cool-app/hello.txt --testnet
-node 3-storage.mjs pubkyoperrr8w.../pub/pubky.app/posts/0033X02JAN0SG
+node 3-storage.mjs pubky://q5oo7ma.../pub/my-cool-app/hello.txt --testnet
+node 3-storage.mjs pubky://operrr8w.../pub/pubky.app/posts/0033X02JAN0SG
 ```
 
 Shows **exists**, **stats**, and downloads the content.

--- a/examples/rust/4-request/main.rs
+++ b/examples/rust/4-request/main.rs
@@ -11,7 +11,7 @@ use pubky::{Method, PubkyHttpClient};
 struct Cli {
     /// HTTP method to use (GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS)
     method: Method,
-    /// Pubky or HTTPS URL (e.g. pubky<user>/pub/my-cool-app/file, pubky://<user>/..., or https://example.com)
+    /// Pubky or HTTPS URL (e.g. pubky://<user>/pub/my-cool-app/file or https://example.com)
     url: Url,
     /// Use testnet endpoints
     #[arg(long)]

--- a/pubky-common/src/keys.rs
+++ b/pubky-common/src/keys.rs
@@ -8,16 +8,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 type ParseError = <pkarr::PublicKey as TryFrom<String>>::Error;
 
-fn parse_public_key(value: &str) -> Result<pkarr::PublicKey, ParseError> {
-    let raw = if PublicKey::is_pubky_prefixed(value) {
-        value.strip_prefix("pubky").unwrap_or(value)
-    } else {
-        value
-    };
-    pkarr::PublicKey::try_from(raw.to_string())
-}
-
-/// Wrapper around [`pkarr::Keypair`] that customizes [`PublicKey`] rendering.
+/// Wrapper around [`pkarr::Keypair`].
 #[derive(Clone)]
 pub struct Keypair(pkarr::Keypair);
 
@@ -50,8 +41,8 @@ impl Keypair {
 
     /// Return the [`PublicKey`] associated with this [`Keypair`].
     ///
-    /// Display the returned key with `.to_string()` to get the `pubky<z32>` identifier or
-    /// [`PublicKey::z32()`] when you specifically need the bare z-base32 text (e.g. hostnames).
+    /// Display the returned key with `.to_string()` or [`PublicKey::z32()`] to get its z-base32
+    /// encoding.
     #[must_use]
     pub fn public_key(&self) -> PublicKey {
         PublicKey(self.0.public_key())
@@ -108,15 +99,22 @@ impl From<Keypair> for pkarr::Keypair {
     }
 }
 
-/// Wrapper around [`pkarr::PublicKey`] that renders with the `pubky` prefix.
+/// Wrapper around [`pkarr::PublicKey`].
 ///
-/// Note: human-readable serde, transport, and database formats use raw z32 strings. Use
-/// [`PublicKey::z32()`] for hostnames, query parameters, storage, and wire formats.
+/// The canonical string representation is raw z-base32. Legacy `pubky<z32>` input remains
+/// accepted for compatibility.
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct PublicKey(pkarr::PublicKey);
 
 impl PublicKey {
-    /// Returns true if the value is in `pubky<z32>` form.
+    fn parse_legacy_compatible(value: &str) -> Result<pkarr::PublicKey, ParseError> {
+        let raw = value
+            .strip_prefix("pubky")
+            .filter(|_| Self::is_pubky_prefixed(value));
+        pkarr::PublicKey::try_from(raw.unwrap_or(value).to_string())
+    }
+
+    /// Returns true if the value is in the legacy `pubky<z32>` form.
     pub fn is_pubky_prefixed(value: &str) -> bool {
         matches!(value.strip_prefix("pubky"), Some(stripped) if stripped.len() == 52)
     }
@@ -133,7 +131,7 @@ impl PublicKey {
         self.0
     }
 
-    /// Return the raw z-base32 representation without the `pubky` prefix.
+    /// Return the canonical z-base32 representation.
     ///
     /// This is the canonical transport/storage form used for hostnames, query
     /// parameters, serde, and database persistence.
@@ -150,7 +148,7 @@ impl PublicKey {
 
 impl fmt::Display for PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "pubky{}", self.z32())
+        f.write_str(&self.z32())
     }
 }
 
@@ -217,7 +215,7 @@ impl TryFrom<&str> for PublicKey {
     type Error = ParseError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        parse_public_key(value).map(Self)
+        Self::parse_legacy_compatible(value).map(Self)
     }
 }
 
@@ -225,7 +223,7 @@ impl TryFrom<&String> for PublicKey {
     type Error = ParseError;
 
     fn try_from(value: &String) -> Result<Self, Self::Error> {
-        parse_public_key(value).map(Self)
+        Self::parse_legacy_compatible(value).map(Self)
     }
 }
 
@@ -233,7 +231,7 @@ impl TryFrom<String> for PublicKey {
     type Error = ParseError;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
-        parse_public_key(&value).map(Self)
+        Self::parse_legacy_compatible(&value).map(Self)
     }
 }
 
@@ -241,7 +239,7 @@ impl FromStr for PublicKey {
     type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        parse_public_key(s).map(Self)
+        Self::parse_legacy_compatible(s).map(Self)
     }
 }
 
@@ -269,9 +267,17 @@ mod tests {
     }
 
     #[test]
-    fn public_key_display_uses_pubky_prefix() {
+    fn public_key_display_uses_z32() {
         let public_key = Keypair::random().public_key();
 
-        assert_eq!(public_key.to_string(), format!("pubky{}", public_key.z32()));
+        assert_eq!(public_key.to_string(), public_key.z32());
+    }
+
+    #[test]
+    fn public_key_parses_legacy_prefixed_input() {
+        let public_key = Keypair::random().public_key();
+        let legacy = format!("pubky{public_key}");
+
+        assert_eq!(legacy.parse::<PublicKey>().unwrap(), public_key);
     }
 }

--- a/pubky-sdk/README.md
+++ b/pubky-sdk/README.md
@@ -42,7 +42,7 @@ assert_eq!(&body, "hello");
 let txt = pubky
     .public_storage()
     .get(format!(
-        "{}/pub/my-cool-app/hello.txt",
+        "pubky://{}/pub/my-cool-app/hello.txt",
         session.info().public_key()
     ))
     .await?
@@ -70,14 +70,11 @@ println!("Your current homeserver: {:?}", resolved);
 # Ok(()) }
 ```
 
-## Key formats (display vs transport)
+## Public-key format
 
-`PublicKey` has two string representations:
+`PublicKey` uses raw z-base-32.
 
-- **Display format**: `pubky<z32>` (used for logs/UI and human-facing identifiers).
-- **Transport/storage format**: raw `z32` (used for hostnames, storage owner path segments, legacy headers, query params, serde/JSON, and database storage).
-
-Use `.z32()` whenever you are building hostnames or transport values (for example `_pubky.<z32>`, `/storage/<z32>/...`, or the legacy `pubky-host` header). Use `Display`/`.to_string()` when you want the prefixed identifier for people.
+Use `.to_string()` or `.z32()` to obtain the key. `pubky://` remains the scheme for addressed resources.
 
 ### Reuse a single facade across your app
 
@@ -131,13 +128,13 @@ let pubky = Pubky::new()?;
 let public = pubky.public_storage();
 
 let file = public
-    .get(format!("{user_id}/pub/example.com/file.bin"))
+    .get(format!("pubky://{user_id}/pub/example.com/file.bin"))
     .await?
     .bytes()
     .await?;
 
 let entries = public
-    .list(format!("{user_id}/pub/example.com/"))?
+    .list(format!("pubky://{user_id}/pub/example.com/"))?
     .limit(10)
     .send()
     .await?;
@@ -153,7 +150,7 @@ See the [Public Storage example](https://github.com/pubky/pubky-homeserver/tree/
 Path rules:
 
 - Session storage uses **absolute** paths under `/pub/` or `/priv/`.
-- Public storage uses **addressed** form `pubky<user>/pub/app/file.txt` (preferred) or `pubky://<user>/...`.
+- Public storage uses `pubky://<user>/pub/app/file.txt`.
 - A storage path cannot be both an exact file and an implicit folder prefix. For example:
   - if `/pub/app/foo` exists, writing `/pub/app/foo/bar.json` returns `409 Conflict`.
   - if descendants under `/pub/app/foo/` exist, writing `/pub/app/foo` returns `409 Conflict`.
@@ -171,7 +168,7 @@ Use [`resolve_pubky`] to turn a public resource identifier into its canonical HT
 # use reqwest::Method;
 # async fn run() -> pubky::Result<()> {
 let client = PubkyHttpClient::new()?;
-let url = resolve_pubky("pubkyoperrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/posts/0033X02JAN0SG")?;
+let url = resolve_pubky("pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/posts/0033X02JAN0SG")?;
 assert_eq!(
     url.as_str(),
     "https://_pubky.operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/storage/operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/posts/0033X02JAN0SG"

--- a/pubky-sdk/bindings/js/pkg/README.md
+++ b/pubky-sdk/bindings/js/pkg/README.md
@@ -52,20 +52,18 @@ await session.storage.putJson(path, { hello: "world" });
 
 // 5) Read it publicly (no auth needed)
 const userPk = session.info.publicKey.toString();
-const addr = `${userPk}/pub/my-cool-app/hello.json`;
+const addr = `pubky://${userPk}/pub/my-cool-app/hello.json`;
 const json = await pubky.publicStorage.getJson(addr); // -> { hello: "world" }
 ```
 
 Find here [**ready-to-run examples**](https://github.com/pubky/pubky-homeserver/tree/main/examples).
 
-### Key formats (display vs transport)
+### Public-key format
 
-`PublicKey` has two string forms:
+`PublicKey` uses raw z-base-32.
 
-- **Display format**: `pubky<z32>` (for logs/UI/human-facing identifiers).
-- **Transport/storage format**: raw `z32` (for hostnames, headers, query params, serde/JSON, DB storage).
-
-Use `publicKey.z32()` for transport/storage. Use `publicKey.toString()` for display.
+Use `publicKey.toString()` or `publicKey.z32()` to obtain the key. `pubky://` remains the
+scheme for addressed resources.
 
 ### Initialization & events
 
@@ -116,9 +114,9 @@ import { Client, PublicKey, resolvePubky } from "@synonymdev/pubky";
 
 const client = new Client(); // or: pubky.client.fetch(); instead of constructing a client manually
 
-// Convert the identifier into a transport URL before fetching.
-const userId = PublicKey.from("pubky<z32>").toString();
-const url = resolvePubky(`${userId}/pub/my-cool-app/file.txt`);
+// Convert the Pubky URL into a transport URL before fetching.
+const userId = PublicKey.from("<z32>").toString();
+const url = resolvePubky(`pubky://${userId}/pub/my-cool-app/file.txt`);
 const res = await client.fetch(url);
 ```
 
@@ -134,7 +132,7 @@ const pubkey = keypair.publicKey;
 
 // z-base-32 roundtrip
 const parsed = PublicKey.from(pubkey.z32());
-const displayId = pubkey.toString(); // pubky<z32> (display only)
+const displayId = pubkey.toString(); // raw z-base-32
 ```
 
 #### Recovery file (encrypt/decrypt root secret)
@@ -178,7 +176,7 @@ await session1.signout(); // invalidates server session
 **Session details**
 
 ```js
-const userPk = session.info.publicKey.toString(); // -> pubky<z32> identifier
+const userPk = session.info.publicKey.toString(); // -> raw z-base-32
 const caps = session.info.capabilities; // -> string[] permissions and paths
 
 const storage = session.storage; // -> This User's storage API (absolute paths)
@@ -358,20 +356,20 @@ const pub = pubky.publicStorage;
 
 // Reads
 const response = await pub.get(
-  `${userPk}/pub/example.com/data.json`
+  `pubky://${userPk}/pub/example.com/data.json`
 ); // -> Response (stream it)
-await pub.getJson(`${userPk}/pub/example.com/data.json`);
-await pub.getText(`${userPk}/pub/example.com/readme.txt`);
-await pub.getBytes(`${userPk}/pub/example.com/icon.png`); // Uint8Array
+await pub.getJson(`pubky://${userPk}/pub/example.com/data.json`);
+await pub.getText(`pubky://${userPk}/pub/example.com/readme.txt`);
+await pub.getBytes(`pubky://${userPk}/pub/example.com/icon.png`); // Uint8Array
 
 // Metadata
-await pub.exists(`${userPk}/pub/example.com/foo`); // boolean
-await pub.stats(`${userPk}/pub/example.com/foo`); // { content_length, content_type, etag, last_modified } | null
+await pub.exists(`pubky://${userPk}/pub/example.com/foo`); // boolean
+await pub.stats(`pubky://${userPk}/pub/example.com/foo`); // { content_length, content_type, etag, last_modified } | null
 
-// List directory (addressed path "<pubky>/pub/.../") must include trailing `/`.
+// List directory (Pubky URL) must include a trailing `/`.
 // list(addr, cursor=null|suffix|fullUrl, reverse=false, limit?, shallow=false)
 await pub.list(
-  `${userPk}/pub/example.com/`,
+  `pubky://${userPk}/pub/example.com/`,
   null,
   false,
   100,
@@ -413,7 +411,7 @@ await s.delete("/pub/example.com/data.json");
 Path rules:
 
 - Session storage uses **absolute** paths under `/pub/` or `/priv/`.
-- Public storage uses **addressed** form `pubky<user>/pub/app/file.txt` (preferred) or `pubky://<user>/...`.
+- Public storage uses `pubky://<user>/pub/app/file.txt`.
 
 **Convention:** put your app’s public data under a domain-like folder in `/pub`, e.g. `/pub/my-new-app/`.
 
@@ -431,7 +429,7 @@ import { Pubky, PublicKey, Keypair } from "@synonymdev/pubky";
 const pubky = new Pubky();
 
 // Read-only resolver
-const homeserver = await pubky.getHomeserverOf(PublicKey.from("pubky<z32>")); // PublicKey | undefined
+const homeserver = await pubky.getHomeserverOf(PublicKey.from("<z32>")); // PublicKey | undefined
 // Rejects if PKARR resolution fails or the `_pubky` target is malformed.
 
 // With keys (signer-bound)
@@ -465,12 +463,13 @@ Use `resolvePubky()` when you need to feed an addressed resource into a raw HTTP
 import { resolvePubky } from "@synonymdev/pubky";
 
 const identifier =
-  "pubkyoperrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/posts/0033X02JAN0SG";
+  "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/posts/0033X02JAN0SG";
 const url = resolvePubky(identifier);
 // -> "https://_pubky.operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/storage/operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/posts/0033X02JAN0SG"
 ```
 
-Both `pubky<pk>/…` (preferred) and `pubky://<pk>/…` resolve to the same HTTPS endpoint.
+Legacy `pubky<pk>/…` identifiers remain accepted for compatibility, but new code should use
+`pubky://<pk>/…`.
 
 ---
 
@@ -501,7 +500,7 @@ Example:
 
 ```js
 try {
-  await publicStorage.getJson(`${pk}/pub/example.com/missing.json`);
+  await publicStorage.getJson(`pubky://${pk}/pub/example.com/missing.json`);
 } catch (e) {
   const error = e as PubkyError;
   if (

--- a/pubky-sdk/bindings/js/pkg/tests/keys.ts
+++ b/pubky-sdk/bindings/js/pkg/tests/keys.ts
@@ -44,6 +44,8 @@ test("PublicKey from and toUint8Array", async (t) => {
   const z32 = "gcumbhd7sqit6nn457jxmrwqx9pyymqwamnarekgo3xppqo6a19o";
   const publicKey = PublicKey.from(z32);
   t.is(publicKey.z32(), z32);
+  t.is(publicKey.toString(), z32);
+  t.is(PublicKey.from(`pubky${z32}`).toString(), z32, "accepts legacy input");
   t.deepEqual(
     publicKey.toUint8Array(),
     Uint8Array.from([

--- a/pubky-sdk/bindings/js/pkg/tests/session.ts
+++ b/pubky-sdk/bindings/js/pkg/tests/session.ts
@@ -499,7 +499,7 @@ test("Auth: multi-user host isolation + stale-handle safety", async (t) => {
     user: string,
     relPath: Path,
   ): Promise<string> => {
-    const address = `pubky${user}${relPath}` as Address;
+    const address = `pubky://${user}${relPath}` as Address;
     return sdk.publicStorage.getText(address);
   };
 
@@ -612,7 +612,7 @@ test("Auth: signup/signout loops keep cookies and host in sync", async (t) => {
 
   const u1 = await signupAndMark("user#1:hello");
   t.equal(
-    await sdk.publicStorage.getText(`pubky${u1.user}${P}` as Address),
+    await sdk.publicStorage.getText(`pubky://${u1.user}${P}` as Address),
     "user#1:hello",
     "first user marked",
   );
@@ -631,7 +631,7 @@ test("Auth: signup/signout loops keep cookies and host in sync", async (t) => {
 
   const u2 = await signupAndMark("user#2:hello");
   t.equal(
-    await sdk.publicStorage.getText(`pubky${u2.user}${P}` as Address),
+    await sdk.publicStorage.getText(`pubky://${u2.user}${P}` as Address),
     "user#2:hello",
     "second user marked",
   );
@@ -654,7 +654,7 @@ test("Auth: signup/signout loops keep cookies and host in sync", async (t) => {
     t.ok(r.ok, "low-level client PUT for user#2 ok");
   }
   t.equal(
-    await sdk.publicStorage.getText(`pubky${u2.user}${P}` as Address),
+    await sdk.publicStorage.getText(`pubky://${u2.user}${P}` as Address),
     "user#2:via-client",
     "low-level client wrote under user#2",
   );

--- a/pubky-sdk/bindings/js/pkg/tests/storage.ts
+++ b/pubky-sdk/bindings/js/pkg/tests/storage.ts
@@ -32,16 +32,16 @@ type _StorageDelete = Assert<
 >;
 
 const toAddress = (user: string, relPath: Path): Address =>
-  `pubky${user}${relPath}` as Address;
+  `pubky://${user}${relPath}` as Address;
 
 test("resolvePubky helper", (t) => {
   const pk = HOMESERVER_PUBLICKEY.z32();
-  const preferred = `pubky${pk}/pub/example.com/data.txt`;
-  const deeplink = `pubky://${pk}/pub/example.com/data.txt`;
+  const canonical = `pubky://${pk}/pub/example.com/data.txt`;
+  const legacy = `pubky${pk}/pub/example.com/data.txt`;
   const expected = `https://_pubky.${pk}/storage/${pk}/pub/example.com/data.txt`;
 
-  t.equal(resolvePubky(preferred), expected, "preferred format resolves");
-  t.equal(resolvePubky(deeplink), expected, "deeplink format resolves");
+  t.equal(resolvePubky(canonical), expected, "canonical URL resolves");
+  t.equal(resolvePubky(legacy), expected, "legacy identifier resolves");
   t.end();
 });
 
@@ -240,7 +240,7 @@ test("list (public dir listing with limit/cursor/reverse)", async (t) => {
   await mk(`/pub/example.wrong/d.txt` as Path);
   await mk(`/pub/z.wrong/a.txt` as Path);
 
-  const dir: Address = `pubky${userPk}/pub/example.com/` as Address;
+  const dir: Address = `pubky://${userPk}/pub/example.com/` as Address;
 
   {
     const list = await sdk.publicStorage.list(dir);
@@ -467,7 +467,7 @@ test("not found", async (t) => {
   const session = await signer.signin("storage.test");
 
   const userPk = session.info.publicKey.z32();
-  const addr = `pubky${userPk}/pub/example.com/definitely-missing.json` as Address;
+  const addr = `pubky://${userPk}/pub/example.com/definitely-missing.json` as Address;
 
   t.equal(
     await sdk.publicStorage.exists(addr),

--- a/pubky-sdk/bindings/js/src/actors/storage/public.rs
+++ b/pubky-sdk/bindings/js/src/actors/storage/public.rs
@@ -9,10 +9,9 @@ use web_sys::Response;
 use crate::js_error::{JsResult, serialize_ts};
 
 #[wasm_bindgen(typescript_custom_section)]
-const TS_ADDRESS: &'static str =
-    r#"export type Address = `pubky${string}/pub/${string}` | `pubky://${string}/pub/${string}`;"#;
+const TS_ADDRESS: &'static str = r#"export type Address = `pubky://${string}/pub/${string}`;"#;
 
-/// Read-only public storage using addressed paths (`"pubky<user>/pub/..."`).
+/// Read-only public storage using Pubky URLs (`"pubky://<user>/pub/..."`).
 #[wasm_bindgen]
 pub struct PublicStorage(pub(crate) pubky::PublicStorage);
 
@@ -87,7 +86,7 @@ impl PublicStorage {
 
     /// Fetch JSON from an addressed path.
     ///
-    /// @param {Address} address `"pubky<user>/pub/.../file.json"` (preferred) or `pubky://<user>/pub/...`.
+    /// @param {Address} address `"pubky://<user>/pub/.../file.json"`.
     /// @returns {Promise<any>}
     #[wasm_bindgen(js_name = "getJson")]
     pub async fn get_json(
@@ -113,7 +112,7 @@ impl PublicStorage {
 
     /// Get metadata for an address
     ///
-    /// @param {Address} address `"pubky<user>/pub/.../file.json"` (preferred) or `pubky://<user>/pub/...`.
+    /// @param {Address} address `"pubky://<user>/pub/.../file.json"`.
     /// @returns {Promise<ResourceStats|undefined>} `undefined` if the resource does not exist.
     /// @throws {PubkyError} On invalid input or transport/server errors.
     #[wasm_bindgen(js_name = "stats")]

--- a/pubky-sdk/bindings/js/src/actors/storage/stats.rs
+++ b/pubky-sdk/bindings/js/src/actors/storage/stats.rs
@@ -10,7 +10,7 @@ use tsify::Tsify;
 /// @property {string=} etag           Opaque server ETag for the current version.
 ///
 /// @example
-/// const stats = await pubky.publicStorage.stats(`${user}/pub/app/file.json`);
+/// const stats = await pubky.publicStorage.stats(`pubky://${user}/pub/app/file.json`);
 /// if (stats) {
 ///   console.log(stats.contentLength, stats.contentType, stats.lastModifiedMs);
 /// }

--- a/pubky-sdk/bindings/js/src/pubky.rs
+++ b/pubky-sdk/bindings/js/src/pubky.rs
@@ -260,13 +260,13 @@ impl Pubky {
 
     /// Public, unauthenticated storage API.
     ///
-    /// Use for **read-only** public access via addressed paths:
-    /// `"pubky<user>/pub/…"`.
+    /// Use for **read-only** public access via Pubky URLs:
+    /// `"pubky://<user>/pub/…"`.
     ///
     /// @returns {PublicStorage}
     ///
     /// @example
-    /// const text = await pubky.publicStorage.getText(`${userPk.toString()}/pub/example.com/hello.txt`);
+    /// const text = await pubky.publicStorage.getText(`pubky://${userPk}/pub/example.com/hello.txt`);
     #[wasm_bindgen(js_name = "publicStorage", getter)]
     pub fn public_storage(&self) -> PublicStorage {
         PublicStorage(self.0.public_storage())

--- a/pubky-sdk/bindings/js/src/utils.rs
+++ b/pubky-sdk/bindings/js/src/utils.rs
@@ -65,9 +65,9 @@ pub fn set_log_level(level: Level) -> Result<(), JsValue> {
     Ok(())
 }
 
-/// Resolve a `pubky://` or `pubky<pk>/…` identifier into the homeserver transport URL.
+/// Resolve a `pubky://` URL into the homeserver transport URL.
 ///
-/// @param {string} identifier Either `pubky<pk>/...` (preferred) or `pubky://<pk>/...`.
+/// Legacy `pubky<pk>/...` identifiers remain accepted.
 /// @returns {string} HTTPS URL in the form `https://_pubky.<pk>/storage/<pk>/...`.
 #[wasm_bindgen(js_name = "resolvePubky")]
 pub fn resolve_pubky(identifier: &str) -> JsResult<String> {

--- a/pubky-sdk/bindings/js/src/wrappers/auth_token.rs
+++ b/pubky-sdk/bindings/js/src/wrappers/auth_token.rs
@@ -99,8 +99,7 @@ impl AuthToken {
 
     /// Returns the **public key** that authenticated with this token.
     ///
-    /// Use `.toString()` on the returned `PublicKey` to get the `pubky<z32>` identifier.
-    /// Call `.z32()` when you specifically need the raw z-base32 value (e.g. hostnames).
+    /// Use `.toString()` or `.z32()` on the returned `PublicKey` to get its z-base32 encoding.
     ///
     /// @example
     /// const who = token.publicKey.toString();

--- a/pubky-sdk/bindings/js/src/wrappers/keys.rs
+++ b/pubky-sdk/bindings/js/src/wrappers/keys.rs
@@ -33,9 +33,7 @@ impl Keypair {
 
     /// Returns the [PublicKey] of this keypair.
     ///
-    /// Use `.toString()` on the returned `PublicKey` to get the string form
-    /// or `.z32()` to get the z32 string form without prefix.
-    /// Transport/storage (query params, headers, persistence) should use `.z32()`.
+    /// Use `.toString()` or `.z32()` on the returned `PublicKey` to get its z-base32 encoding.
     ///
     /// @example
     /// const who = keypair.publicKey.toString();
@@ -92,8 +90,7 @@ impl PublicKey {
     }
 
     #[wasm_bindgen(js_name = "toString")]
-    /// Returns the identifier form with the `pubky` prefix.
-    /// Use for display only; transport/storage should use `.z32()`.
+    /// Returns the canonical z-base32 encoding.
     pub fn to_string_js(&self) -> String {
         self.0.to_string()
     }
@@ -104,7 +101,7 @@ impl PublicKey {
         if value.starts_with("pubky://") {
             return Err(PubkyError::new(
                 PubkyErrorName::InvalidInput,
-                "public key must be raw z32 or pubky<z32>; pubky:// is not supported",
+                "public key must be raw z32 or legacy pubky<z32>; pubky:// is not supported",
             ));
         }
         let value = if NativePublicKey::is_pubky_prefixed(&value) {

--- a/pubky-sdk/bindings/js/src/wrappers/resource.rs
+++ b/pubky-sdk/bindings/js/src/wrappers/resource.rs
@@ -26,7 +26,7 @@ impl PubkyResource {
     ///
     /// Accepts:
     /// - `pubky://<public_key>/<path>` (URL form)
-    /// - `pubky<public_key>/<path>` (identifier form)
+    /// - legacy `pubky<public_key>/<path>` (identifier form)
     ///
     /// @param {string} value - The resource string to parse
     /// @returns {PubkyResource} - The parsed resource
@@ -55,7 +55,7 @@ impl PubkyResource {
         self.0.to_pubky_url()
     }
 
-    /// Render as `pubky<owner>/<path>` (identifier form).
+    /// Render as `pubky://<owner>/<path>`.
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string_js(&self) -> String {
         self.0.to_string()

--- a/pubky-sdk/bindings/js/src/wrappers/session_info.rs
+++ b/pubky-sdk/bindings/js/src/wrappers/session_info.rs
@@ -10,8 +10,7 @@ pub struct SessionInfo(pub(crate) pubky::SessionInfo);
 impl SessionInfo {
     /// The user’s public key for this session.
     ///
-    /// Use `.toString()` on the returned `PublicKey` to get the `pubky<z32>` identifier.
-    /// Call `.z32()` when you specifically need the raw z-base32 value (e.g. hostnames).
+    /// Use `.toString()` or `.z32()` on the returned `PublicKey` to get its z-base32 encoding.
     ///
     /// @returns {PublicKey}
     ///

--- a/pubky-sdk/src/actors/storage/core.rs
+++ b/pubky-sdk/src/actors/storage/core.rs
@@ -107,7 +107,7 @@ impl SessionStorage {
 /// No keys or session needed. Accepts **addressed resources** that pair a user's
 /// public key with an absolute path. Supported address formats:
 /// - `"pubky://<z32-pubkey>/pub/..."` (canonical)
-/// - `"pubky<z32-pubkey>/pub/..."` (compact)
+/// - legacy `"pubky<z32-pubkey>/pub/..."`
 /// - `(PublicKey, "/pub/...")` tuple
 ///
 /// Writes are not available — use [`SessionStorage`] for that.

--- a/pubky-sdk/src/actors/storage/resource.rs
+++ b/pubky-sdk/src/actors/storage/resource.rs
@@ -8,9 +8,9 @@
 //!   operations that act “as me”. Example: `session.storage().get("/pub/my-cool-app/file")`.
 //!
 //! - [`PubkyResource`]: an **addressed resource** that pairs a user with an absolute path,
-//!   e.g. `"pubky<public_key>/pub/my-cool-app/file"` (preferred) or `pubky://<public_key>/pub/my-cool-app/file`.
+//!   e.g. `pubky://<public_key>/pub/my-cool-app/file`.
 //!   It is used by *public* (unauthenticated) operations and any API that must
-//!   target **another user’s** data. Example: `public.get("pubky<pk>/pub/site/index.html")`.
+//!   target **another user’s** data. Example: `public.get("pubky://<pk>/pub/site/index.html")`.
 //!
 //! Keeping these distinct eliminates ambiguity and makes IDE auto-completion
 //! tell you exactly what each method expects.
@@ -163,11 +163,9 @@ impl fmt::Display for ResourcePath {
 /// This is the unambiguous “user + absolute path” form used when acting on
 /// **another user’s** data (public reads, etc.).
 ///
-/// Accepted inputs for `FromStr`:
-/// - `pubky<public_key>/<abs-path>` (preferred)
-/// - `pubky://<public_key>/<abs-path>`
+/// Canonically renders as `pubky://<public_key>/<abs-path>`.
 ///
-/// Display renders as `pubky<public_key>/<abs-path>` for quick visual identification.
+/// Legacy `pubky<public_key>/<abs-path>` values remain accepted as input for compatibility.
 ///
 /// ### Examples
 /// ```
@@ -265,12 +263,6 @@ impl PubkyResource {
             .map_err(|_err| invalid("transport URL path is not valid UTF-8"))?;
         Self::new(owner, decoded_path.as_ref())
     }
-
-    /// Render as the identifier form `pubky<owner>/<abs-path>`.
-    pub(crate) fn to_identifier(&self) -> String {
-        let path = self.path.as_root_relative_str();
-        format!("{}/{path}", self.owner)
-    }
 }
 
 fn parse_transport_owner(owner: &str) -> Result<PublicKey, Error> {
@@ -303,7 +295,7 @@ impl FromStr for PubkyResource {
             return Self::new(user, path);
         }
 
-        // 2) pubky<user>/<path>
+        // 2) Legacy pubky<user>/<path>
         if let Some(rest) = s.strip_prefix("pubky") {
             if let Some((user_id, path)) = rest.split_once('/') {
                 if PublicKey::is_pubky_prefixed(user_id) {
@@ -329,11 +321,13 @@ impl FromStr for PubkyResource {
 
 impl fmt::Display for PubkyResource {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.to_identifier())
+        f.write_str(&self.to_pubky_url())
     }
 }
 
-/// Resolve a Pubky identifier (either `pubky://` or `pubky<pk>/…`) into a transport URL.
+/// Resolve a Pubky URL into a transport URL.
+///
+/// Legacy `pubky<pk>/…` identifiers remain accepted for compatibility.
 ///
 /// Returns the same URL as [`PubkyResource::to_transport_url`], making it easy to
 /// bridge human-facing identifiers with low-level HTTP clients.
@@ -411,7 +405,7 @@ impl IntoResourcePath for &String {
 ///
 /// Implementations:
 /// - `PubkyResource` / `&PubkyResource` (pass-through / clone)
-/// - `&str`, `String`, `&String` parsed as `pubky<pk>/<abs-path>` or `pubky://<pk>/<abs-path>`
+/// - `&str`, `String`, `&String` parsed as `pubky://<pk>/<abs-path>`
 /// - `(PublicKey, P: AsRef<str>)` and `(&PublicKey, P: AsRef<str>)` to pair a key with a path
 ///
 /// This trait is used by *public* storage methods (`PublicStorage`) and any API that must
@@ -426,11 +420,8 @@ impl IntoResourcePath for &String {
 /// // Pair (pk, path)
 /// let r1 = (user.clone(), "/pub/site/index.html").into_pubky_resource()?;
 ///
-/// // Parse `<pk>/<path>`
-/// let r2: PubkyResource = format!("{}/pub/site/index.html", user).parse()?;
-///
 /// // Parse `pubky://`
-/// let r3: PubkyResource = format!("pubky://{}/pub/site/index.html", user.z32()).parse()?;
+/// let r2: PubkyResource = format!("pubky://{user}/pub/site/index.html").parse()?;
 /// # Ok::<(), pubky::Error>(())
 /// ```
 pub trait IntoPubkyResource {
@@ -509,7 +500,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_addressed_user_both_forms() {
+    fn parses_legacy_identifier_but_renders_a_pubky_url() {
         let kp = Keypair::random();
         let user = kp.public_key();
         let user_raw = user.z32();
@@ -524,10 +515,8 @@ mod tests {
         assert_eq!(p1.path.as_str(), "/pub/my-cool-app/file");
         assert_eq!(p3.path.as_str(), "/pub/my-cool-app/file");
 
-        // Display: identifier form
-        assert_eq!(p1.to_string(), s3);
-        assert_eq!(p3.to_string(), s3);
-        // Deep-link rendering (no default needed; owner is known)
+        assert_eq!(p1.to_string(), s1);
+        assert_eq!(p3.to_string(), s1);
         assert_eq!(p1.to_pubky_url(), s1);
     }
 
@@ -565,7 +554,7 @@ mod tests {
         ));
 
         // Double-slash inside path
-        let s_bad = format!("{user}/pub//app");
+        let s_bad = format!("pubky://{user}/pub//app");
         assert!(matches!(
             PubkyResource::from_str(&s_bad),
             Err(Error::Request(RequestError::Validation { .. }))
@@ -611,6 +600,7 @@ mod tests {
         assert_eq!(resolved, resolved2);
 
         let resource = PubkyResource::from_str(&prefixed).unwrap();
+        assert_eq!(resource.to_string(), base);
         assert_eq!(resource.to_transport_url().unwrap(), resolved);
 
         let parsed = PubkyResource::from_transport_url(&resolved).unwrap();

--- a/pubky-sdk/src/actors/storage/resource.rs
+++ b/pubky-sdk/src/actors/storage/resource.rs
@@ -174,7 +174,7 @@ impl fmt::Display for ResourcePath {
 /// // Build from parts
 /// let pk = Keypair::random().public_key();
 /// let r = PubkyResource::new(pk.clone(), "/pub/site/index.html")?;
-/// assert_eq!(r.to_string(), format!("{pk}/pub/site/index.html"));
+/// assert_eq!(r.to_string(), format!("pubky://{pk}/pub/site/index.html"));
 ///
 /// // Parse from string
 /// // `pubky://` form

--- a/pubky-sdk/src/actors/storage/verbs.rs
+++ b/pubky-sdk/src/actors/storage/verbs.rs
@@ -123,7 +123,7 @@ impl SessionStorage {
 //
 
 impl PublicStorage {
-    /// HTTP `GET` for an **addressed resource** (`pubky://<pk>/<path>`, `pubky<pk>/<path>`, or `(PublicKey, path)` tuple).
+    /// HTTP `GET` for an **addressed resource** (`pubky://<pk>/<path>` or `(PublicKey, path)` tuple).
     ///
     /// # Examples
     /// ```no_run

--- a/pubky-sdk/src/client/http_targets/mod.rs
+++ b/pubky-sdk/src/client/http_targets/mod.rs
@@ -150,7 +150,7 @@ mod tests {
 
     #[test]
     fn rejects_pubky_prefixed_transport_hosts() {
-        let prefixed = crate::Keypair::random().public_key().to_string();
+        let prefixed = format!("pubky{}", crate::Keypair::random().public_key().z32());
 
         for host in [prefixed.clone(), format!("_pubky.{prefixed}")] {
             let error = classify_transport_host(&host).unwrap_err();


### PR DESCRIPTION
Closes https://github.com/pubky/pubky-homeserver/issues/571

### Summary

Unifies public key string output around raw z-base32.

| Value | Canonical output | Legacy input |
|---|---|---|
| Public key | `<z32>` | `pubky<z32>` remains accepted |
| Public resource | `pubky://<z32>/<path>` | `pubky<z32>/<path>` remains accepted |

`PublicKey::Display` and JavaScript `PublicKey.toString()` now return raw z-base32. `PubkyResource` string output and public-storage addresses use canonical `pubky://` URLs.

Legacy `pubky<z32>` parsing is retained for compatibility while we confirm downstream usage and decide whether it can be removed in a future breaking release.

### ⚠️ Breaking changes

- Rust `PublicKey` display output changes from `pubky<z32>` to `<z32>`.
- JavaScript `PublicKey.toString()` changes from `pubky<z32>` to `<z32>`.
- `PubkyResource` string output changes from `pubky<z32>/<path>` to `pubky://<z32>/<path>`.
- JavaScript public-storage `Address` values now use canonical `pubky://` URLs.

Applications that persist, display, or compare the old output format must migrate to the canonical form. Existing legacy values remain parseable.

### Acceptance criteria

- [x] Rust and JavaScript public-key string output uses raw z-base32.
- [x] Public resource output uses `pubky://<z32>/<path>`.
- [x] Legacy `pubky<z32>` public keys and resource addresses remain accepted as input.
- [x] JavaScript public-storage types reject legacy bare addresses.
- [x] SDK documentation and examples use canonical output formats.
- [x] Rust, WASM, and JavaScript format-level tests cover canonical output and legacy parsing.