### PR TITLE
chore: resolve clippy warnings

### DIFF
--- a/e2e/src/tests/storage/listing.rs
+++ b/e2e/src/tests/storage/listing.rs
@@ -16,14 +16,14 @@ async fn list_deep() {
     let public_key = owner_session.public_key();
     // Write files to the server
     let mut paths = vec![
-        format!("/pub/a.wrong/a.txt"),
-        format!("/pub/example.com/a.txt"),
-        format!("/pub/example.com/b.txt"),
-        format!("/pub/example.com/cc-nested/z.txt"),
-        format!("/pub/example.wrong/a.txt"),
-        format!("/pub/example.com/c.txt"),
-        format!("/pub/example.com/d.txt"),
-        format!("/pub/z.wrong/a.txt"),
+        "/pub/a.wrong/a.txt",
+        "/pub/example.com/a.txt",
+        "/pub/example.com/b.txt",
+        "/pub/example.com/cc-nested/z.txt",
+        "/pub/example.wrong/a.txt",
+        "/pub/example.com/c.txt",
+        "/pub/example.com/d.txt",
+        "/pub/z.wrong/a.txt",
     ];
     paths.shuffle(&mut rng()); // Shuffle randomly to test the order of the list
     for url in paths {
@@ -156,16 +156,16 @@ async fn list_shallow() {
 
     // Write files to the server
     let mut urls = vec![
-        format!("/pub/a.com/a.txt"),
-        format!("/pub/example.com/a.txt"),
-        format!("/pub/example.com/b.txt"),
-        format!("/pub/example.com/c.txt"),
-        format!("/pub/example.com/d.txt"),
-        format!("/pub/example.con/d.txt"),
-        format!("/pub/example.con-file"),
-        format!("/pub/file"),
-        format!("/pub/file2"),
-        format!("/pub/z.com/a.txt"),
+        "/pub/a.com/a.txt",
+        "/pub/example.com/a.txt",
+        "/pub/example.com/b.txt",
+        "/pub/example.com/c.txt",
+        "/pub/example.com/d.txt",
+        "/pub/example.con/d.txt",
+        "/pub/example.con-file",
+        "/pub/file",
+        "/pub/file2",
+        "/pub/z.com/a.txt",
     ];
     urls.shuffle(&mut rng()); // Shuffle randomly to test the order of the list
     for url in urls {

--- a/pubky-sdk/src/actors/auth/grant/credential.rs
+++ b/pubky-sdk/src/actors/auth/grant/credential.rs
@@ -753,7 +753,7 @@ mod tests {
         let mut builder = PubkyHttpClient::builder();
         builder
             .isolated_pkarr_test()
-            .pkarr(|b| b.cache(cache.clone()));
+            .pkarr(|b| b.cache(Arc::<InMemoryCache>::clone(&cache)));
         let client = builder.build().unwrap();
         cache.put(&homeserver_keypair.public_key().into(), &homeserver_packet);
 

--- a/pubky-sdk/src/actors/session/core.rs
+++ b/pubky-sdk/src/actors/session/core.rs
@@ -133,6 +133,10 @@ impl PubkySession {
     /// # Errors
     /// - Returns the original [`crate::errors::Error`] alongside `self` when the transport
     ///   request fails or the homeserver responds with a non-success status.
+    #[allow(
+        clippy::result_large_err,
+        reason = "return the session alongside the error so callers can retry signout"
+    )]
     pub async fn signout(self) -> std::result::Result<(), (Error, Self)> {
         cross_log!(info, "Signing out session for {}", self.info().public_key());
         if let Err(e) = self.credential.signout(&self.client).await {

--- a/pubky-sdk/src/client/http_targets/native.rs
+++ b/pubky-sdk/src/client/http_targets/native.rs
@@ -284,8 +284,9 @@ impl PubkyHttpClient {
         })
     }
 
-    #[expect(
-        clippy::unused_async,
+    // Use the group because newer Clippy versions split this into a lint unknown to our MSRV.
+    #[allow(
+        clippy::pedantic,
         reason = "keep async signature aligned with WASM build"
     )]
     pub(super) async fn prepare_transport_request(&self, url: &mut Url) -> Result<Option<String>> {
@@ -372,7 +373,7 @@ mod tests {
         let mut builder = PubkyHttpClient::builder();
         builder
             .isolated_pkarr_test()
-            .pkarr(|b| b.cache(cache.clone()));
+            .pkarr(|b| b.cache(Arc::<InMemoryCache>::clone(&cache)));
         let client = builder.build().unwrap();
         let cache_key: pkarr::CacheKey = keypair.public_key().into();
         cache.put(&cache_key, packet);
@@ -539,7 +540,7 @@ mod tests {
         let mut builder = PubkyHttpClient::builder();
         builder
             .isolated_pkarr_test()
-            .pkarr(|b| b.cache(cache.clone()));
+            .pkarr(|b| b.cache(Arc::<InMemoryCache>::clone(&cache)));
         let client = builder.build().unwrap();
         cache.put(&homeserver.public_key().into(), &homeserver_packet);
         cache.put(&user.public_key().into(), &user_packet);
@@ -588,7 +589,7 @@ mod tests {
         let mut builder = PubkyHttpClient::builder();
         builder
             .isolated_pkarr_test()
-            .pkarr(|b| b.cache(cache.clone()));
+            .pkarr(|b| b.cache(Arc::<InMemoryCache>::clone(&cache)));
         let client = builder.build().unwrap();
         cache.put(&homeserver.public_key().into(), &homeserver_packet);
         let homeserver_pk = PublicKey::try_from_z32(&homeserver.public_key().to_string()).unwrap();


### PR DESCRIPTION
Document intentional lint exceptions for the retryable signout result
and the cross-target async transport API. Use a lint group compatible
with the workspace MSRV and newer Clippy versions.

Avoid unnecessary test string allocations and make Arc reference-count
clones explicit.
