### PR TITLE
chore: pin ci-workflows to v1.0.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,10 @@ updates:
       cargo-dependencies:
         patterns:
           - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      time: "08:00"
+      day: "tuesday"
+    commit-message:
+      prefix: "ci"
     cooldown:
       default-days: 7
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,7 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,7 +31,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: pubky/ci-workflows/.github/actions/docker/build_and_push@main
+        uses: pubky/ci-workflows/.github/actions/docker/build_and_push@e6d3b38b5ebfa97b86595cb44f3a86695e473b09 # v1.0.0
         with:
           registry: registry-1.docker.io/synonymsoft
           context: .


### PR DESCRIPTION
Part of pubky/pubky-stack#281.

## What

`pubky/ci-workflows` was referenced at `@main`. That repo is public, its `main` branch has no protection, and 25 references across 8 repositories track it — so any push there reached this repository's next build, with no review in between.

[`v1.0.0`](https://github.com/pubky/ci-workflows/releases/tag/v1.0.0) is the first tagged release. It pins its own third-party actions to SHAs and adds a zizmor gate plus smoke tests, but **runs byte-identical upstream code to what `@main` ran before it** — so this PR carries no behaviour change.

## Why a SHA and not `@v1.0.0`

A tag is a name its owner can move; a SHA is not. The trailing `# v1.0.0` comment keeps the line readable and is what Dependabot reads to work out which version the pin corresponds to.

## The Dependabot entry

A pin without a bump bot trades "unreviewed changes arrive instantly" for "frozen forever on an old version", including a vulnerable one. The `github-actions` entry uses a 7-day cooldown so a freshly published release is never proposed on the day it lands.

Happy to split that into its own PR if you would rather keep this to the pin alone.

## Verification

These workflows are release- or dispatch-triggered, so no CI runs on this PR — the pin is first exercised on the next build. Upstream, `v1.0.0` is covered by smoke tests that build a real image through `build_and_push` on `linux/amd64` and `linux/amd64,linux/arm64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)