### PR TITLE
ci: add mbx (mr boxington) pilot job to PR Check

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -349,8 +349,7 @@ jobs:
           toolchain: "1.89"
           components: clippy
       - name: Set up mbx (mr boxington)
-        # actionlint disable=unpinned-uses: pilot, comparison only
-        uses: jdx/mr-boxington-action@v1
+        uses: jdx/mr-boxington-action@7234d3dd1a6ca8f6c381eea8e4dfb03f18fcf777
         with:
           # match the cache key to the pinned 1.89 toolchain
           toolchain: "1.89"

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -356,3 +356,9 @@ jobs:
           save-on-workflow-dispatch: true
       - name: Lint (host targets)
         run: mbx clippy --workspace --all-features --exclude pubky-wasm -- -D warnings
+
+      - name: Add wasm target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Lint wasm crate (wasm32)
+        run: mbx clippy -p pubky-wasm --target wasm32-unknown-unknown -- -D warnings

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   push:
     branches: [main]
+  # temporary, for the mbx-pilot job below: the action only saves cache
+  # entries on default-branch pushes or trusted workflow_dispatch runs
+  workflow_dispatch:
 
 jobs:
   msrv:
@@ -332,3 +335,25 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build Docker image
         run: docker build .
+
+  # Pilot (see PR description): same steps as the clippy job above, but using
+  # mr boxington (mbx) instead of Swatinem/rust-cache, so the two can be
+  # compared like-for-like on identical inputs. Remove once benchmarked.
+  mbx-pilot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.89"
+          components: clippy
+      - name: Set up mbx (mr boxington)
+        # actionlint disable=unpinned-uses: pilot, comparison only
+        uses: jdx/mr-boxington-action@v1
+        with:
+          # match the cache key to the pinned 1.89 toolchain
+          toolchain: "1.89"
+          save-on-workflow-dispatch: true
+      - name: Lint (host targets)
+        run: mbx clippy --workspace --all-features --exclude pubky-wasm -- -D warnings


### PR DESCRIPTION
Pilot comparing [mr boxington](https://mr-boxington.jdx.dev) (mbx) against Swatinem/rust-cache, requested by @ok300 after his ask in Slack to evaluate it for speeding up CI.

**What changed**

Adds an `mbx-pilot` job to `.github/workflows/pr-check.yml` mirroring the existing `clippy` job step for step (same toolchain 1.89, same lint command), using `jdx/mr-boxington-action@v1` instead of rust-cache, so both are compared like-for-like on identical inputs.

**Benchmark plan**

One `workflow_dispatch` run from this branch warms the cache (the action only saves entries on default-branch pushes or trusted dispatch runs), then a few PR runs of `clippy` vs `mbx-pilot` give the comparison. If it does not win here, it will not win anywhere in our repos.

**Notes**

- `jdx/mr-boxington-action@v1` is a moving tag. Pin to a commit SHA before this goes anywhere near main.
- The `workflow_dispatch` trigger is temporary, to warm the cache from the branch. Remove it with the pilot.
- mbx is one day old as a project (v1.6.0); its own docs say the GitHub Actions cache backend does not yet consistently outperform rust-cache on GitHub-hosted runners, hence measuring rather than assuming.
- Nextest compatibility is unverified; this pilot only exercises clippy. A test-suite pilot can follow if the numbers are good.