### PR TITLE
feat(sdk): make two stage auth flow publicly available

### DIFF
--- a/pubky-sdk/src/actors/auth/cookie/credential.rs
+++ b/pubky-sdk/src/actors/auth/cookie/credential.rs
@@ -157,8 +157,27 @@ impl CookieCredential {
         Ok(Self::new(user, cookie, record, homeserver))
     }
 
-    /// Establish a cookie credential from a signed [`AuthToken`] (legacy flow).
-    pub(crate) async fn from_auth_token(
+    /// Establish a cookie credential from a verified, signed [`AuthToken`]
+    /// (legacy flow).
+    ///
+    /// This is the second stage of split cookie authentication. Obtain the
+    /// token with [`crate::PubkyCookieAuthFlow::await_token`], retain it, then
+    /// call this method to resolve the homeserver and exchange the token at
+    /// `/session`. Because the token is borrowed, callers may retry failures
+    /// independently from relay polling while the token remains valid.
+    ///
+    /// [`AuthToken`] is short-lived and one-shot at the homeserver. A retry is
+    /// therefore not guaranteed to recover an exchange whose request reached
+    /// the homeserver but whose response was lost.
+    ///
+    /// `homeserver` binds signup credentials to the homeserver named by the
+    /// signup deep link. Pass `None` for signin, whose deep link does not name
+    /// a homeserver.
+    ///
+    /// # Errors
+    /// - Propagates homeserver resolution, HTTP transport, authentication, and
+    ///   response decoding failures.
+    pub async fn from_auth_token(
         token: &AuthToken,
         client: &PubkyHttpClient,
         homeserver: Option<PublicKey>,

--- a/pubky-sdk/src/actors/auth/cookie/flow.rs
+++ b/pubky-sdk/src/actors/auth/cookie/flow.rs
@@ -31,6 +31,24 @@
 //! # Ok(()) }
 //! ```
 //!
+//! ## Sign in (split relay receipt from session exchange)
+//! ```no_run
+//! # use pubky::{AuthFlowKind, Capabilities, CookieCredential, PubkyCookieAuthFlow, PubkyHttpClient};
+//! # async fn run() -> pubky::Result<()> {
+//! # #[allow(deprecated)] {
+//! let client = PubkyHttpClient::new()?;
+//! let flow = PubkyCookieAuthFlow::builder(&Capabilities::default(), AuthFlowKind::signin())
+//!     .client(client.clone())
+//!     .start()?;
+//! let token = flow.await_token().await?;
+//!
+//! // Homeserver resolution and `/session` exchange are now independent from
+//! // relay polling. Retain `token` to retry failures while it remains valid.
+//! let credential = CookieCredential::from_auth_token(&token, &client, None).await?;
+//! # }
+//! # Ok(()) }
+//! ```
+//!
 //! ## Sign up
 //! ```no_run
 //! # use pubky::{Capabilities, PubkyCookieAuthFlow, AuthFlowKind, PublicKey};
@@ -175,6 +193,14 @@ impl PubkyCookieAuthFlow {
     }
 
     /// Block until the signer approves and we receive an [`AuthToken`].
+    ///
+    /// This is the first stage of split cookie authentication. For an inbox
+    /// relay, the SDK attempts a best-effort acknowledgement before this method
+    /// returns; acknowledgement failure does not discard the verified token.
+    /// The token is returned to the caller instead of being hidden inside
+    /// [`await_credential`](Self::await_credential). Retain it and pass it to
+    /// [`CookieCredential::from_auth_token`] to retry homeserver resolution or
+    /// the `/session` exchange independently from relay polling.
     ///
     /// # Errors
     /// - Returns [`crate::errors::Error::Authentication`] if the relay channel

--- a/pubky-sdk/src/actors/auth/cookie/flow.rs
+++ b/pubky-sdk/src/actors/auth/cookie/flow.rs
@@ -40,11 +40,12 @@
 //! let flow = PubkyCookieAuthFlow::builder(&Capabilities::default(), AuthFlowKind::signin())
 //!     .client(client.clone())
 //!     .start()?;
+//! let homeserver = flow.target_homeserver();
 //! let token = flow.await_token().await?;
 //!
 //! // Homeserver resolution and `/session` exchange are now independent from
 //! // relay polling. Retain `token` to retry failures while it remains valid.
-//! let credential = CookieCredential::from_auth_token(&token, &client, None).await?;
+//! let credential = CookieCredential::from_auth_token(&token, &client, homeserver).await?;
 //! # }
 //! # Ok(()) }
 //! ```
@@ -268,7 +269,12 @@ impl PubkyCookieAuthFlow {
     /// Only signup links carry it. Signin links intentionally return `None`; a
     /// signin cookie stays unbound and private event streams remain anonymous
     /// until the resulting session successfully revalidates.
-    fn target_homeserver(&self) -> Option<crate::PublicKey> {
+    ///
+    /// Capture this value before calling [`await_token`](Self::await_token),
+    /// which consumes the flow, then pass it to
+    /// [`CookieCredential::from_auth_token`] during the session exchange.
+    #[must_use]
+    pub fn target_homeserver(&self) -> Option<crate::PublicKey> {
         match &self.auth_url {
             DeepLink::Signup(link) => Some(link.params().homeserver.clone()),
             _ => None,

--- a/pubky-sdk/tests/cookie_auth_stages.rs
+++ b/pubky-sdk/tests/cookie_auth_stages.rs
@@ -1,0 +1,19 @@
+#![allow(deprecated, reason = "Regression covers legacy cookie auth API")]
+
+use pubky::{AuthToken, CookieCredential, PubkyCookieAuthFlow, PubkyHttpClient, PublicKey};
+
+// Compile-time regression: callers can split relay approval receipt from the
+// homeserver session exchange, retaining the verified token across retries.
+async fn cookie_auth_can_be_completed_in_two_stages(
+    flow: PubkyCookieAuthFlow,
+    client: &PubkyHttpClient,
+    homeserver: Option<PublicKey>,
+) -> pubky::Result<CookieCredential> {
+    let token: AuthToken = flow.await_token().await?;
+    CookieCredential::from_auth_token(&token, client, homeserver).await
+}
+
+#[test]
+fn split_cookie_auth_api_is_public() {
+    let _ = cookie_auth_can_be_completed_in_two_stages;
+}

--- a/pubky-sdk/tests/cookie_auth_stages.rs
+++ b/pubky-sdk/tests/cookie_auth_stages.rs
@@ -7,8 +7,8 @@ use pubky::{AuthToken, CookieCredential, PubkyCookieAuthFlow, PubkyHttpClient, P
 async fn cookie_auth_can_be_completed_in_two_stages(
     flow: PubkyCookieAuthFlow,
     client: &PubkyHttpClient,
-    homeserver: Option<PublicKey>,
 ) -> pubky::Result<CookieCredential> {
+    let homeserver: Option<PublicKey> = flow.target_homeserver();
     let token: AuthToken = flow.await_token().await?;
     CookieCredential::from_auth_token(&token, client, homeserver).await
 }


### PR DESCRIPTION


- changes visibility of `pub(crate) async fn from_auth_token` to `pub async fn from_auth_token`
- adds documentation and test

Helps addressing the issue described in https://github.com/pubky/pubky-homeserver/issues/575#issuecomment-5561879414
