### PR TITLE
ci: use mbx for clippy and test matrix

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   msrv:
     runs-on: ubuntu-latest
@@ -40,17 +43,21 @@ jobs:
         with:
           toolchain: "1.89"
           components: clippy
-      - name: Cache
-        uses: Swatinem/rust-cache@v2
+      - name: Set up mbx
+        uses: jdx/mr-boxington-action@7234d3dd1a6ca8f6c381eea8e4dfb03f18fcf777 # v1.3.0
+        with:
+          version: "1.9.0"
+          toolchain: "1.89"
+          cache-generation: ci-mbx-v1-clippy
 
       - name: Lint (host targets)
-        run: cargo clippy --workspace --all-features --exclude pubky-wasm -- -D warnings
+        run: mbx clippy --workspace --all-features --exclude pubky-wasm -- -D warnings
 
       - name: Add wasm target
         run: rustup target add wasm32-unknown-unknown
 
       - name: Lint wasm crate (wasm32)
-        run: cargo clippy -p pubky-wasm --target wasm32-unknown-unknown -- -D warnings
+        run: mbx clippy -p pubky-wasm --target wasm32-unknown-unknown -- -D warnings
 
   helper-crates:
     runs-on: ubuntu-latest
@@ -115,8 +122,12 @@ jobs:
           toolchain: "1.89"
       - name: Install Nextest
         uses: taiki-e/install-action@nextest
-      - name: Cache
-        uses: Swatinem/rust-cache@v2
+      - name: Set up mbx
+        uses: jdx/mr-boxington-action@7234d3dd1a6ca8f6c381eea8e4dfb03f18fcf777 # v1.3.0
+        with:
+          version: "1.9.0"
+          toolchain: "1.89"
+          cache-generation: ci-mbx-v1-test-${{ matrix.crate }}
       - name: Wait for PostgreSQL
         run: |
           for i in {1..10}; do
@@ -129,10 +140,10 @@ jobs:
           set -e
           # nextest does not support doctests yet.
           if [ "${{ matrix.crate }}" != "homeservercli" ]; then
-            cargo test --doc -p ${{ matrix.crate }} --all-features
+            mbx test --doc -p ${{ matrix.crate }} --all-features
           fi
 
-          if cargo nextest run \
+          if mbx nextest run \
             -p ${{ matrix.crate }} \
             --all-features \
             --test-threads num-cpus \


### PR DESCRIPTION
The recent test https://github.com/pubky/pubky-homeserver/pull/585#issuecomment-5568417815 showed promising speedups when using `mbx` cache instead of `Swatinem/rust-cache`.

This PR integrates `mbx` into the CI `clippy` and test jobs.

Partially addresses #486

## Summary

- Replace `Swatinem/rust-cache@v2` with pinned `jdx/mr-boxington-action` in the `clippy` job and six-lane test matrix.
- Run the existing Clippy, doctest, and nextest commands through mbx without changing their flags or control flow.
- Pin the action to `7234d3dd1a6ca8f6c381eea8e4dfb03f18fcf777` (`v1.3.0`) and mbx to `1.9.0`.
- Add `permissions: contents: read` at workflow scope, as extra hardening.
- Use independent cache generations:
  - `ci-mbx-v1-clippy`
  - `ci-mbx-v1-test-${{ matrix.crate }}`

## Rationale

The existing warm-cache pilot showed substantial speedups for the full Clippy workload. The test matrix is included in this PR because it is the largest remaining direct-Cargo workload in `PR Check`.

Each matrix lane receives its own cache generation so concurrent `main` jobs do not compete to save the same immutable GitHub Actions cache entry.

The integration keeps `mbx` on its default GitHub Actions backend:

- pushes to `main` seed caches;
- PRs, including fork PRs, restore only;
- no OIDC permission, secret, cache server, or manual cache-seeding workflow is added.

## Out of scope

- Other `rust-cache` jobs remain unchanged.
- Docker, `wasm-pack`/npm, `cross`, artifact-build, release, and publishing workflows remain unchanged.
- No production release path restores compiler outputs from an `mbx` cache.