### PR TITLE
build(docker)!: support debug builds and default to homeserver

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,66 @@
+name: Build Docker Images
+
+on:
+  workflow_call:
+    inputs:
+      build_profile:
+        description: Docker build profile (debug or release)
+        type: string
+        default: release
+      platforms:
+        description: Target platforms for the Docker images
+        type: string
+        default: |
+          linux/arm64
+          linux/amd64
+      publish:
+        description: Publish images to Docker Hub with version and latest tags
+        type: boolean
+        default: false
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: false
+      DOCKERHUB_TOKEN:
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 150
+    strategy:
+      matrix:
+        include:
+          - image: homeserver-testnet
+            target: testnet
+          - image: homeserver
+            target: homeserver
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Log in to Docker Hub
+        if: ${{ inputs.publish }}
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build Docker image
+        uses: pubky/ci-workflows/.github/actions/docker/build_and_push@e6d3b38b5ebfa97b86595cb44f3a86695e473b09 # v1.0.0
+        with:
+          registry: registry-1.docker.io/synonymsoft
+          context: .
+          push: ${{ inputs.publish }}
+          latest: ${{ inputs.publish }}
+          tags: |
+            type=ref,event=tag
+          platforms: ${{ inputs.platforms }}
+          image: ${{ matrix.image }}
+          cache_from: type=gha,scope=docker-${{ inputs.build_profile }}-${{ matrix.target }}
+          cache_to: type=gha,scope=docker-${{ inputs.build_profile }}-${{ matrix.target }},mode=max
+          build_args: |
+            BUILD_TARGET=${{ matrix.target }}
+            BUILD_PROFILE=${{ inputs.build_profile }}

--- a/.github/workflows/docker-check.yml
+++ b/.github/workflows/docker-check.yml
@@ -1,0 +1,14 @@
+name: Check Release Docker Images
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      publish: false

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,44 +5,13 @@ on:
     tags: ['v*']
 
 permissions:
-    contents: read
+  contents: read
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
-    timeout-minutes: 150
-    strategy:
-      matrix:
-        include:
-         - image: homeserver-testnet
-           build_args: |
-             BUILD_TARGET=testnet
-         - image: homeserver
-           build_args: |
-             BUILD_TARGET=homeserver
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and push Docker image
-        uses: pubky/ci-workflows/.github/actions/docker/build_and_push@e6d3b38b5ebfa97b86595cb44f3a86695e473b09 # v1.0.0
-        with:
-          registry: registry-1.docker.io/synonymsoft
-          context: .
-          push: true
-          latest: true
-          tags: |
-            type=ref,event=tag
-          platforms: |
-            linux/arm64
-            linux/amd64
-          image: ${{ matrix.image }}
-          cache_from: type=gha
-          cache_to: type=gha,mode=max
-          build_args: ${{ matrix.build_args }}
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      publish: true
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -327,11 +327,8 @@ jobs:
             -- --test-threads=1
 
   docker-build:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target: [testnet, homeserver]
-    steps:
-      - uses: actions/checkout@v7
-      - name: Build Docker image
-        run: docker build --build-arg BUILD_TARGET=${{ matrix.target }} .
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      build_profile: debug
+      platforms: linux/amd64
+      publish: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,14 +34,20 @@ COPY Cargo.toml Cargo.lock ./
 COPY . .
 
 # Add build argument for binary selection (homeserver or testnet)
-ARG BUILD_TARGET=testnet
+ARG BUILD_TARGET=homeserver
 
-# Build the project in release mode for the MUSL target
-# Only apply environment setup script only when host is ARM so we don't override the native compiler on x86 hosts
-RUN cargo build --release --bin pubky-$BUILD_TARGET
+# Build in release mode by default; use debug for faster development builds.
+ARG BUILD_PROFILE=release
 
-# Strip the binary to reduce size
-RUN strip target/release/pubky-$BUILD_TARGET
+# Cargo calls the debug profile "dev", but writes its artifacts to target/debug.
+RUN case "$BUILD_PROFILE" in \
+      release) cargo build --release --bin "pubky-$BUILD_TARGET" && \
+               strip "target/release/pubky-$BUILD_TARGET" ;; \
+      debug) cargo build --bin "pubky-$BUILD_TARGET" ;; \
+      *) echo "Invalid BUILD_PROFILE: $BUILD_PROFILE (expected debug or release)" >&2; exit 1 ;; \
+    esac && \
+    mkdir -p /out && \
+    cp "target/$BUILD_PROFILE/pubky-$BUILD_TARGET" /out/homeserver
 
 # ========================
 # Runtime Stage
@@ -49,13 +55,12 @@ RUN strip target/release/pubky-$BUILD_TARGET
 FROM alpine:3.20
 
 ARG TARGETARCH
-ARG BUILD_TARGET=testnet
 
 # Install runtime dependencies (only ca-certificates)
 RUN apk add --no-cache ca-certificates
 
 # Copy the compiled binary from the builder stage
-COPY --from=builder /usr/src/app/target/release/pubky-$BUILD_TARGET /usr/local/bin/homeserver
+COPY --from=builder /out/homeserver /usr/local/bin/homeserver
 
 # Set the working directory
 WORKDIR /usr/local/bin

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -106,7 +106,7 @@ Requires [Docker Engine](https://docs.docker.com/engine/install/).
 Build the homeserver image using the [Dockerfile](../Dockerfile):
 
 ```bash
-docker build --build-arg BUILD_TARGET=homeserver -t pubky-homeserver .
+docker build -t pubky-homeserver .
 ```
 
 Verify the image built correctly:
@@ -114,6 +114,8 @@ Verify the image built correctly:
 ```bash
 docker run --rm pubky-homeserver homeserver --version
 ```
+
+For debug builds and testnet images, see [Docker build options](./TESTING.md#docker-build-options).
 
 ## Initialise the Data Directory
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -97,6 +97,46 @@ TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgr
   cargo test -p e2e
 ```
 
+## Docker Build Options
+
+The root [Dockerfile](../Dockerfile) builds either a homeserver or a testnet image. Run the commands below from the repository root.
+
+| Build argument | Values | Default |
+| --- | --- | --- |
+| `BUILD_TARGET` | `homeserver`, `testnet` | `homeserver` |
+| `BUILD_PROFILE` | `release` (optimized and stripped), `debug` (faster development builds) | `release` |
+
+Build a debug homeserver image:
+
+```bash
+docker build --build-arg BUILD_TARGET=homeserver --build-arg BUILD_PROFILE=debug -t pubky-homeserver:debug .
+```
+
+Build a release testnet image:
+
+```bash
+docker build --build-arg BUILD_TARGET=testnet --build-arg BUILD_PROFILE=release -t pubky-testnet:release .
+```
+
+Both images install their binary as `homeserver`. Check that it runs without starting services or connecting to PostgreSQL:
+
+```bash
+docker run --rm --network none pubky-homeserver:debug homeserver --help
+docker run --rm --network none pubky-testnet:release homeserver --help
+```
+
+### Docker builds in CI
+
+All Docker jobs use the shared [build workflow](../.github/workflows/docker-build.yml) for both targets:
+
+| Workflow | Trigger | Profile | Platforms | Publishes images |
+| --- | --- | --- | --- | --- |
+| [PR Check](../.github/workflows/pr-check.yml) | Pull requests and pushes to `main` | `debug` | `linux/amd64` | No |
+| [Release Docker check](../.github/workflows/docker-check.yml) | Pushes to `main` | `release` | `linux/amd64`, `linux/arm64` | No |
+| [Docker publishing](../.github/workflows/docker.yml) | Tags matching `v*` | `release` | `linux/amd64`, `linux/arm64` | Yes |
+
+Build caches are scoped by profile and target.
+
 ## Common Commands
 
 Run the homeserver tests against external PostgreSQL:

--- a/pubky-testnet/README.md
+++ b/pubky-testnet/README.md
@@ -2,6 +2,8 @@
 
 A local test network for developing Pubky homeserver or applications depending on it.
 
+To build a testnet Docker image, see [Docker build options](../docs/TESTING.md#docker-build-options).
+
 ## Quick start
 
 Start Postgres if you don't already have one running:


### PR DESCRIPTION
Add BUILD_PROFILE with release as the default. Use debug mode for
PR Docker checks and document usage.

BREAKING CHANGE: Docker builds now default to homeserver instead of
testnet. Pass --build-arg BUILD_TARGET=testnet to build the testnet image.
