### PR TITLE
test(pkdns): add ignored network test for get_homeserver_of

### DIFF
--- a/pubky-sdk/src/actors/pkdns.rs
+++ b/pubky-sdk/src/actors/pkdns.rs
@@ -531,6 +531,22 @@ mod tests {
     use pkarr::{Cache, InMemoryCache, dns::rdata::TXT};
 
     #[tokio::test]
+    #[ignore = "requires access to the public Pkarr network"]
+    async fn get_homeserver_of_resolves_known_user() {
+        let user = PublicKey::try_from_z32("w79nsmujodq6up1heoh6y3mxk4k7xa6e94ma15fbdhopffy8nhgy")
+            .expect("valid user public key");
+        let pkdns = Pkdns::new().expect("Pkdns client");
+
+        let homeserver = pkdns
+            .get_homeserver_of(&user)
+            .await
+            .expect("homeserver lookup should succeed")
+            .expect("user should have a homeserver record");
+
+        eprintln!("resolved homeserver: {homeserver}");
+    }
+
+    #[tokio::test]
     async fn require_homeserver_of_returns_validation_when_packet_has_no_pubky_record() {
         let user = Keypair::random();
         let mut dnslink_txt = TXT::new();


### PR DESCRIPTION
Adds an `#[ignore]`-gated tokio test to `pubky-sdk/src/actors/pkdns.rs` that resolves the homeserver of a known user key through the public Pkarr network.

- Gated with `#[ignore = "requires access to the public Pkarr network"]` so the normal suite stays offline.
- Verified locally: `cargo test -p pubky --lib actors::pkdns::tests::get_homeserver_of_resolves_known_user -- --ignored --nocapture` passes and resolves `pubkyw79nsm…8nhgy` to `pubkyufibwbmed6jeq9k4p583go95wofakh9fwpp4k734trq79pd9u1uy`.
- Rest of the `actors::pkdns` module (9 tests) still passes; `cargo fmt --check` and `cargo clippy -p pubky --lib -- -D warnings` clean.

Requested in DM by Andrei.