### PR TITLE
fix(sdk): avoid caching failed transport discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3807,9 +3807,8 @@ dependencies = [
 
 [[package]]
 name = "pkarr"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3248274a604751c9a6749137cebfe0ddfc8b4b0e31c779515c4f984c937a4dac"
+version = "8.0.1"
+source = "git+https://github.com/pubky/pkarr.git?rev=5443822f8eb479862cfa8a269356eb4da4db5d4d#5443822f8eb479862cfa8a269356eb4da4db5d4d"
 dependencies = [
  "async-compat",
  "base32",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3808,7 +3808,7 @@ dependencies = [
 [[package]]
 name = "pkarr"
 version = "8.0.1"
-source = "git+https://github.com/pubky/pkarr.git?rev=9513d032c4f549ec6d6cc1a7baef305f00524fc1#9513d032c4f549ec6d6cc1a7baef305f00524fc1"
+source = "git+https://github.com/pubky/pkarr.git?rev=b09864db53bf3f4a95e877c2c9cc01a7b8a364af#b09864db53bf3f4a95e877c2c9cc01a7b8a364af"
 dependencies = [
  "async-compat",
  "base32",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3808,7 +3808,7 @@ dependencies = [
 [[package]]
 name = "pkarr"
 version = "8.0.1"
-source = "git+https://github.com/pubky/pkarr.git?rev=5443822f8eb479862cfa8a269356eb4da4db5d4d#5443822f8eb479862cfa8a269356eb4da4db5d4d"
+source = "git+https://github.com/pubky/pkarr.git?rev=9513d032c4f549ec6d6cc1a7baef305f00524fc1#9513d032c4f549ec6d6cc1a7baef305f00524fc1"
 dependencies = [
  "async-compat",
  "base32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,4 +82,4 @@ wasm-bindgen-futures = "0.4"
 wasm-streams = "0.5"
 
 [patch.crates-io]
-pkarr = { git = "https://github.com/pubky/pkarr.git", rev = "9513d032c4f549ec6d6cc1a7baef305f00524fc1" }
+pkarr = { git = "https://github.com/pubky/pkarr.git", rev = "b09864db53bf3f4a95e877c2c9cc01a7b8a364af" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,3 +80,6 @@ url = "2"
 wasm-bindgen-futures = "0.4"
 # Same version as used by reqwest version defined above
 wasm-streams = "0.5"
+
+[patch.crates-io]
+pkarr = { git = "https://github.com/pubky/pkarr.git", rev = "5443822f8eb479862cfa8a269356eb4da4db5d4d" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,4 +82,4 @@ wasm-bindgen-futures = "0.4"
 wasm-streams = "0.5"
 
 [patch.crates-io]
-pkarr = { git = "https://github.com/pubky/pkarr.git", rev = "5443822f8eb479862cfa8a269356eb4da4db5d4d" }
+pkarr = { git = "https://github.com/pubky/pkarr.git", rev = "9513d032c4f549ec6d6cc1a7baef305f00524fc1" }

--- a/pubky-sdk/src/client/http_targets/native.rs
+++ b/pubky-sdk/src/client/http_targets/native.rs
@@ -6,6 +6,7 @@ use super::{TransportHost, classify_transport_host, homeserver_url};
 use futures_util::StreamExt;
 use tokio::net::TcpStream;
 
+use crate::errors::PkarrError;
 use crate::{PubkyHttpClient, PublicKey, Result, cross_log};
 use reqwest::{IntoUrl, Method, RequestBuilder};
 use url::Url;
@@ -51,9 +52,13 @@ impl TransportResolver {
     }
 
     /// Look up the transport for `qname`, resolving via PKARR on cache miss.
-    pub(crate) async fn resolve(&self, qname: &str, pkarr: &pkarr::Client) -> ResolvedTransport {
+    pub(crate) async fn resolve(
+        &self,
+        qname: &str,
+        pkarr: &pkarr::Client,
+    ) -> Result<ResolvedTransport> {
         if let Some(t) = self.cached(qname) {
-            return t;
+            return Ok(t);
         }
         self.resolve_and_cache(qname, pkarr).await
     }
@@ -69,7 +74,11 @@ impl TransportResolver {
 
     /// Slow path: acquire a per-qname guard, double-check the cache, resolve,
     /// and store the result.
-    async fn resolve_and_cache(&self, qname: &str, pkarr: &pkarr::Client) -> ResolvedTransport {
+    async fn resolve_and_cache(
+        &self,
+        qname: &str,
+        pkarr: &pkarr::Client,
+    ) -> Result<ResolvedTransport> {
         let guard = {
             let mut guards = self.guards.lock().unwrap_or_else(PoisonError::into_inner);
             Arc::clone(guards.entry(qname.to_string()).or_default())
@@ -78,53 +87,68 @@ impl TransportResolver {
 
         // Another task may have resolved while we waited for the guard.
         if let Some(t) = self.cached(qname) {
-            return t;
+            return Ok(t);
         }
 
-        let t = Self::resolve_from_pkarr(pkarr, qname).await;
+        let t = Self::resolve_from_pkarr(pkarr, qname).await?;
         self.cache
             .write()
             .unwrap_or_else(PoisonError::into_inner)
             .insert(qname.to_string(), (Instant::now(), t.clone()));
-        t
+        Ok(t)
     }
 
     /// Inspect PKARR endpoints and probe reachability to pick a transport.
-    async fn resolve_from_pkarr(pkarr: &pkarr::Client, qname: &str) -> ResolvedTransport {
-        let stream = pkarr.resolve_https_endpoints(qname);
+    async fn resolve_from_pkarr(pkarr: &pkarr::Client, qname: &str) -> Result<ResolvedTransport> {
+        let stream = pkarr.try_resolve_endpoints(qname, true);
         futures_util::pin_mut!(stream);
 
-        let mut has_direct = false;
         let mut direct_addrs = Vec::new();
         let mut icann: Option<(String, Option<u16>)> = None;
+        let mut resolution_error = None;
 
-        while let Some(ep) = stream.next().await {
+        while let Some(result) = stream.next().await {
+            let ep = match result {
+                Ok(endpoint) => endpoint,
+                Err(error) => {
+                    resolution_error.get_or_insert(error);
+                    continue;
+                }
+            };
             if let Some(domain) = ep.domain() {
                 if icann.is_none() {
                     icann = Some((domain.to_string(), ep.port()));
                 }
             } else {
-                has_direct = true;
                 direct_addrs.extend(ep.to_socket_addrs());
             }
         }
 
         let Some((domain, port)) = icann else {
-            return ResolvedTransport::PubkyTls;
+            if !direct_addrs.is_empty() {
+                return Ok(ResolvedTransport::PubkyTls);
+            }
+            return Err(resolution_error.map_or_else(
+                || {
+                    PkarrError::InvalidRecord(format!("no usable HTTPS endpoints for {qname}"))
+                        .into()
+                },
+                crate::Error::from,
+            ));
         };
-        if !has_direct {
-            return ResolvedTransport::Icann { domain, port };
+        if direct_addrs.is_empty() {
+            return Ok(ResolvedTransport::Icann { domain, port });
         }
 
         // Both exist — probe direct endpoint reachability.
         if probe_reachable(&direct_addrs, PROBE_TIMEOUT).await {
-            ResolvedTransport::PubkyTls
+            Ok(ResolvedTransport::PubkyTls)
         } else {
             cross_log!(
                 warn,
                 "Direct endpoint unreachable for {qname}; ICANN fallback to {domain}"
             );
-            ResolvedTransport::Icann { domain, port }
+            Ok(ResolvedTransport::Icann { domain, port })
         }
     }
 }
@@ -199,7 +223,7 @@ impl PubkyHttpClient {
         let url = homeserver_url(homeserver, path)?;
         let homeserver_z32 = homeserver.z32();
         let pubky_host_z32 = pubky_host.z32();
-        let transport = self.transport.resolve(&homeserver_z32, &self.pkarr).await;
+        let transport = self.transport.resolve(&homeserver_z32, &self.pkarr).await?;
 
         self.build_request(
             method,
@@ -217,7 +241,10 @@ impl PubkyHttpClient {
     ) -> Result<RequestBuilder> {
         // Bypass cross_request so discovery cannot recursively trigger itself.
         let url = homeserver_url(homeserver, "/info")?;
-        let transport = self.transport.resolve(&homeserver.z32(), &self.pkarr).await;
+        let transport = self
+            .transport
+            .resolve(&homeserver.z32(), &self.pkarr)
+            .await?;
 
         self.build_transport_request(Method::GET, &url, &transport)
     }
@@ -272,7 +299,7 @@ impl PubkyHttpClient {
 
         // `_pubky.<pk>` endpoints live under the full qname, not the bare key apex.
         let qname = url.host_str().unwrap_or(&pubky_host).to_string();
-        let transport = self.transport.resolve(&qname, &self.pkarr).await;
+        let transport = self.transport.resolve(&qname, &self.pkarr).await?;
         let standard_pubky_host =
             matches!(&transport, ResolvedTransport::Icann { .. }).then_some(pubky_host);
         let pubky_host = addressing.into_pubky_host(standard_pubky_host);
@@ -492,7 +519,90 @@ mod tests {
         let pkarr = pkarr_with_packet(&kp, &packet);
 
         let t = TransportResolver::resolve_from_pkarr(&pkarr, &kp.public_key().to_string()).await;
-        assert!(matches!(t, ResolvedTransport::PubkyTls));
+        assert!(matches!(t, Ok(ResolvedTransport::PubkyTls)));
+    }
+
+    #[tokio::test]
+    async fn failed_transport_resolution_recovers_without_cache_expiry() {
+        let server = httpmock::MockServer::start_async().await;
+        let unavailable = server
+            .mock_async(|when, then| {
+                when.method(httpmock::Method::GET);
+                then.status(503);
+            })
+            .await;
+        let cache = Arc::new(InMemoryCache::new(NonZeroUsize::MIN));
+        let client = PubkyHttpClient::builder()
+            .pkarr(|builder| {
+                builder
+                    .no_dht()
+                    .relays(&[server.base_url()])
+                    .unwrap()
+                    .cache(Arc::<InMemoryCache>::clone(&cache))
+            })
+            .build()
+            .unwrap();
+        let key = Keypair::random();
+        let name = key.public_key().to_string();
+        assert!(matches!(
+            client.transport.resolve(&name, &client.pkarr).await,
+            Err(crate::Error::Pkarr(PkarrError::Resolve(_)))
+        ));
+        assert!(client.transport.cached(&name).is_none());
+        unavailable.assert_hits_async(1).await;
+
+        let packet = SignedPacket::builder()
+            .https(
+                ".".try_into().unwrap(),
+                SVCB::new(1, "example.com".try_into().unwrap()),
+                3600,
+            )
+            .sign(&key)
+            .unwrap();
+        cache.put(&key.public_key().into(), &packet);
+        let clone = client.clone();
+        assert!(matches!(clone.transport.resolve(&name, &clone.pkarr).await,
+            Ok(ResolvedTransport::Icann { domain, .. }) if domain == "example.com"));
+        assert!(matches!(
+            client.transport.cached(&name),
+            Some(ResolvedTransport::Icann { .. })
+        ));
+        unavailable.assert_hits_async(1).await;
+    }
+
+    #[tokio::test]
+    async fn empty_transport_resolution_is_not_cached() {
+        let key = Keypair::random();
+        let packet = SignedPacket::builder().sign(&key).unwrap();
+        let pkarr = pkarr_with_packet(&key, &packet);
+        let transport = TransportResolver::new();
+        let name = key.public_key().to_string();
+        assert!(matches!(
+            transport.resolve(&name, &pkarr).await,
+            Err(crate::Error::Pkarr(PkarrError::InvalidRecord(_)))
+        ));
+        assert!(transport.cached(&name).is_none());
+    }
+
+    #[tokio::test]
+    async fn direct_transport_without_addresses_is_not_cached() {
+        let key = Keypair::random();
+        let packet = SignedPacket::builder()
+            .https(
+                ".".try_into().unwrap(),
+                SVCB::new(1, ".".try_into().unwrap()),
+                3600,
+            )
+            .sign(&key)
+            .unwrap();
+        let pkarr = pkarr_with_packet(&key, &packet);
+        let transport = TransportResolver::new();
+        let name = key.public_key().to_string();
+        assert!(matches!(
+            transport.resolve(&name, &pkarr).await,
+            Err(crate::Error::Pkarr(PkarrError::InvalidRecord(_)))
+        ));
+        assert!(transport.cached(&name).is_none());
     }
 
     #[tokio::test]
@@ -506,8 +616,8 @@ mod tests {
         let pkarr = pkarr_with_packet(&kp, &packet);
 
         let t = TransportResolver::resolve_from_pkarr(&pkarr, &kp.public_key().to_string()).await;
-        assert!(matches!(t, ResolvedTransport::Icann { .. }));
-        if let ResolvedTransport::Icann { domain, .. } = t {
+        assert!(matches!(t, Ok(ResolvedTransport::Icann { .. })));
+        if let Ok(ResolvedTransport::Icann { domain, .. }) = t {
             assert_eq!(domain, "example.com");
         }
     }
@@ -623,7 +733,7 @@ mod tests {
 
         let t = TransportResolver::resolve_from_pkarr(&pkarr, &kp.public_key().to_string()).await;
         assert!(
-            matches!(t, ResolvedTransport::Icann { ref domain, .. } if domain == "example.com"),
+            matches!(t, Ok(ResolvedTransport::Icann { ref domain, .. }) if domain == "example.com"),
             "expected ICANN fallback, got {t:?}"
         );
     }


### PR DESCRIPTION
## Summary

- Return typed errors when PKARR transport discovery fails, instead of silently choosing direct Pubky TLS.
- Do not cache a transport inferred from failed, empty, or addressless discovery.
- Keep usable endpoint alternatives when another alias lookup fails.
- Propagate discovery failures before dispatching an HTTP request.

## Why

An empty endpoint stream currently becomes a direct-transport choice cached for 60 seconds. In the local reproduction, a temporary lookup outage leaves the existing client and its clones failing after service recovery while a fresh client succeeds. Pre-resolving PKARR does not clear that transport cache.

With this change, failed discovery is not cached and the next attempt can discover the recovered endpoint immediately. Successful transport selection and its existing cache lifetime are unchanged.

These are reproduced SDK/PKARR defects. The team reports that relay rate limiting triggered the staging lookup failures and that DHT `NotFound` results masked those failures. This change addresses the SDK's failure caching, not the relay rate limit.

## Staging logs still needed

We still need correlated staging logs to confirm the exact relay responses, the rate-limit policy being hit, and whether the session POST reached the homeserver. Disabling DHT can avoid the mixed DHT/relay result, but does not fix relay rate limiting or the SDK's failed-discovery cache bug.

Please provide a correlated failing auth attempt with:

- UTC timestamp/request ID and deployed versions.
- Locks-side SDK/PKARR logs, including the full underlying error chain and relay/DHT lookup results, not just the final 503.
- Matching relay logs with response status and rate-limit details, and homeserver logs where available to establish whether the session POST reached the homeserver and what it returned.

Please redact credentials, cookies, auth tokens, and request bodies, and share sensitive logs privately.

## Dependency

Depends on [pubky/pkarr#306](https://github.com/pubky/pkarr/pull/306), which adds fallible endpoint discovery and fixes endpoint/error handling.

For review and CI, the workspace pins the exact published PKARR commit `b09864db53bf3f4a95e877c2c9cc01a7b8a364af` with a root Cargo patch. This keeps the SDK, testnet, and relay on the same PKARR source without a local path override. No unrelated lockfile changes are included. This pin contains the narrowed error-discovery fix. The reqwest/address-fallback changes and backup-discovery timeout policy have been removed from #306.

**Before merging/publishing:** merge and release the PKARR fix, then replace the temporary git patch with a dependency requiring that fixed release. This PR does not create a release or change any deployment.

## Validation

- All 201 SDK library tests passed using the pinned remote PKARR commit and `--locked`.
- Strict Clippy (`-D warnings`) passed for the SDK library and tests.
- Workspace formatting and diff-whitespace checks passed.
- Verified that all workspace PKARR consumers resolve to the same pinned commit.
- Loopback reproduction passed with signed packets: the original client and its clone recover immediately after an injected lookup outage, without waiting for transport-cache expiry.
- Regressions cover failed discovery, empty HTTPS endpoints, and direct endpoints with no usable addresses.

No application-level retries or signed authentication/session POST replay are added. TLS probing and broader transport redesign are outside this change.
