### PR TITLE
ci: bump `sha2` to 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1533,6 +1533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
 ]
 
@@ -4214,7 +4215,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_valid",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "sqlx",
  "tempfile",
  "thiserror 2.0.20",

--- a/pubky-homeserver/Cargo.toml
+++ b/pubky-homeserver/Cargo.toml
@@ -88,7 +88,7 @@ opentelemetry-prometheus = "0.32"
 prometheus = "0.14"
 jsonwebtoken = "9"
 chrono = { version = "0.4", features = ["serde"] }
-sha2 = "0.10"
+sha2 = "0.11"
 rand.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
This PR bumps `sha2` to `0.11`, which was released 6 months ago.

Changelog: https://github.com/RustCrypto/hashes/blob/master/sha2/CHANGELOG.md#0110-2026-03-25