### PR TITLE
ci(docker): run PR builds on native amd64 and arm64 runners

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,6 +3,14 @@ name: Build Docker Images
 on:
   workflow_call:
     inputs:
+      runner:
+        description: GitHub runner label for the build
+        type: string
+        default: ubuntu-latest
+      cache_scope_suffix:
+        description: Optional suffix to isolate caches for separate architecture builds
+        type: string
+        default: ''
       build_profile:
         description: Docker build profile (debug or release)
         type: string
@@ -28,7 +36,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 150
     strategy:
       matrix:
@@ -59,8 +67,8 @@ jobs:
             type=ref,event=tag
           platforms: ${{ inputs.platforms }}
           image: ${{ matrix.image }}
-          cache_from: type=gha,scope=docker-${{ inputs.build_profile }}-${{ matrix.target }}
-          cache_to: type=gha,scope=docker-${{ inputs.build_profile }}-${{ matrix.target }},mode=max
+          cache_from: type=gha,scope=docker-${{ inputs.build_profile }}-${{ matrix.target }}${{ inputs.cache_scope_suffix }}
+          cache_to: type=gha,scope=docker-${{ inputs.build_profile }}-${{ matrix.target }}${{ inputs.cache_scope_suffix }},mode=max
           build_args: |
             BUILD_TARGET=${{ matrix.target }}
             BUILD_PROFILE=${{ inputs.build_profile }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -57,7 +57,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build Docker image
-        uses: pubky/ci-workflows/.github/actions/docker/build_and_push@e6d3b38b5ebfa97b86595cb44f3a86695e473b09 # v1.0.0
+        uses: pubky/ci-workflows/.github/actions/docker/build_and_push@5faaf004d36bb93a204b58cf7190ffe7fbcce16f
         with:
           registry: registry-1.docker.io/synonymsoft
           context: .
@@ -67,8 +67,12 @@ jobs:
             type=ref,event=tag
           platforms: ${{ inputs.platforms }}
           image: ${{ matrix.image }}
-          cache_from: type=gha,scope=docker-${{ inputs.build_profile }}-${{ matrix.target }}${{ inputs.cache_scope_suffix }}
-          cache_to: type=gha,scope=docker-${{ inputs.build_profile }}-${{ matrix.target }}${{ inputs.cache_scope_suffix }},mode=max
+          # Publishing imports only the caches warmed by native release checks on main.
+          cache_from: |
+            ${{ !inputs.publish && format('type=gha,scope=docker-{0}-{1}{2}', inputs.build_profile, matrix.target, inputs.cache_scope_suffix) || '' }}
+            ${{ inputs.publish && format('type=gha,scope=docker-{0}-{1}-amd64', inputs.build_profile, matrix.target) || '' }}
+            ${{ inputs.publish && format('type=gha,scope=docker-{0}-{1}-arm64', inputs.build_profile, matrix.target) || '' }}
+          cache_to: ${{ !inputs.publish && format('type=gha,scope=docker-{0}-{1}{2},mode=max', inputs.build_profile, matrix.target, inputs.cache_scope_suffix) || '' }}
           build_args: |
             BUILD_TARGET=${{ matrix.target }}
             BUILD_PROFILE=${{ inputs.build_profile }}

--- a/.github/workflows/docker-check.yml
+++ b/.github/workflows/docker-check.yml
@@ -9,6 +9,17 @@ permissions:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        include:
+          - architecture: amd64
+            runner: ubuntu-24.04
+          - architecture: arm64
+            runner: ubuntu-24.04-arm
     uses: ./.github/workflows/docker-build.yml
     with:
+      runner: ${{ matrix.runner }}
+      cache_scope_suffix: -${{ matrix.architecture }}
+      build_profile: release
+      platforms: linux/${{ matrix.architecture }}
       publish: false

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -327,8 +327,17 @@ jobs:
             -- --test-threads=1
 
   docker-build:
+    strategy:
+      matrix:
+        include:
+          - architecture: amd64
+            runner: ubuntu-24.04
+          - architecture: arm64
+            runner: ubuntu-24.04-arm
     uses: ./.github/workflows/docker-build.yml
     with:
+      runner: ${{ matrix.runner }}
+      cache_scope_suffix: -${{ matrix.architecture }}
       build_profile: debug
-      platforms: linux/amd64
+      platforms: linux/${{ matrix.architecture }}
       publish: false

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -327,17 +327,10 @@ jobs:
             -- --test-threads=1
 
   docker-build:
-    strategy:
-      matrix:
-        include:
-          - architecture: amd64
-            runner: ubuntu-24.04
-          - architecture: arm64
-            runner: ubuntu-24.04-arm
     uses: ./.github/workflows/docker-build.yml
     with:
-      runner: ${{ matrix.runner }}
-      cache_scope_suffix: -${{ matrix.architecture }}
+      runner: ubuntu-24.04
+      cache_scope_suffix: -amd64
       build_profile: debug
-      platforms: linux/${{ matrix.architecture }}
+      platforms: linux/amd64
       publish: false

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -127,15 +127,19 @@ docker run --rm --network none pubky-testnet:release homeserver --help
 
 ### Docker builds in CI
 
-All Docker jobs use the shared [build workflow](../.github/workflows/docker-build.yml) for both targets:
+All Docker jobs use the shared [build
+workflow](../.github/workflows/docker-build.yml) for both targets:
 
 | Workflow | Trigger | Profile | Platforms | Publishes images |
 | --- | --- | --- | --- | --- |
-| [PR Check](../.github/workflows/pr-check.yml) | Pull requests and pushes to `main` | `debug` | `linux/amd64` | No |
-| [Release Docker check](../.github/workflows/docker-check.yml) | Pushes to `main` | `release` | `linux/amd64`, `linux/arm64` | No |
+| [PR Check](../.github/workflows/pr-check.yml) | Pull requests and pushes to `main` | `debug` | `linux/amd64`, `linux/arm64` (native runners) | No |
+| [Release Docker check](../.github/workflows/docker-check.yml) | Pushes to `main` | `release` | `linux/amd64`, `linux/arm64` (native runners) | No |
 | [Docker publishing](../.github/workflows/docker.yml) | Tags matching `v*` | `release` | `linux/amd64`, `linux/arm64` | Yes |
 
-Build caches are scoped by profile and target.
+Build caches are scoped by profile and target. PR Docker checks and release
+Docker checks on `main` run AMD64 on `ubuntu-24.04` and ARM64 on
+`ubuntu-24.04-arm`, with caches additionally scoped by architecture. Publishing
+builds both architectures together on `ubuntu-latest`, using emulation for ARM64.
 
 ## Common Commands
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -132,14 +132,19 @@ workflow](../.github/workflows/docker-build.yml) for both targets:
 
 | Workflow | Trigger | Profile | Platforms | Publishes images |
 | --- | --- | --- | --- | --- |
-| [PR Check](../.github/workflows/pr-check.yml) | Pull requests and pushes to `main` | `debug` | `linux/amd64`, `linux/arm64` (native runners) | No |
+| [PR Check](../.github/workflows/pr-check.yml) | Pull requests and pushes to `main` | `debug` | `linux/amd64` (native runner) | No |
 | [Release Docker check](../.github/workflows/docker-check.yml) | Pushes to `main` | `release` | `linux/amd64`, `linux/arm64` (native runners) | No |
 | [Docker publishing](../.github/workflows/docker.yml) | Tags matching `v*` | `release` | `linux/amd64`, `linux/arm64` | Yes |
 
-Build caches are scoped by profile and target. PR Docker checks and release
-Docker checks on `main` run AMD64 on `ubuntu-24.04` and ARM64 on
-`ubuntu-24.04-arm`, with caches additionally scoped by architecture. Publishing
+Build caches are scoped by profile, target, and architecture. Debug Docker checks
+run AMD64 on `ubuntu-24.04` for PRs and pushes to `main`, warming the
+`docker-debug-<target>-amd64` caches on `main` for PRs to reuse. On `main`,
+release Docker checks also run AMD64 on `ubuntu-24.04` and ARM64 on
+`ubuntu-24.04-arm`.
+ARM64 build failures are therefore caught on `main` after merging. Publishing
 builds both architectures together on `ubuntu-latest`, using emulation for ARM64.
+Publishing imports only the two architecture-specific release caches warmed on
+`main` and disables cache export by passing an empty `cache_to` value.
 
 ## Common Commands
 


### PR DESCRIPTION
Add ARM64 coverage to debug Docker checks using native runners.
Allow runner selection and cache scope suffixes in the shared workflow
to isolate caches by architecture.
