### PR TITLE
fix(sdk): bound error diagnostics and expose raw storage GET

### DIFF
--- a/e2e/src/tests/storage/objects.rs
+++ b/e2e/src/tests/storage/objects.rs
@@ -538,3 +538,44 @@ async fn write_same_path_separate_users() {
     let read_bytes_b = response.bytes().await.unwrap();
     assert_eq!(read_bytes_b, content1);
 }
+
+#[tokio::test]
+#[pubky_testnet::test]
+async fn raw_private_storage_preserves_grant_and_cookie_authorization() {
+    use pubky_testnet::pubky::ClientId;
+
+    let testnet = build_full_testnet().await;
+    let server = testnet.homeserver_app();
+    let pubky = testnet.sdk().unwrap();
+    let signer = pubky.signer(Keypair::random());
+    signer.signup(&server.public_key(), None).await.unwrap();
+    let grant = signer
+        .signin(ClientId::new("raw-storage.test").unwrap())
+        .await
+        .unwrap();
+    grant
+        .storage()
+        .put("/priv/test/file", "private")
+        .await
+        .unwrap();
+    let cookie = signer.signin_cookie().await.unwrap();
+    for session in [&grant, &cookie] {
+        let response = session.storage().get_raw("/priv/test/file").await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.text().await.unwrap(), "private");
+        let response = session
+            .storage()
+            .get_raw("/priv/test/missing")
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert_server_status(
+            session
+                .storage()
+                .get("/priv/test/missing")
+                .await
+                .unwrap_err(),
+            StatusCode::NOT_FOUND,
+        );
+    }
+}

--- a/pubky-sdk/README.md
+++ b/pubky-sdk/README.md
@@ -70,6 +70,49 @@ println!("Your current homeserver: {:?}", resolved);
 # Ok(()) }
 ```
 
+## Bounded storage reads
+
+`SessionStorage::get()` returns successful responses without reading their bodies.
+For non-success responses, SDK status handling captures at most 4096 response
+bytes as diagnostic text and marks longer messages as truncated. This applies to
+all checked SDK requests, including errors during proactive credential refresh.
+
+Use `SessionStorage::get_raw()` when you need to inspect the GET status before
+reading any body. It uses the same authentication and routing as `get()`, but
+returns HTTP errors such as 404 or 500 as responses. Path, transport and credential
+preparation failures still return SDK errors. The existing redirect policy applies.
+
+```rust,no_run
+use futures_util::StreamExt;
+
+# async fn read(session: pubky::PubkySession) -> Result<(), Box<dyn std::error::Error>> {
+let response = session.storage().get_raw("/priv/my.app/backup").await?;
+if !response.status().is_success() {
+    // Classify absence or other server errors without collecting their bodies.
+    return Err(format!("backup request failed: {}", response.status()).into());
+}
+let limit = 4096;
+let mut body = Vec::new();
+let mut stream = response.bytes_stream();
+while let Some(chunk) = stream.next().await {
+    let chunk = chunk?;
+    if chunk.len() > limit - body.len() {
+        return Err("backup exceeds the byte limit".into());
+    }
+    body.extend_from_slice(&chunk);
+}
+// Decode and validate the complete, bounded backup here.
+# Ok(()) }
+```
+
+A HEAD preflight and Content-Length are advisory; count actual bytes before
+appending. Calling `text()`, `bytes()` or `json()` collects the complete body.
+The bound covers SDK accumulation, with additional bounded text-decoding overhead;
+transport buffers and individual chunks have separate memory costs. Timeouts remain
+caller-configured. Successful credential-refresh JSON is a separate response and
+is not bounded by the storage reader. `get_raw()` is available in Rust (native and
+WASM); this change does not add a JavaScript `getRaw()` binding.
+
 ## Key formats (display vs transport)
 
 `PublicKey` has two string representations:

--- a/pubky-sdk/bindings/js/pkg/tests/bounded_storage.ts
+++ b/pubky-sdk/bindings/js/pkg/tests/bounded_storage.ts
@@ -1,0 +1,110 @@
+import test from "tape";
+import { Keypair, Pubky, PublicKey, type Path } from "../index.js";
+import { assertPubkyError, createSignupToken, getStatusCode } from "./utils.js";
+
+const PATH: Path = "/priv/bounded-reader/value";
+const SUFFIX = "\n[response body truncated at 4096 bytes]";
+
+test("checked storage bounds and cancels error bodies", async (t) => {
+  const sdk = Pubky.testnet();
+  const signer = sdk.signer(Keypair.random());
+  const homeserver = PublicKey.from(
+    "8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo",
+  );
+  await signer.signup(homeserver, await createSignupToken());
+  const session = await signer.signin("bounded-reader.test");
+  await session.storage.exists(PATH); // Warm discovery before intercepting GET.
+  const originalFetch = globalThis.fetch;
+  const encoder = new TextEncoder();
+  try {
+    for (const parts of [["x".repeat(8192)], ["x".repeat(4096), "y"]]) {
+      let cancelled = false;
+      let pulled = 0;
+      let intercepted = 0;
+      globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        if (!new URL(request.url).pathname.endsWith(PATH)) {
+          return originalFetch(input, init);
+        }
+        intercepted += 1;
+        t.ok(request.headers.has("authorization"), "GET remains authenticated");
+        const body = new ReadableStream<Uint8Array>(
+          {
+            pull(controller) {
+              if (pulled < parts.length) {
+                controller.enqueue(encoder.encode(parts[pulled++]));
+              }
+              // No EOF: status handling must stop at overflow.
+            },
+            cancel() {
+              cancelled = true;
+            },
+          },
+          { highWaterMark: 0 },
+        );
+        const response = new Response(body, { status: 500 });
+        Object.defineProperty(response, "url", { value: request.url });
+        return response;
+      }) as typeof fetch;
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        await Promise.race([
+          session.storage.get(PATH),
+          new Promise<never>((_, reject) => {
+            timer = setTimeout(
+              () => reject(new Error("error reader waited for EOF")),
+              5000,
+            );
+          }),
+        ]);
+        t.fail("500 must reject checked GET");
+      } catch (error) {
+        assertPubkyError(t, error);
+        t.equal(getStatusCode(error), 500, "original status survives");
+        t.ok(
+          error.message.endsWith("x".repeat(4096) + SUFFIX),
+          "bounded prefix and truncation marker",
+        );
+      } finally {
+        clearTimeout(timer);
+      }
+      t.equal(intercepted, 1, "one storage GET");
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      t.ok(cancelled, "overflow cancels the response stream");
+    }
+
+    for (const [status, body] of [
+      [500, ""],
+      [500, "small"],
+      [500, "x".repeat(4096)],
+      [500, "\ufeffhello"],
+      [200, "success"],
+    ] as const) {
+      globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        if (!new URL(request.url).pathname.endsWith(PATH)) {
+          return originalFetch(input, init);
+        }
+        const response = new Response(encoder.encode(body), { status });
+        Object.defineProperty(response, "url", { value: request.url });
+        return response;
+      }) as typeof fetch;
+      try {
+        const response = await session.storage.get(PATH);
+        t.equal(status, 200, "only success returns a response");
+        t.equal(await response.text(), body, "success body remains readable");
+      } catch (error) {
+        assertPubkyError(t, error);
+        t.equal(getStatusCode(error), status, "small error status preserved");
+        t.equal(
+          error.message,
+          `Request failed: Server responded with an error: 500 Internal Server Error - ${body.replace(/^\ufeff/, "")}`,
+          "complete errors preserve browser text decoding",
+        );
+      }
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+  t.end();
+});

--- a/pubky-sdk/src/actors/auth/grant/credential.rs
+++ b/pubky-sdk/src/actors/auth/grant/credential.rs
@@ -771,4 +771,47 @@ mod tests {
             &claims.iss.z32()
         );
     }
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test]
+    async fn oversized_refresh_error_is_bounded_before_storage_request() {
+        use crate::util::test_server::TestServer;
+        use std::time::Duration;
+
+        let reply = format!(
+            "HTTP/1.1 500 Error\r\nTransfer-Encoding: chunked\r\n\r\n1001\r\n{}\r\n",
+            "x".repeat(4097)
+        );
+        let server = TestServer::start(reply.into_bytes());
+        let (mut stored, claims) = stored_credential(now_unix() + 3600);
+        stored.homeserver_pk = server.homeserver.clone();
+        let signer = GrantPopSigner::local(Keypair::from_secret(&stored.client_key_secret));
+        let credential = test_credential(stored, claims, signer);
+        credential.state.lock().await.token_expires_at = 0;
+        let storage = crate::SessionStorage {
+            client: server.client.clone(),
+            user: server.user.clone(),
+            credential: Arc::new(credential),
+        };
+        let error =
+            tokio::time::timeout(Duration::from_secs(2), storage.get_raw("/priv/test/file"))
+                .await
+                .expect("refresh error must stop at the body cap")
+                .unwrap_err();
+        let crate::Error::Request(RequestError::Server { status, message }) = error else {
+            panic!("unexpected error: {error:?}");
+        };
+        assert_eq!(status, reqwest::StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(
+            message,
+            format!(
+                "{}\n[response body truncated at 4096 bytes]",
+                "x".repeat(4096)
+            )
+        );
+        let request = server.finish().await;
+        assert!(
+            request.starts_with("POST /auth/grant/session "),
+            "{request}"
+        );
+    }
 }

--- a/pubky-sdk/src/actors/storage/verbs.rs
+++ b/pubky-sdk/src/actors/storage/verbs.rs
@@ -57,12 +57,39 @@ impl SessionStorage {
     ///
     /// # Errors
     /// - [`crate::errors::Error::Request`] on HTTP transport failures or when the server
-    ///   responds with a non-success status (the server message is captured).
+    ///   responds with a non-success status. Diagnostics capture up to 4096 body
+    ///   bytes, with a truncation marker when more bytes are observed.
     /// - [`crate::errors::Error::Parse`] if `path` cannot be converted into a valid
     ///   resource/URL.
     pub async fn get<P: IntoResourcePath>(&self, path: P) -> Result<Response> {
+        let response = self.get_raw(path).await?;
+        check_http_status(response).await
+    }
+
+    /// HTTP `GET` with caller-controlled status and body handling.
+    ///
+    /// Uses the same path validation, routing and credentials as [`Self::get`],
+    /// but returns the final HTTP response without checking its status or reading
+    /// its body. A received 404, 410, 429 or 500 is therefore `Ok(Response)`.
+    /// The HTTP client's existing redirect policy still applies.
+    ///
+    /// Inspect [`Response::status`] before consuming the body. Drop responses you
+    /// do not need, or count streamed bytes before appending them to a buffer.
+    /// Calling `text()`, `bytes()` or `json()` still collects the entire body;
+    /// neither a HEAD preflight nor Content-Length enforces a download limit.
+    ///
+    /// This gives control over the storage response, not separate requests made
+    /// during credential refresh or transport discovery.
+    ///
+    /// # Errors
+    /// - Propagates path validation, discovery, credential preparation and HTTP
+    ///   transport errors. A failed proactive refresh is a preparation error,
+    ///   not the storage GET response.
+    pub async fn get_raw<P: IntoResourcePath>(&self, path: P) -> Result<Response> {
         let rb = self.request(Method::GET, path).await?;
-        send_checked(rb).await
+        let response = rb.send().await?;
+        cross_log!(debug, "Request completed with status {}", response.status());
+        Ok(response)
     }
 
     /// Lightweight existence check (HEAD) for an **absolute path**.
@@ -93,7 +120,8 @@ impl SessionStorage {
     ///
     /// # Errors
     /// - [`crate::errors::Error::Request`] on HTTP transport failures or when the server
-    ///   responds with a non-success status (the server message is captured).
+    ///   responds with a non-success status. Diagnostics capture up to 4096 body
+    ///   bytes, with a truncation marker when more bytes are observed.
     /// - [`crate::errors::Error::Parse`] if `path` cannot be converted into a valid
     ///   resource/URL.
     pub async fn put<P, B>(&self, path: P, body: B) -> Result<Response>
@@ -109,7 +137,8 @@ impl SessionStorage {
     ///
     /// # Errors
     /// - [`crate::errors::Error::Request`] on HTTP transport failures or when the server
-    ///   responds with a non-success status (the server message is captured).
+    ///   responds with a non-success status. Diagnostics capture up to 4096 body
+    ///   bytes, with a truncation marker when more bytes are observed.
     /// - [`crate::errors::Error::Parse`] if `path` cannot be converted into a valid
     ///   resource/URL.
     pub async fn delete<P: IntoResourcePath>(&self, path: P) -> Result<Response> {
@@ -140,7 +169,8 @@ impl PublicStorage {
     ///
     /// # Errors
     /// - [`crate::errors::Error::Request`] on HTTP transport failures or when the server
-    ///   responds with a non-success status (the server message is captured).
+    ///   responds with a non-success status. Diagnostics capture up to 4096 body
+    ///   bytes, with a truncation marker when more bytes are observed.
     /// - [`crate::errors::Error::Parse`] if `addr` cannot be converted into a valid
     ///   addressed resource/URL.
     pub async fn get<A: IntoPubkyResource>(&self, addr: A) -> Result<Response> {
@@ -170,3 +200,7 @@ impl PublicStorage {
             .map(|resp| ResourceStats::from_headers(resp.headers())))
     }
 }
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+#[allow(deprecated, reason = "Verify the supported legacy-cookie storage path")]
+mod tests;

--- a/pubky-sdk/src/actors/storage/verbs/tests.rs
+++ b/pubky-sdk/src/actors/storage/verbs/tests.rs
@@ -1,0 +1,62 @@
+use super::*;
+use crate::{
+    Capabilities, CookieCredential, Error, errors::RequestError, util::test_server::TestServer,
+};
+use pubky_common::session::CookieSessionRecord;
+use std::{sync::Arc, time::Duration};
+
+fn storage(server: &TestServer) -> SessionStorage {
+    let caps = Capabilities::builder().read_write("/").unwrap().finish();
+    SessionStorage {
+        client: server.client.clone(),
+        user: server.user.clone(),
+        credential: Arc::new(CookieCredential::new(
+            server.user.clone(),
+            Some("test-secret".into()),
+            CookieSessionRecord::new(&server.user, caps, None),
+            Some(server.homeserver.clone()),
+        )),
+    }
+}
+
+#[tokio::test]
+async fn raw_get_returns_headers_without_consuming_success_or_error_bodies() {
+    for status in [200, 404, 410, 429, 500] {
+        let server = TestServer::start(
+            format!("HTTP/1.1 {status} Test\r\nContent-Length: 1000000000\r\nX-Test: raw\r\n\r\n")
+                .into_bytes(),
+        );
+        let storage = storage(&server);
+        let response =
+            tokio::time::timeout(Duration::from_secs(2), storage.get_raw("/priv/test/file"))
+                .await
+                .expect("raw GET must return before body/EOF")
+                .unwrap();
+        assert_eq!(response.status().as_u16(), status);
+        assert_eq!(response.headers()["x-test"], "raw");
+        drop(response);
+        let request = server.finish().await;
+        assert!(request.starts_with(&format!(
+            "GET /storage/{}/priv/test/file ",
+            storage.user.z32()
+        )));
+        assert!(request.to_ascii_lowercase().contains("cookie:"));
+        assert!(request.contains("test-secret"));
+    }
+}
+
+#[tokio::test]
+async fn raw_get_retains_path_and_transport_errors() {
+    let server = TestServer::start(Vec::new());
+    let storage = storage(&server);
+    assert!(matches!(
+        storage.get_raw("/pub/../invalid").await,
+        Err(Error::Parse(_) | Error::Request(RequestError::Validation { .. }))
+    ));
+    // Close the advertised endpoint; the next request must be a transport error.
+    assert!(server.finish().await.is_empty());
+    assert!(matches!(
+        storage.get_raw("/pub/test/file").await,
+        Err(Error::Request(RequestError::Transport(_)))
+    ));
+}

--- a/pubky-sdk/src/client/http_targets/features.rs
+++ b/pubky-sdk/src/client/http_targets/features.rs
@@ -141,7 +141,7 @@ impl HomeserverFeatures {
     }
 
     #[cfg(test)]
-    pub(super) fn insert(&self, homeserver: &PublicKey, features: &[&str]) {
+    pub(crate) fn insert(&self, homeserver: &PublicKey, features: &[&str]) {
         let cell = self.cell(homeserver);
         let mut cached = cell
             .try_lock()

--- a/pubky-sdk/src/errors.rs
+++ b/pubky-sdk/src/errors.rs
@@ -125,12 +125,13 @@ pub enum RequestError {
     #[error("HTTP transport error: {0}")]
     Transport(#[from] reqwest::Error),
 
-    /// The server returned a non-success status. Includes status and body message.
+    /// The server returned a non-success status. Includes status and bounded diagnostics.
     #[error("Server responded with an error: {status} - {message}")]
     Server {
         /// The HTTP status code returned by the server.
         status: reqwest::StatusCode,
-        /// Short description or the server response body captured for context.
+        /// Short description or up to 4096 response bytes decoded for context.
+        /// Oversized bodies have a truncation marker; decoding may expand invalid UTF-8.
         message: String,
     },
 

--- a/pubky-sdk/src/util.rs
+++ b/pubky-sdk/src/util.rs
@@ -2,23 +2,57 @@ use reqwest::Response;
 
 use crate::errors::{Error, RequestError, Result};
 
-/// Convert non-2xx responses into a structured error that includes the server body.
-///
-/// If the status is successful (2xx), the original response is returned.
-/// If the status is an error (4xx or 5xx), the response body is consumed
-/// to create a `PubkyError::Request(RequestError::Server)` and returned as an `Err`.
+const MAX_ERROR_BODY_BYTES: usize = 4096;
+const ERROR_BODY_TRUNCATION_SUFFIX: &str = "\n[response body truncated at 4096 bytes]";
+
+/// Return successful responses untouched; capture bounded diagnostics for all
+/// other statuses. Oversized error bodies are dropped without draining them.
 pub async fn check_http_status(response: Response) -> Result<Response> {
     if response.status().is_success() {
         return Ok(response);
     }
-
     let status = response.status();
-    let message = response.text().await.unwrap_or_else(|_| {
+    let message = read_error_message(response).await.unwrap_or_else(|_| {
         status
             .canonical_reason()
             .unwrap_or("Unknown Error")
             .to_string()
     });
-
     Err(Error::from(RequestError::Server { status, message }))
 }
+
+async fn read_error_message(response: Response) -> std::result::Result<String, reqwest::Error> {
+    use futures_util::StreamExt;
+
+    let mut body = Vec::with_capacity(MAX_ERROR_BODY_BYTES);
+    let mut chunks = response.bytes_stream();
+    let mut truncated = false;
+    while let Some(chunk) = chunks.next().await {
+        let chunk = chunk?;
+        let remaining = MAX_ERROR_BODY_BYTES - body.len();
+        body.extend_from_slice(&chunk[..chunk.len().min(remaining)]);
+        if chunk.len() > remaining {
+            truncated = true;
+            break;
+        }
+    }
+    // Release the transport (and the browser stream) before constructing the error.
+    drop(chunks);
+
+    // Native reqwest without `charset` retains a BOM; browser Response.text()
+    // strips it. Preserve those existing target-specific decoding semantics.
+    let body = body.as_slice();
+    #[cfg(target_arch = "wasm32")]
+    let body = body.strip_prefix(b"\xef\xbb\xbf").unwrap_or(body);
+    let mut message = String::from_utf8_lossy(body).into_owned();
+    if truncated {
+        message.push_str(ERROR_BODY_TRUNCATION_SUFFIX);
+    }
+    Ok(message)
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests;
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+pub(crate) mod test_server;

--- a/pubky-sdk/src/util/test_server.rs
+++ b/pubky-sdk/src/util/test_server.rs
@@ -1,0 +1,109 @@
+//! A one-request Pubky TLS peer whose response never reaches EOF until released.
+
+use std::{
+    io::{Read, Write},
+    net::TcpListener,
+    num::NonZeroUsize,
+    sync::{Arc, mpsc},
+    time::Duration,
+};
+
+use pkarr::{Cache, InMemoryCache, SignedPacket, dns::rdata::SVCB};
+
+use crate::{Keypair, PubkyHttpClient, PublicKey};
+
+pub(crate) struct TestServer {
+    pub client: PubkyHttpClient,
+    pub user: PublicKey,
+    pub homeserver: PublicKey,
+    finish: mpsc::Sender<()>,
+    task: tokio::task::JoinHandle<String>,
+}
+
+impl TestServer {
+    pub fn start(response: Vec<u8>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let address = listener.local_addr().unwrap();
+        let homeserver = Keypair::random();
+        let user = Keypair::random();
+        let cache = Arc::new(InMemoryCache::new(NonZeroUsize::new(8).unwrap()));
+        let mut endpoint = SVCB::new(1, ".".try_into().unwrap());
+        endpoint.set_port(address.port());
+        endpoint.set_ipv4hint(&[u32::from(std::net::Ipv4Addr::LOCALHOST)]);
+        let packet = SignedPacket::builder()
+            .https(".".try_into().unwrap(), endpoint, 3600)
+            .address(".".try_into().unwrap(), address.ip(), 3600)
+            .sign(&homeserver)
+            .unwrap();
+        cache.put(&homeserver.public_key().as_inner().into(), &packet);
+        let packet = SignedPacket::builder()
+            .https(
+                "_pubky".try_into().unwrap(),
+                SVCB::new(
+                    0,
+                    homeserver.public_key().z32().as_str().try_into().unwrap(),
+                ),
+                3600,
+            )
+            .sign(&user)
+            .unwrap();
+        cache.put(&user.public_key().as_inner().into(), &packet);
+        let client = PubkyHttpClient::builder()
+            .isolated_pkarr_test()
+            .pkarr(|builder| builder.cache(Arc::<InMemoryCache>::clone(&cache)))
+            .build()
+            .unwrap();
+        client
+            .features
+            .insert(&homeserver.public_key(), &["path-addressed-storage"]);
+        let config = homeserver.to_rpk_rustls_server_config();
+        let (finish, finished) = mpsc::channel();
+        let task = tokio::task::spawn_blocking(move || {
+            // A bounded nonblocking accept also lets fixture cleanup finish if
+            // validation/refresh fails before opening a socket.
+            let deadline = std::time::Instant::now() + Duration::from_secs(5);
+            let socket = loop {
+                if let Ok((socket, _)) = listener.accept() {
+                    break socket;
+                }
+                if finished.try_recv().is_ok() || std::time::Instant::now() >= deadline {
+                    return String::new();
+                }
+                std::thread::sleep(Duration::from_millis(5));
+            };
+            socket.set_nonblocking(false).unwrap();
+            socket
+                .set_read_timeout(Some(Duration::from_secs(5)))
+                .unwrap();
+            socket
+                .set_write_timeout(Some(Duration::from_secs(5)))
+                .unwrap();
+            let connection = rustls::ServerConnection::new(Arc::new(config)).unwrap();
+            let mut stream = rustls::StreamOwned::new(connection, socket);
+            let mut request = Vec::new();
+            while !request.ends_with(b"\r\n\r\n") {
+                let mut byte = [0];
+                stream.read_exact(&mut byte).unwrap();
+                request.push(byte[0]);
+                assert!(request.len() < 16 * 1024);
+            }
+            stream.write_all(&response).unwrap();
+            stream.flush().unwrap();
+            let _ = finished.recv_timeout(Duration::from_secs(5));
+            String::from_utf8(request).unwrap()
+        });
+        Self {
+            client,
+            user: user.public_key(),
+            homeserver: homeserver.public_key(),
+            finish,
+            task,
+        }
+    }
+
+    pub async fn finish(self) -> String {
+        let _ = self.finish.send(());
+        self.task.await.unwrap()
+    }
+}

--- a/pubky-sdk/src/util/tests.rs
+++ b/pubky-sdk/src/util/tests.rs
@@ -1,0 +1,200 @@
+use super::check_http_status;
+use crate::{Error, errors::RequestError};
+use reqwest::{Response, StatusCode};
+use std::time::Duration;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+};
+
+// Keep the server socket alive after returning headers/body. Tests decide when
+// EOF happens, so a response reader cannot pass by waiting for the whole body.
+async fn serve_response(status: u16, framing: &str, body: &[u8]) -> (Response, TcpStream) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("http://{}", listener.local_addr().unwrap());
+    let client = reqwest::Client::new();
+    let send = client.get(url).send();
+    let serve = async {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut request = Vec::new();
+        loop {
+            let byte = socket.read_u8().await.unwrap();
+            request.push(byte);
+            if request.ends_with(b"\r\n\r\n") {
+                break;
+            }
+            assert!(request.len() < 16 * 1024);
+        }
+        socket
+            .write_all(format!("HTTP/1.1 {status} Test\r\n{framing}\r\n").as_bytes())
+            .await
+            .unwrap();
+        socket.write_all(body).await.unwrap();
+        socket
+    };
+    let (response, socket) = tokio::join!(send, serve);
+    (response.unwrap(), socket)
+}
+
+async fn server_error(response: Response) -> (StatusCode, String) {
+    let error = tokio::time::timeout(Duration::from_secs(2), check_http_status(response))
+        .await
+        .expect("status handling must not wait for the rest of an oversized body")
+        .unwrap_err();
+    let Error::Request(RequestError::Server { status, message }) = error else {
+        panic!("unexpected error: {error:?}");
+    };
+    (status, message)
+}
+
+#[tokio::test]
+async fn oversized_error_stops_before_eof() {
+    let body = format!("1001\r\n{}\r\n", "x".repeat(4097));
+    let (response, _socket) =
+        serve_response(500, "Transfer-Encoding: chunked\r\n", body.as_bytes()).await;
+    let (status, message) = server_error(response).await;
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(
+        message,
+        format!(
+            "{}\n[response body truncated at 4096 bytes]",
+            "x".repeat(4096)
+        )
+    );
+}
+
+#[tokio::test]
+async fn error_body_boundaries_and_status_are_preserved() {
+    for size in [0, 3, 4095, 4096, 4097, 8192] {
+        let body = vec![b'x'; size];
+        let (response, _socket) =
+            serve_response(429, &format!("Content-Length: {size}\r\n"), &body).await;
+        let (status, message) = server_error(response).await;
+        assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
+        let mut expected = "x".repeat(size.min(4096));
+        if size > 4096 {
+            expected.push_str("\n[response body truncated at 4096 bytes]");
+        }
+        assert_eq!(message, expected, "body size {size}");
+    }
+}
+
+#[tokio::test]
+async fn error_limit_is_independent_of_framing_and_chunk_boundaries() {
+    for framing in ["", "Content-Length: 1000000000000\r\n"] {
+        let (response, _socket) = serve_response(503, framing, &vec![b'x'; 4097]).await;
+        let (_, message) = server_error(response).await;
+        assert_eq!(
+            message,
+            format!(
+                "{}\n[response body truncated at 4096 bytes]",
+                "x".repeat(4096)
+            )
+        );
+    }
+
+    let (response, mut socket) = serve_response(500, "Transfer-Encoding: chunked\r\n", b"").await;
+    let read = tokio::spawn(server_error(response));
+    for _ in 0..4096 {
+        socket.write_all(b"1\r\nx\r\n").await.unwrap();
+    }
+    // Reaching the limit alone is not truncation; the next byte proves overflow.
+    socket.write_all(b"1\r\ny\r\n").await.unwrap();
+    let (_, message) = read.await.unwrap();
+    assert_eq!(
+        message,
+        format!(
+            "{}\n[response body truncated at 4096 bytes]",
+            "x".repeat(4096)
+        )
+    );
+}
+
+#[tokio::test]
+async fn checked_success_does_not_consume_the_body() {
+    let (response, mut socket) = serve_response(200, "Content-Length: 5\r\n", b"").await;
+    let response = tokio::time::timeout(Duration::from_secs(2), check_http_status(response))
+        .await
+        .unwrap()
+        .unwrap();
+    socket.write_all(b"hello").await.unwrap();
+    assert_eq!(response.text().await.unwrap(), "hello");
+}
+
+#[tokio::test]
+async fn error_text_decoding_and_read_failure() {
+    for body in [
+        b"\xef\xbb\xbfhello".as_slice(),
+        b"bad\xfftext",
+        "caf\u{e9}".as_bytes(),
+    ] {
+        let (response, _socket) =
+            serve_response(400, &format!("Content-Length: {}\r\n", body.len()), body).await;
+        let (_, message) = server_error(response).await;
+        assert_eq!(message, String::from_utf8_lossy(body));
+    }
+    let mut body = vec![b'x'; 4095];
+    body.extend_from_slice("\u{20ac}".as_bytes());
+    let (response, _socket) =
+        serve_response(400, &format!("Content-Length: {}\r\n", body.len()), &body).await;
+    let (_, message) = server_error(response).await;
+    assert_eq!(
+        message,
+        format!(
+            "{}\u{fffd}\n[response body truncated at 4096 bytes]",
+            "x".repeat(4095)
+        )
+    );
+
+    for (status, fallback) in [(500, "Internal Server Error"), (599, "Unknown Error")] {
+        let (response, socket) =
+            serve_response(status, "Content-Length: 100\r\n", b"partial").await;
+        drop(socket);
+        let (actual, message) = server_error(response).await;
+        assert_eq!(actual.as_u16(), status);
+        assert_eq!(message, fallback);
+    }
+}
+
+#[tokio::test]
+async fn small_head_does_not_protect_against_oversized_get_errors() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("http://{}", listener.local_addr().unwrap());
+    let peer = tokio::spawn(async move {
+        for method in ["HEAD", "GET"] {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = Vec::new();
+            while !request.ends_with(b"\r\n\r\n") {
+                request.push(socket.read_u8().await.unwrap());
+                assert!(request.len() < 16 * 1024);
+            }
+            assert!(request.starts_with(method.as_bytes()));
+            if method == "HEAD" {
+                socket
+                    .write_all(
+                        b"HTTP/1.1 200 OK\r\nContent-Length: 16\r\nConnection: close\r\n\r\n",
+                    )
+                    .await
+                    .unwrap();
+            } else {
+                socket.write_all(format!("HTTP/1.1 500 Error\r\nTransfer-Encoding: chunked\r\n\r\n1001\r\n{}\r\n", "x".repeat(4097)).as_bytes()).await.unwrap();
+                return socket; // Withhold EOF until the checked GET has returned.
+            }
+        }
+        unreachable!()
+    });
+    let client = reqwest::Client::new();
+    let head = client.head(&url).send().await.unwrap();
+    assert_eq!(head.headers()["content-length"], "16");
+    let response = client.get(&url).send().await.unwrap();
+    let _socket = peer.await.unwrap();
+    let (status, message) = server_error(response).await;
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(
+        message,
+        format!(
+            "{}\n[response body truncated at 4096 bytes]",
+            "x".repeat(4096)
+        )
+    );
+}


### PR DESCRIPTION
Closes [https://github.com/pubky/pubky-homeserver/issues/604](https://github.com/pubky/pubky-homeserver/issues/604)

### Summary

Adds `SessionStorage::get_raw()` for authenticated GETs whose status and body must be handled by the caller. It reuses existing path validation, routing, credentials, proactive refresh and redirect behavior, then returns the final response without consuming its body. `get()` composes this API with checked status handling.

The shared status checker now captures at most 4096 error-body bytes. It preserves the original status, appends `\n[response body truncated at 4096 bytes]` only after observing overflow, and drops the remaining stream without draining it. Successful responses still return untouched. Short-body read failures retain the canonical-reason fallback; UTF-8 decoding and target-specific BOM handling remain compatible.

### Compatibility and scope

- The Rust API is additive and compiles for native and WASM; no JavaScript raw API or public-storage equivalent is added.
- All checked SDK methods, including JavaScript methods and failed credential refreshes, receive the shared diagnostic limit. Consumers inspecting exceptionally large error messages will now see truncation.
- The limit bounds captured bytes plus bounded decoding/message overhead, not transport buffers or individual delivered chunks. Successful downloads and successful credential-refresh JSON retain their existing collection and timeout policies.
- No new dependencies, public error variants, server changes or migrations.

### Validation

- Established the oversized-error regression failing before the fix. Added the small-HEAD/oversized-chunked-500 reproduction, withheld-EOF tests, boundary/chunking/length metadata/UTF-8/body-failure cases, raw status tests and expiring access-token refresh coverage.
- SDK: **210 unit tests pass**. E2E against local PostgreSQL: **16 storage, 3 private-data and 13 grant tests pass**, including private grant and legacy-cookie raw reads.
- Built the JavaScript package. Full harness: **357 Node assertions and 402 browser assertions pass**. Focused regressions also pass on the final build in both runtimes (**20 assertions each**), including cancellation of a controlled `ReadableStream` after overflow, small errors, BOM decoding and readable success bodies. Fetch interception is restored in `finally`.
- `cargo fmt --all --check`, Rust **1.89** CI-toolchain Clippy (`-p pubky --all-targets --all-features --locked -- -D warnings`), WASM SDK check, WASM binding Clippy and SDK rustdoc pass.
- On installed Rust 1.95, the same native Clippy command also lints a pre-existing `collapsible_match` warning in `pubky-homeserver/src/admin_server/routes/admin_events.rs:71`; SDK-only Clippy with `--no-deps` passes. No unrelated server code is changed.

Consumer adoption is tracked in [pubky-noise#37](https://github.com/pubky/pubky-noise/pull/37), a separate draft PR; this SDK change does not remove its HEAD workaround itself.
