### PR TITLE
feat(sdk): configure error responses limits

### DIFF
--- a/e2e/src/tests/storage/objects.rs
+++ b/e2e/src/tests/storage/objects.rs
@@ -1,5 +1,6 @@
 use super::*;
 use base64::Engine;
+use pubky_testnet::pubky::{ClientId, Pubky};
 
 fn assert_server_status(error: Error, expected: StatusCode) {
     assert!(
@@ -537,4 +538,51 @@ async fn write_same_path_separate_users() {
     assert_eq!(content_length, content1.len() as u64);
     let read_bytes_b = response.bytes().await.unwrap();
     assert_eq!(read_bytes_b, content1);
+}
+
+#[tokio::test]
+#[pubky_testnet::test]
+async fn configured_error_limit_preserves_private_grant_and_cookie_reads() {
+    let testnet = build_full_testnet().await;
+    let pubky = Pubky::with_client(
+        testnet
+            .client_builder()
+            .max_error_body_bytes(0)
+            .build()
+            .unwrap(),
+    );
+    let signer = pubky.signer(Keypair::random());
+    signer
+        .signup(&testnet.homeserver_app().public_key(), None)
+        .await
+        .unwrap();
+    let grant = signer
+        .signin(ClientId::new("error-limit.test").unwrap())
+        .await
+        .unwrap();
+    grant
+        .storage()
+        .put("/priv/test/file", "private")
+        .await
+        .unwrap();
+    let cookie = signer.signin_cookie().await.unwrap();
+    for session in [&grant, &cookie] {
+        let response = session.storage().get("/priv/test/file").await.unwrap();
+        assert_eq!(response.text().await.unwrap(), "private");
+        let error = session
+            .storage()
+            .get("/priv/test/missing")
+            .await
+            .unwrap_err();
+        let Error::Request(RequestError::Server { status, message }) = error else {
+            panic!("unexpected error: {error:?}");
+        };
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(message, "Not Found");
+        assert!(!session
+            .storage()
+            .exists("/priv/test/missing")
+            .await
+            .unwrap());
+    }
 }

--- a/pubky-sdk/README.md
+++ b/pubky-sdk/README.md
@@ -70,6 +70,28 @@ println!("Your current homeserver: {:?}", resolved);
 # Ok(()) }
 ```
 
+## Error-body limits
+
+HTTP status checking leaves successful response bodies unread. For HTTP errors,
+the client captures up to 4096 body bytes for the error message. Change this limit when creating the client:
+
+```rust,no_run
+use pubky::{Pubky, PubkyHttpClient};
+
+let client = PubkyHttpClient::builder()
+    .max_error_body_bytes(1024)
+    .build()?;
+let pubky = Pubky::with_client(client);
+# Ok::<_, pubky::BuildError>(())
+```
+
+The setting applies to all checked requests made through that client, including
+credential-refresh errors. Set it to `0` to skip error-body reads and use the
+HTTP status reason as the message. Positive limits preserve short messages and
+mark longer ones with `[response body truncated at N bytes]`.
+
+In JavaScript, use `Pubky.withClient(new Client({ maxErrorBodyBytes: 1024 }))`.
+
 ## Key formats (display vs transport)
 
 `PublicKey` has two string representations:

--- a/pubky-sdk/bindings/js/pkg/tests/bounded_storage.ts
+++ b/pubky-sdk/bindings/js/pkg/tests/bounded_storage.ts
@@ -1,0 +1,126 @@
+import test from "tape";
+import { Client, Keypair, Pubky, PublicKey, type Path } from "../index.js";
+import { assertPubkyError, createSignupToken, getStatusCode } from "./utils.js";
+
+const PATH: Path = "/priv/bounded-reader/value";
+const errorPrefix = "Request failed: Server responded with an error: 500 Internal Server Error - ";
+
+for (const setting of [undefined, 16, 8192, 0]) {
+  test(`checked storage error-body limit: ${setting ?? "default"}`, async (t) => {
+    const limit = setting ?? 4096;
+    const sdk = Pubky.withClient(new Client({
+      maxErrorBodyBytes: setting,
+      pkarr: { relays: ["http://localhost:15411/"] },
+    }));
+    const signer = sdk.signer(Keypair.random());
+    const homeserver = PublicKey.from(
+      "8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo",
+    );
+    await signer.signup(homeserver, await createSignupToken());
+    const session = await signer.signin("bounded-reader.test");
+    await session.storage.exists(PATH);
+    const originalFetch = globalThis.fetch;
+    const encoder = new TextEncoder();
+    let reply: () => Response;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      if (!new URL(request.url).pathname.endsWith(PATH)) return originalFetch(input, init);
+      t.ok(request.headers.has("authorization"), "GET remains authenticated");
+      const response = reply();
+      Object.defineProperty(response, "url", { value: request.url });
+      return response;
+    }) as typeof fetch;
+    try {
+      const bodies = limit === 0 ? [[]] : [["x".repeat(limit + 1)], ["x".repeat(limit), "y"]];
+      for (const parts of bodies) {
+        let cancelled = false;
+        let pulled = 0;
+        reply = () => new Response(new ReadableStream<Uint8Array>({
+          pull(controller) {
+            const part = parts[pulled++];
+            if (part !== undefined) controller.enqueue(encoder.encode(part));
+            // Withhold EOF to catch readers that drain the body.
+          },
+          cancel() { cancelled = true; },
+        }, { highWaterMark: 0 }), { status: 500 });
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        try {
+          await Promise.race([
+            session.storage.get(PATH),
+            new Promise<never>((_, reject) => {
+              timer = setTimeout(() => reject(new Error("reader waited for EOF")), 5000);
+            }),
+          ]);
+          t.fail("checked GET must reject 500");
+        } catch (error) {
+          assertPubkyError(t, error);
+          t.equal(getStatusCode(error), 500, "original status survives");
+          const message = limit === 0
+            ? "Internal Server Error"
+            : "x".repeat(limit) + `\n[response body truncated at ${limit} bytes]`;
+          t.equal(error.message, errorPrefix + message, "configured diagnostic limit");
+        } finally {
+          clearTimeout(timer);
+        }
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        t.ok(cancelled, "error reader releases the stream");
+        if (limit === 0) t.equal(pulled, 0, "zero limit never polls the body");
+      }
+
+      for (const body of ["", "small", "\ufeffhello", "x".repeat(limit)]) {
+        reply = () => new Response(encoder.encode(body), { status: 500 });
+        try {
+          await session.storage.get(PATH);
+          t.fail("checked GET must reject 500");
+        } catch (error) {
+          assertPubkyError(t, error);
+          const message = limit === 0 ? "Internal Server Error" : body.replace(/^\ufeff/, "");
+          t.equal(error.message, errorPrefix + message, "complete error text");
+        }
+      }
+      // Successful bodies are independent of the error-body setting, even at zero.
+      reply = () => new Response("successful body", { status: 200 });
+      const response = await session.storage.get(PATH);
+      t.equal(await response.text(), "successful body", "success body remains readable");
+
+      let exchanges = 0;
+      let storageSent = false;
+      globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        const path = new URL(request.url).pathname;
+        if (!path.endsWith("/auth/grant/session") || request.method !== "POST") {
+          if (path.endsWith(PATH)) storageSent = true;
+          return originalFetch(input, init);
+        }
+        let response: Response;
+        if (exchanges++ === 0) {
+          const issued = await originalFetch(input, init);
+          const body = await issued.json();
+          body.session.token_expires_at = 0;
+          response = new Response(JSON.stringify(body), { status: issued.status });
+        } else {
+          response = new Response("x".repeat(limit + 1), { status: 500 });
+        }
+        Object.defineProperty(response, "url", { value: request.url });
+        return response;
+      }) as typeof fetch;
+      const expiring = await signer.signin("bounded-reader.test");
+      try {
+        await expiring.storage.get(PATH);
+        t.fail("refresh error must reject the storage read");
+      } catch (error) {
+        assertPubkyError(t, error);
+        t.equal(getStatusCode(error), 500, "refresh status survives");
+        const message = limit === 0
+          ? "Internal Server Error"
+          : "x".repeat(limit) + `\n[response body truncated at ${limit} bytes]`;
+        t.equal(error.message, errorPrefix + message, "refresh uses the client limit");
+      }
+      t.equal(exchanges, 2, "expired bearer triggers a refresh");
+      t.notOk(storageSent, "failed refresh prevents the storage GET");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+    t.end();
+  });
+}

--- a/pubky-sdk/bindings/js/pkg/tests/bounded_storage.ts
+++ b/pubky-sdk/bindings/js/pkg/tests/bounded_storage.ts
@@ -1,121 +1,155 @@
-import test from "tape";
+import test, { type Test } from "tape";
 import { Client, Keypair, Pubky, PublicKey, type Path } from "../index.js";
 import { assertPubkyError, createSignupToken, getStatusCode } from "./utils.js";
 
 const PATH: Path = "/priv/bounded-reader/value";
-const errorPrefix = "Request failed: Server responded with an error: 500 Internal Server Error - ";
+const ERROR_PREFIX = "Request failed: Server responded with an error: 500 Internal Server Error - ";
+
+async function createSigner(maxErrorBodyBytes: number | undefined) {
+  const sdk = Pubky.withClient(new Client({
+    maxErrorBodyBytes,
+    pkarr: { relays: ["http://localhost:15411/"] },
+  }));
+  const signer = sdk.signer(Keypair.random());
+  const homeserver = PublicKey.from(
+    "8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo",
+  );
+  await signer.signup(homeserver, await createSignupToken());
+  return signer;
+}
+
+async function assertServerError(t: Test, request: Promise<unknown>, message: string) {
+  try {
+    await request;
+    t.fail("request must reject HTTP 500");
+  } catch (error) {
+    assertPubkyError(t, error);
+    t.equal(getStatusCode(error), 500, "original status survives");
+    t.equal(error.message, ERROR_PREFIX + message, "expected diagnostic message");
+  }
+}
 
 for (const setting of [undefined, 16, 8192, 0]) {
-  test(`checked storage error-body limit: ${setting ?? "default"}`, async (t) => {
-    const limit = setting ?? 4096;
-    const sdk = Pubky.withClient(new Client({
-      maxErrorBodyBytes: setting,
-      pkarr: { relays: ["http://localhost:15411/"] },
-    }));
-    const signer = sdk.signer(Keypair.random());
-    const homeserver = PublicKey.from(
-      "8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo",
-    );
-    await signer.signup(homeserver, await createSignupToken());
+  const label = setting ?? "default";
+  const limit = setting ?? 4096;
+  const overflowMessage = limit === 0
+    ? "Internal Server Error"
+    : "x".repeat(limit) + `\n[response body truncated at ${limit} bytes]`;
+
+  test(`storage stops reading oversized errors: limit ${label}`, async (t) => {
+    const signer = await createSigner(setting);
     const session = await signer.signin("bounded-reader.test");
     await session.storage.exists(PATH);
     const originalFetch = globalThis.fetch;
     const encoder = new TextEncoder();
-    let reply: () => Response;
-    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-      const request = input instanceof Request ? input : new Request(input, init);
-      if (!new URL(request.url).pathname.endsWith(PATH)) return originalFetch(input, init);
-      t.ok(request.headers.has("authorization"), "GET remains authenticated");
-      const response = reply();
-      Object.defineProperty(response, "url", { value: request.url });
-      return response;
-    }) as typeof fetch;
-    try {
-      const bodies = limit === 0 ? [[]] : [["x".repeat(limit + 1)], ["x".repeat(limit), "y"]];
-      for (const parts of bodies) {
-        let cancelled = false;
-        let pulled = 0;
-        reply = () => new Response(new ReadableStream<Uint8Array>({
+    const chunkings = limit === 0
+      ? [[]]
+      : [["x".repeat(limit + 1)], ["x".repeat(limit), "y"]];
+
+    for (const chunks of chunkings) {
+      let cancelled = false;
+      let pulls = 0;
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      globalThis.fetch = async (input, init) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        if (!new URL(request.url).pathname.endsWith(PATH)) return originalFetch(input, init);
+        t.ok(request.headers.has("authorization"), "GET remains authenticated");
+        const body = new ReadableStream<Uint8Array>({
           pull(controller) {
-            const part = parts[pulled++];
-            if (part !== undefined) controller.enqueue(encoder.encode(part));
+            const chunk = chunks[pulls++];
+            if (chunk !== undefined) controller.enqueue(encoder.encode(chunk));
             // Withhold EOF to catch readers that drain the body.
           },
           cancel() { cancelled = true; },
-        }, { highWaterMark: 0 }), { status: 500 });
-        let timer: ReturnType<typeof setTimeout> | undefined;
-        try {
-          await Promise.race([
-            session.storage.get(PATH),
-            new Promise<never>((_, reject) => {
-              timer = setTimeout(() => reject(new Error("reader waited for EOF")), 5000);
-            }),
-          ]);
-          t.fail("checked GET must reject 500");
-        } catch (error) {
-          assertPubkyError(t, error);
-          t.equal(getStatusCode(error), 500, "original status survives");
-          const message = limit === 0
-            ? "Internal Server Error"
-            : "x".repeat(limit) + `\n[response body truncated at ${limit} bytes]`;
-          t.equal(error.message, errorPrefix + message, "configured diagnostic limit");
-        } finally {
-          clearTimeout(timer);
-        }
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        t.ok(cancelled, "error reader releases the stream");
-        if (limit === 0) t.equal(pulled, 0, "zero limit never polls the body");
-      }
-
-      for (const body of ["", "small", "\ufeffhello", "x".repeat(limit)]) {
-        reply = () => new Response(encoder.encode(body), { status: 500 });
-        try {
-          await session.storage.get(PATH);
-          t.fail("checked GET must reject 500");
-        } catch (error) {
-          assertPubkyError(t, error);
-          const message = limit === 0 ? "Internal Server Error" : body.replace(/^\ufeff/, "");
-          t.equal(error.message, errorPrefix + message, "complete error text");
-        }
-      }
-      // Successful bodies are independent of the error-body setting, even at zero.
-      reply = () => new Response("successful body", { status: 200 });
-      const response = await session.storage.get(PATH);
-      t.equal(await response.text(), "successful body", "success body remains readable");
-
-      let exchanges = 0;
-      let storageSent = false;
-      globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-        const request = input instanceof Request ? input : new Request(input, init);
-        const path = new URL(request.url).pathname;
-        if (!path.endsWith("/auth/grant/session") || request.method !== "POST") {
-          if (path.endsWith(PATH)) storageSent = true;
-          return originalFetch(input, init);
-        }
-        let response: Response;
-        if (exchanges++ === 0) {
-          const issued = await originalFetch(input, init);
-          const body = await issued.json();
-          body.session.token_expires_at = 0;
-          response = new Response(JSON.stringify(body), { status: issued.status });
-        } else {
-          response = new Response("x".repeat(limit + 1), { status: 500 });
-        }
+        }, { highWaterMark: 0 });
+        const response = new Response(body, { status: 500 });
         Object.defineProperty(response, "url", { value: request.url });
         return response;
-      }) as typeof fetch;
-      const expiring = await signer.signin("bounded-reader.test");
+      };
+
       try {
-        await expiring.storage.get(PATH);
-        t.fail("refresh error must reject the storage read");
-      } catch (error) {
-        assertPubkyError(t, error);
-        t.equal(getStatusCode(error), 500, "refresh status survives");
-        const message = limit === 0
-          ? "Internal Server Error"
-          : "x".repeat(limit) + `\n[response body truncated at ${limit} bytes]`;
-        t.equal(error.message, errorPrefix + message, "refresh uses the client limit");
+        const deadline = new Promise<never>((_, reject) => {
+          timer = setTimeout(() => reject(new Error("reader waited for EOF")), 5000);
+        });
+        await assertServerError(t, Promise.race([session.storage.get(PATH), deadline]), overflowMessage);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        t.ok(cancelled, "error reader releases the stream");
+        if (limit === 0) t.equal(pulls, 0, "zero limit never polls the body");
+      } finally {
+        clearTimeout(timer);
+        globalThis.fetch = originalFetch;
       }
+    }
+    t.end();
+  });
+
+  test(`storage preserves complete bodies: limit ${label}`, async (t) => {
+    const signer = await createSigner(setting);
+    const session = await signer.signin("bounded-reader.test");
+    await session.storage.exists(PATH);
+    const originalFetch = globalThis.fetch;
+    const cases = [
+      { status: 500, body: "" },
+      { status: 500, body: "small" },
+      { status: 500, body: "\ufeffhello" },
+      { status: 500, body: "x".repeat(limit) },
+      { status: 200, body: "successful body" },
+    ];
+
+    for (const { status, body } of cases) {
+      globalThis.fetch = async (input, init) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        if (!new URL(request.url).pathname.endsWith(PATH)) return originalFetch(input, init);
+        t.ok(request.headers.has("authorization"), "GET remains authenticated");
+        const response = new Response(body, { status });
+        Object.defineProperty(response, "url", { value: request.url });
+        return response;
+      };
+
+      try {
+        if (status === 200) {
+          const response = await session.storage.get(PATH);
+          t.equal(await response.text(), body, "success body remains readable");
+        } else {
+          const message = limit === 0 ? "Internal Server Error" : body.replace(/^\ufeff/, "");
+          await assertServerError(t, session.storage.get(PATH), message);
+        }
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    }
+    t.end();
+  });
+
+  test(`refresh errors prevent the storage GET: limit ${label}`, async (t) => {
+    const signer = await createSigner(setting);
+    const originalFetch = globalThis.fetch;
+    let exchanges = 0;
+    let storageSent = false;
+    globalThis.fetch = async (input, init) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      const path = new URL(request.url).pathname;
+      if (!path.endsWith("/auth/grant/session") || request.method !== "POST") {
+        if (path.endsWith(PATH)) storageSent = true;
+        return originalFetch(input, init);
+      }
+
+      let response: Response;
+      if (exchanges++ === 0) {
+        const issued = await originalFetch(input, init);
+        const body = await issued.json();
+        body.session.token_expires_at = 0;
+        response = new Response(JSON.stringify(body), { status: issued.status });
+      } else {
+        response = new Response("x".repeat(limit + 1), { status: 500 });
+      }
+      Object.defineProperty(response, "url", { value: request.url });
+      return response;
+    };
+
+    try {
+      const session = await signer.signin("bounded-reader.test");
+      await assertServerError(t, session.storage.get(PATH), overflowMessage);
       t.equal(exchanges, 2, "expired bearer triggers a refresh");
       t.notOk(storageSent, "failed refresh prevents the storage GET");
     } finally {

--- a/pubky-sdk/bindings/js/pkg/tests/constructor.ts
+++ b/pubky-sdk/bindings/js/pkg/tests/constructor.ts
@@ -41,3 +41,13 @@ test("new Client() with faulty config", async (t) => {
     "should throw an error",
   );
 });
+
+test("error-body limit without pkarr options", (t) => {
+  for (const maxErrorBodyBytes of [0, 16, 4294967295]) {
+    t.doesNotThrow(() => new Client({ maxErrorBodyBytes }), `accepts ${maxErrorBodyBytes}`);
+  }
+  for (const maxErrorBodyBytes of [-1, 1.5, NaN, Infinity, 4294967296]) {
+    t.throws(() => new Client({ maxErrorBodyBytes }), `rejects ${maxErrorBodyBytes}`);
+  }
+  t.end();
+});

--- a/pubky-sdk/bindings/js/src/client/constructor.rs
+++ b/pubky-sdk/bindings/js/src/client/constructor.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use tsify::{Ts, Tsify};
 use wasm_bindgen::prelude::*;
 
-use crate::js_error::{JsResult, PubkyError, PubkyErrorName, deserialize_ts};
+use crate::js_error::{JsResult, PubkyError, PubkyErrorName};
 
 // ------------------------------------------------------------------------------------------------
 // JS style config objects for the client.
@@ -31,7 +31,9 @@ pub struct PubkyClientConfig {
     /// Configuration on how to access pkarr packets on the mainline DHT.
     #[tsify(optional)]
     pub(crate) pkarr: Option<PkarrConfig>,
-    // NOTE: user_max_record_age belonged to the old client — removed here.
+    /// Maximum HTTP error-body bytes to capture. Defaults to 4096; zero skips the body.
+    #[tsify(optional)]
+    pub(crate) max_error_body_bytes: Option<usize>,
 }
 
 /// Low-level HTTP bridge used by the Pubky facade and actors.
@@ -52,26 +54,36 @@ impl Client {
     /// Create a Pubky HTTP client.
     ///
     /// @param {PubkyClientConfig} [config]
-    /// Optional transport overrides:
-    /// `{ pkarr?: { relays?: string[], request_timeout?: number } }`.
+    /// Optional error-body limit and PKARR overrides:
+    /// `{ maxErrorBodyBytes?: number, pkarr?: { relays?: string[], requestTimeout?: number } }`.
     ///
     /// @returns {Client}
     /// A configured low-level client. Prefer `new Pubky().client` unless you
-    /// need custom relays/timeouts.
+    /// need custom relays, timeouts or error-body limits.
     ///
     /// @throws {InvalidInput}
-    /// If any PKARR relay URL is invalid.
+    /// If a relay URL is invalid or the error-body limit is not an integer in 0..=4294967295.
     ///
     /// @example
     /// const client = new Client({
-    ///   pkarr: { relays: ["https://relay1/","https://relay2/"], request_timeout: 8000 }
+    ///   maxErrorBodyBytes: 1024,
+    ///   pkarr: { relays: ["https://relay1/","https://relay2/"], requestTimeout: 8000 }
     /// });
     /// const pubky = Pubky.withClient(client);
     #[wasm_bindgen(constructor)]
     pub fn new(config_opt: Option<Ts<PubkyClientConfig>>) -> JsResult<Self> {
-        let config_opt = config_opt.as_ref().map(deserialize_ts).transpose()?;
+        // A JSON roundtrip would turn NaN/Infinity into null and silently use defaults.
+        let config_opt = config_opt
+            .map(|config| serde_wasm_bindgen::from_value::<PubkyClientConfig>(config.js_value()))
+            .transpose()
+            .map_err(|error| PubkyError::new(PubkyErrorName::InvalidInput, error))?;
         let mut builder = pubky::PubkyHttpClient::builder();
 
+        if let Some(config) = config_opt.as_ref()
+            && let Some(limit) = config.max_error_body_bytes
+        {
+            builder.max_error_body_bytes(limit);
+        }
         if let Some(config) = config_opt
             && let Some(pkarr) = config.pkarr
         {

--- a/pubky-sdk/src/actors/auth/cookie/credential.rs
+++ b/pubky-sdk/src/actors/auth/cookie/credential.rs
@@ -37,7 +37,6 @@ use crate::{
     client::user_endpoint_url,
     cross_log,
     errors::{PkarrError, Result},
-    util::check_http_status,
 };
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -196,7 +195,7 @@ impl CookieCredential {
         .await?;
         let response = request.body(token.serialize()).send().await?;
 
-        let response = check_http_status(response).await?;
+        let response = client.check_http_status(response).await?;
         cross_log!(
             info,
             "Session exchange for {} succeeded; constructing credential",
@@ -278,7 +277,7 @@ impl SessionCredential for CookieCredential {
         let rb = session_request(client, Method::DELETE, &self.user, homeserver.as_ref()).await?;
         let rb = self.attach(rb, client).await?;
         let response = rb.send().await.map_err(crate::Error::from)?;
-        check_http_status(response).await?;
+        client.check_http_status(response).await?;
         Ok(())
     }
 
@@ -329,7 +328,7 @@ impl SessionCredential for CookieCredential {
             cross_log!(info, "Cookie session missing on revalidate");
             return Ok(None);
         }
-        let response = check_http_status(response).await?;
+        let response = client.check_http_status(response).await?;
         let bytes = response.bytes().await?;
         let record = CookieSessionRecord::deserialize(&bytes)?;
         let info = SessionInfo::new(record.public_key().clone(), record.capabilities().to_vec());

--- a/pubky-sdk/src/actors/auth/grant/credential.rs
+++ b/pubky-sdk/src/actors/auth/grant/credential.rs
@@ -35,7 +35,6 @@ use crate::{
     actors::session::SessionInfo,
     cross_log,
     errors::{AuthError, RequestError, Result},
-    util::check_http_status,
 };
 
 /// Refresh the bearer proactively when it has less than this many seconds left.
@@ -343,7 +342,7 @@ impl GrantCredential {
             .json(&body)
             .send()
             .await?;
-        let resp = check_http_status(resp).await?;
+        let resp = client.check_http_status(resp).await?;
         let parsed: GrantSessionResponse =
             resp.json().await.map_err(|e| RequestError::DecodeJson {
                 message: format!("decoding /auth/grant/session response: {e}"),
@@ -390,7 +389,7 @@ impl SessionCredential for GrantCredential {
             .send()
             .await
             .map_err(crate::Error::from)?;
-        check_http_status(response).await?;
+        client.check_http_status(response).await?;
         Ok(())
     }
 
@@ -428,7 +427,7 @@ impl SessionCredential for GrantCredential {
         if credential_session_missing(&response) {
             return Ok(None);
         }
-        let response = check_http_status(response).await?;
+        let response = client.check_http_status(response).await?;
         let session: GrantSessionInfo =
             response
                 .json()

--- a/pubky-sdk/src/actors/auth/grant/grant_exchange.rs
+++ b/pubky-sdk/src/actors/auth/grant/grant_exchange.rs
@@ -20,7 +20,6 @@ use super::{
     pop_signer::GrantPopSigner,
 };
 use crate::errors::{RequestError, Result};
-use crate::util::check_http_status;
 use crate::{PubkyHttpClient, cross_log};
 
 /// Establish a grant-backed session by exchanging a user-signed grant for
@@ -90,7 +89,7 @@ pub(crate) async fn signup_account_from_grant(
         .json(&body)
         .send()
         .await?;
-    check_http_status(resp).await?;
+    client.check_http_status(resp).await?;
     Ok(())
 }
 
@@ -116,7 +115,7 @@ async fn post_grant_session(
         .json(&body)
         .send()
         .await?;
-    let resp = check_http_status(resp).await?;
+    let resp = client.check_http_status(resp).await?;
     resp.json().await.map_err(|e| {
         RequestError::DecodeJson {
             message: format!("decoding grant session response: {e}"),

--- a/pubky-sdk/src/actors/auth/grant/manager.rs
+++ b/pubky-sdk/src/actors/auth/grant/manager.rs
@@ -12,7 +12,6 @@ use std::sync::Arc;
 use crate::actors::session::credential::SessionCredential;
 use crate::client::user_endpoint_url;
 use crate::errors::{RequestError, Result};
-use crate::util::check_http_status;
 use crate::{PubkyHttpClient, PubkySession};
 
 /// Account-level grant management for a signed-in user.
@@ -76,7 +75,7 @@ impl GrantManager {
             .await?
             .send()
             .await?;
-        let resp = check_http_status(resp).await?;
+        let resp = self.client.check_http_status(resp).await?;
         let grants: Vec<GrantInfo> = resp.json().await.map_err(|e| RequestError::DecodeJson {
             message: format!("decoding /auth/grant/sessions response: {e}"),
         })?;
@@ -101,7 +100,7 @@ impl GrantManager {
             .await?
             .send()
             .await?;
-        check_http_status(resp).await?;
+        self.client.check_http_status(resp).await?;
         Ok(())
     }
 }

--- a/pubky-sdk/src/actors/auth/relay/http_relay_inbox_channel.rs
+++ b/pubky-sdk/src/actors/auth/relay/http_relay_inbox_channel.rs
@@ -5,7 +5,7 @@ use pubky_common::crypto::hash;
 use reqwest::{Method, StatusCode};
 use url::Url;
 
-use crate::{PubkyHttpClient, cross_log, util::check_http_status};
+use crate::{PubkyHttpClient, cross_log};
 
 /// Default HTTP relay inbox base when none is supplied.
 pub const DEFAULT_HTTP_RELAY_INBOX: &str = "https://httprelay.pubky.app/inbox";
@@ -126,7 +126,7 @@ impl HttpRelayInboxChannel {
             return Err(PollError::Timeout);
         }
 
-        let response = match check_http_status(response).await {
+        let response = match client.check_http_status(response).await {
             Ok(response) => response,
             Err(e) => return Err(PollError::Failure(e)),
         };
@@ -202,7 +202,7 @@ impl HttpRelayInboxChannel {
         let request = client.cross_request(Method::POST, self.to_url()).await?;
         let request = request.body(body.to_vec());
         let response = request.send().await?;
-        check_http_status(response).await?;
+        client.check_http_status(response).await?;
         Ok(())
     }
 
@@ -220,7 +220,7 @@ impl HttpRelayInboxChannel {
             StatusCode::OK => Ok(true),
             StatusCode::NOT_FOUND => Ok(false),
             _ => {
-                check_http_status(response).await?;
+                client.check_http_status(response).await?;
                 Ok(false)
             }
         }
@@ -243,7 +243,7 @@ impl HttpRelayInboxChannel {
             }
             StatusCode::NOT_FOUND => Ok(None),
             _ => {
-                check_http_status(response).await?;
+                client.check_http_status(response).await?;
                 Ok(None)
             }
         }
@@ -276,7 +276,7 @@ impl HttpRelayInboxChannel {
             StatusCode::REQUEST_TIMEOUT => Ok(Some(false)),
             StatusCode::NOT_FOUND => Ok(None),
             _ => {
-                check_http_status(response).await?;
+                client.check_http_status(response).await?;
                 Ok(None)
             }
         }
@@ -427,6 +427,8 @@ impl Display for EncryptedHttpRelayInboxChannel {
 
 #[cfg(test)]
 mod tests {
+    use crate::{Error, errors::RequestError};
+    use httpmock::MockServer;
     use pubky_common::crypto::random_bytes;
 
     use super::*;
@@ -762,5 +764,30 @@ mod tests {
             result.is_err(),
             "Expected error after MAX_FAILURES, got {result:?}"
         );
+    }
+    #[tokio::test]
+    async fn relay_errors_use_the_client_limit() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method("DELETE");
+            then.status(500).body("diagnostic");
+        });
+        let channel = random_channel(&Url::parse(&server.base_url()).unwrap());
+        for (limit, expected) in [
+            (0, "Internal Server Error"),
+            (4, "diag\n[response body truncated at 4 bytes]"),
+        ] {
+            let client = PubkyHttpClient::builder()
+                .isolated_pkarr_test()
+                .max_error_body_bytes(limit)
+                .build()
+                .unwrap();
+            let error = channel.ack(&client).await.unwrap_err();
+            let Error::Request(RequestError::Server { status, message }) = error else {
+                panic!("unexpected error: {error:?}");
+            };
+            assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+            assert_eq!(message, expected);
+        }
     }
 }

--- a/pubky-sdk/src/actors/auth/relay/http_relay_link_channel.rs
+++ b/pubky-sdk/src/actors/auth/relay/http_relay_link_channel.rs
@@ -9,7 +9,7 @@ use pubky_common::crypto::hash;
 use reqwest::Method;
 use url::Url;
 
-use crate::{PubkyHttpClient, cross_log, util::check_http_status};
+use crate::{PubkyHttpClient, cross_log};
 
 /// Default HTTP relay base when none is supplied.
 #[deprecated(note = "Use `DEFAULT_HTTP_RELAY_INBOX` with `HttpRelayInboxChannel` instead")]
@@ -96,7 +96,7 @@ impl HttpRelayLinkChannel {
             Err(err) => return Err(PollError::Failure(err.into())),
         };
 
-        let response = match check_http_status(response).await {
+        let response = match client.check_http_status(response).await {
             Ok(response) => response,
             Err(e) => return Err(PollError::Failure(e)),
         };

--- a/pubky-sdk/src/actors/event_stream.rs
+++ b/pubky-sdk/src/actors/event_stream.rs
@@ -102,7 +102,6 @@ use crate::{
     actors::session::credential::SessionCredential,
     cross_log,
     errors::{Error, RequestError, Result},
-    util::check_http_status,
 };
 
 /// A single event from the event stream.
@@ -482,7 +481,7 @@ impl EventStreamBuilder {
         // Surface homeserver rejections (e.g. 401/403/400 for private-path
         // authorization) as a typed `RequestError::Server` carrying the status
         // and the server's message, rather than a hand-rolled string.
-        let response = check_http_status(response).await?;
+        let response = self.client.check_http_status(response).await?;
 
         let sse_stream = response.bytes_stream().eventsource();
         let event_stream = sse_stream.filter_map(|result| async move {

--- a/pubky-sdk/src/actors/signer/auth.rs
+++ b/pubky-sdk/src/actors/signer/auth.rs
@@ -19,7 +19,6 @@ use crate::{
     },
     cross_log,
     errors::{AuthError, Result},
-    util::check_http_status,
 };
 
 use super::PubkySigner;
@@ -174,7 +173,7 @@ impl PubkySigner {
             .send()
             .await?;
 
-        check_http_status(response).await?;
+        self.client.check_http_status(response).await?;
         cross_log!(info, "Auth payload delivered successfully");
         Ok(())
     }

--- a/pubky-sdk/src/actors/signer/session.rs
+++ b/pubky-sdk/src/actors/signer/session.rs
@@ -24,7 +24,6 @@ use crate::{
         grant::pop_signer::GrantPopSigner,
     },
     cross_log,
-    util::check_http_status,
 };
 
 const SIGNUP_CLIENT_ID: &str = "pubky.signup";
@@ -321,7 +320,7 @@ impl PubkySigner {
             .await?;
 
         // Map non-2xx into our error type; keep body/headers intact for the caller.
-        check_http_status(response).await
+        self.client.check_http_status(response).await
     }
 
     async fn publish_signup_homeserver(&self, homeserver: &PublicKey) -> Result<()> {

--- a/pubky-sdk/src/actors/storage/json.rs
+++ b/pubky-sdk/src/actors/storage/json.rs
@@ -3,7 +3,6 @@ use reqwest::Response;
 use super::core::{PublicStorage, SessionStorage};
 use super::resource::{IntoPubkyResource, IntoResourcePath};
 use crate::Result;
-use crate::util::check_http_status;
 
 //
 // SessionStorage (as-me)
@@ -30,7 +29,7 @@ impl SessionStorage {
             .header(reqwest::header::ACCEPT, "application/json")
             .send()
             .await?;
-        let resp = check_http_status(resp).await?;
+        let resp = self.client.check_http_status(resp).await?;
         Ok(resp.json::<T>().await?)
     }
 
@@ -54,7 +53,7 @@ impl SessionStorage {
             .json(body)
             .send()
             .await?;
-        check_http_status(resp).await
+        self.client.check_http_status(resp).await
     }
 }
 
@@ -81,7 +80,7 @@ impl PublicStorage {
             .header(reqwest::header::ACCEPT, "application/json")
             .send()
             .await?;
-        let resp = check_http_status(resp).await?;
+        let resp = self.client.check_http_status(resp).await?;
         Ok(resp.json::<T>().await?)
     }
 }

--- a/pubky-sdk/src/actors/storage/list.rs
+++ b/pubky-sdk/src/actors/storage/list.rs
@@ -5,7 +5,6 @@ use super::core::{PublicStorage, SessionStorage, dir_trailing_slash_error};
 use crate::actors::storage::resource::{
     IntoPubkyResource, IntoResourcePath, PubkyResource, ResourcePath,
 };
-use crate::util::check_http_status;
 use crate::{Result, cross_log};
 
 impl SessionStorage {
@@ -171,19 +170,20 @@ impl<'a> ListBuilder<'a> {
         }
 
         // 2) Build request per scope
-        let rb = match self.scope {
-            ListScope::Public(storage) => {
+        let (client, rb) = match self.scope {
+            ListScope::Public(storage) => (
+                &storage.client,
                 storage
                     .client
                     .cross_request(Method::GET, url.clone())
-                    .await?
-            }
+                    .await?,
+            ),
             ListScope::Session(storage) => {
                 let rb = storage
                     .client
                     .cross_request(Method::GET, url.clone())
                     .await?;
-                storage.attach_credential(rb).await?
+                (&storage.client, storage.attach_credential(rb).await?)
             }
         };
 
@@ -195,7 +195,7 @@ impl<'a> ListBuilder<'a> {
             resp.status(),
             resp.url()
         );
-        let resp = check_http_status(resp).await?;
+        let resp = client.check_http_status(resp).await?;
 
         let bytes = resp.bytes().await?;
         let mut out = Vec::new();

--- a/pubky-sdk/src/actors/storage/verbs.rs
+++ b/pubky-sdk/src/actors/storage/verbs.rs
@@ -3,11 +3,11 @@ use reqwest::{Method, RequestBuilder, Response, StatusCode};
 use super::core::{PublicStorage, SessionStorage};
 use super::resource::{IntoPubkyResource, IntoResourcePath};
 use super::stats::ResourceStats;
-use crate::{Result, cross_log, util::check_http_status};
+use crate::{PubkyHttpClient, Result, cross_log};
 
 /// Interpret the result of a `HEAD` request into a shared outcome used by both
 /// session and public storage clients.
-async fn interpret_head(resp: Response) -> Result<Option<Response>> {
+async fn interpret_head(client: &PubkyHttpClient, resp: Response) -> Result<Option<Response>> {
     match resp.status() {
         StatusCode::NOT_FOUND | StatusCode::GONE => {
             cross_log!(debug, "HEAD request returned {}", resp.status());
@@ -15,27 +15,27 @@ async fn interpret_head(resp: Response) -> Result<Option<Response>> {
         }
         _ => {
             cross_log!(debug, "HEAD request returned {}", resp.status());
-            Ok(Some(check_http_status(resp).await?))
+            Ok(Some(client.check_http_status(resp).await?))
         }
     }
 }
 
 /// Send a prepared request and ensure the HTTP status indicates success.
-async fn send_checked(rb: RequestBuilder) -> Result<Response> {
+async fn send_checked(client: &PubkyHttpClient, rb: RequestBuilder) -> Result<Response> {
     let resp = rb.send().await?;
     cross_log!(debug, "Request completed with status {}", resp.status());
-    check_http_status(resp).await
+    client.check_http_status(resp).await
 }
 
 /// Send a prepared `HEAD` request and interpret the outcome.
-async fn send_head(rb: RequestBuilder) -> Result<Option<Response>> {
+async fn send_head(client: &PubkyHttpClient, rb: RequestBuilder) -> Result<Option<Response>> {
     let resp = rb.send().await?;
     cross_log!(
         debug,
         "HEAD request completed with status {}",
         resp.status()
     );
-    interpret_head(resp).await
+    interpret_head(client, resp).await
 }
 
 //
@@ -62,7 +62,7 @@ impl SessionStorage {
     ///   resource/URL.
     pub async fn get<P: IntoResourcePath>(&self, path: P) -> Result<Response> {
         let rb = self.request(Method::GET, path).await?;
-        send_checked(rb).await
+        send_checked(&self.client, rb).await
     }
 
     /// Lightweight existence check (HEAD) for an **absolute path**.
@@ -72,7 +72,7 @@ impl SessionStorage {
     /// - Returns [`crate::errors::Error::Parse`] if `path` cannot be converted into a valid resource.
     pub async fn exists<P: IntoResourcePath>(&self, path: P) -> Result<bool> {
         let rb = self.request(Method::HEAD, path).await?;
-        Ok(send_head(rb).await?.is_some())
+        Ok(send_head(&self.client, rb).await?.is_some())
     }
 
     /// Retrieve metadata via `HEAD` for an **absolute path** (no body).
@@ -82,7 +82,7 @@ impl SessionStorage {
     /// - Returns [`crate::errors::Error::Parse`] if `path` cannot be converted into a valid resource.
     pub async fn stats<P: IntoResourcePath>(&self, path: P) -> Result<Option<ResourceStats>> {
         let rb = self.request(Method::HEAD, path).await?;
-        Ok(send_head(rb)
+        Ok(send_head(&self.client, rb)
             .await?
             .map(|resp| ResourceStats::from_headers(resp.headers())))
     }
@@ -102,7 +102,7 @@ impl SessionStorage {
         B: Into<reqwest::Body>,
     {
         let rb = self.request(Method::PUT, path).await?.body(body);
-        send_checked(rb).await
+        send_checked(&self.client, rb).await
     }
 
     /// HTTP `DELETE` for an **absolute path**.
@@ -114,7 +114,7 @@ impl SessionStorage {
     ///   resource/URL.
     pub async fn delete<P: IntoResourcePath>(&self, path: P) -> Result<Response> {
         let rb = self.request(Method::DELETE, path).await?;
-        send_checked(rb).await
+        send_checked(&self.client, rb).await
     }
 }
 
@@ -145,7 +145,7 @@ impl PublicStorage {
     ///   addressed resource/URL.
     pub async fn get<A: IntoPubkyResource>(&self, addr: A) -> Result<Response> {
         let rb = self.request(Method::GET, addr).await?;
-        send_checked(rb).await
+        send_checked(&self.client, rb).await
     }
 
     /// HEAD existence check for an addressed resource.
@@ -155,7 +155,7 @@ impl PublicStorage {
     /// - Returns [`crate::errors::Error::Parse`] if `addr` cannot be converted into a valid addressed resource.
     pub async fn exists<A: IntoPubkyResource>(&self, addr: A) -> Result<bool> {
         let rb = self.request(Method::HEAD, addr).await?;
-        Ok(send_head(rb).await?.is_some())
+        Ok(send_head(&self.client, rb).await?.is_some())
     }
 
     /// Metadata via `HEAD` for an addressed resource (no body).
@@ -165,7 +165,7 @@ impl PublicStorage {
     /// - Returns [`crate::errors::Error::Parse`] if `addr` cannot be converted into a valid addressed resource.
     pub async fn stats<A: IntoPubkyResource>(&self, addr: A) -> Result<Option<ResourceStats>> {
         let rb = self.request(Method::HEAD, addr).await?;
-        Ok(send_head(rb)
+        Ok(send_head(&self.client, rb)
             .await?
             .map(|resp| ResourceStats::from_headers(resp.headers())))
     }

--- a/pubky-sdk/src/client/core.rs
+++ b/pubky-sdk/src/client/core.rs
@@ -5,6 +5,8 @@ use std::time::Duration;
 use super::http_targets::HomeserverFeatures;
 use crate::{cross_log, errors::BuildError};
 
+pub(crate) const DEFAULT_MAX_ERROR_BODY_BYTES: usize = 4096;
+
 const DEFAULT_USER_AGENT: &str = concat!("pubky.org", "@", env!("CARGO_PKG_VERSION"),);
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -29,6 +31,7 @@ struct NativeHttpConfig {
 ///   [`Self::request_timeout`]
 /// - HTTP read timeout (native only): reqwest default (disabled) unless set via
 ///   [`Self::read_timeout`]
+/// - Error-body capture: 4096 bytes; see [`Self::max_error_body_bytes`].
 /// - User-agent: `pubky.org@<crate-version>` plus any [`Self::user_agent_extra`]
 /// - Idle keep-alive connections per host (native only): reqwest default unless set via
 ///   [`Self::pool_max_idle_per_host`]
@@ -63,6 +66,7 @@ pub struct PubkyHttpClientBuilder {
 
     /// Optional user-agent segment appended to the default UA for app-level telemetry.
     user_agent_extra: Option<String>,
+    max_error_body_bytes: Option<usize>,
 
     #[cfg(not(target_arch = "wasm32"))]
     native_http: NativeHttpConfig,
@@ -198,6 +202,28 @@ impl PubkyHttpClientBuilder {
         self
     }
 
+    /// Limit the body bytes captured for HTTP error diagnostics. Defaults to 4096.
+    ///
+    /// Set `0` to skip error-body reads and use the status reason as the message.
+    /// Longer bodies receive a truncation marker. This applies to all checked SDK
+    /// requests, including credential refresh. Successful-body handling is unchanged.
+    ///
+    /// A stalled body at or below a positive limit still needs a request timeout.
+    /// Transport buffers and UTF-8 decoding have separate memory costs.
+    ///
+    /// # Example
+    /// ```
+    /// # use pubky::PubkyHttpClient;
+    /// let client = PubkyHttpClient::builder()
+    ///     .max_error_body_bytes(1024)
+    ///     .build()?;
+    /// # Ok::<_, pubky::BuildError>(())
+    /// ```
+    pub fn max_error_body_bytes(&mut self, limit: usize) -> &mut Self {
+        self.max_error_body_bytes = Some(limit);
+        self
+    }
+
     /// Build a [`PubkyHttpClient`].
     ///
     /// # Errors
@@ -280,6 +306,9 @@ impl PubkyHttpClientBuilder {
             pkarr,
             http: http_builder.build()?,
             features,
+            max_error_body_bytes: self
+                .max_error_body_bytes
+                .unwrap_or(DEFAULT_MAX_ERROR_BODY_BYTES),
 
             #[cfg(not(target_arch = "wasm32"))]
             icann_http: icann_http_builder.build()?,
@@ -462,6 +491,7 @@ pub struct PubkyHttpClient {
     pub(crate) http: reqwest::Client,
     pub(crate) pkarr: pkarr::Client,
     pub(crate) features: HomeserverFeatures,
+    pub(crate) max_error_body_bytes: usize,
 
     #[cfg(not(target_arch = "wasm32"))]
     pub(crate) icann_http: reqwest::Client,

--- a/pubky-sdk/src/errors.rs
+++ b/pubky-sdk/src/errors.rs
@@ -125,12 +125,13 @@ pub enum RequestError {
     #[error("HTTP transport error: {0}")]
     Transport(#[from] reqwest::Error),
 
-    /// The server returned a non-success status. Includes status and body message.
+    /// The server returned a non-success status. Includes status and bounded diagnostics.
     #[error("Server responded with an error: {status} - {message}")]
     Server {
         /// The HTTP status code returned by the server.
         status: reqwest::StatusCode,
-        /// Short description or the server response body captured for context.
+        /// Status reason or response text bounded by the client's error-body limit.
+        /// A truncation marker identifies oversized bodies; UTF-8 decoding may expand the text.
         message: String,
     },
 

--- a/pubky-sdk/src/util.rs
+++ b/pubky-sdk/src/util.rs
@@ -1,24 +1,64 @@
+use std::fmt::Write;
+
+use futures_util::StreamExt;
 use reqwest::Response;
 
-use crate::errors::{Error, RequestError, Result};
+use crate::{
+    PubkyHttpClient,
+    client::core::DEFAULT_MAX_ERROR_BODY_BYTES,
+    errors::{Error, RequestError, Result},
+};
 
-/// Convert non-2xx responses into a structured error that includes the server body.
-///
-/// If the status is successful (2xx), the original response is returned.
-/// If the status is an error (4xx or 5xx), the response body is consumed
-/// to create a `PubkyError::Request(RequestError::Server)` and returned as an `Err`.
-pub async fn check_http_status(response: Response) -> Result<Response> {
-    if response.status().is_success() {
-        return Ok(response);
+impl PubkyHttpClient {
+    pub(crate) async fn check_http_status(&self, response: Response) -> Result<Response> {
+        if response.status().is_success() {
+            return Ok(response);
+        }
+        let status = response.status();
+        let message = if self.max_error_body_bytes == 0 {
+            // Dropping the stream also cancels the browser reader without polling it.
+            drop(response.bytes_stream());
+            None
+        } else {
+            self.read_error_message(response).await.ok()
+        }
+        .unwrap_or_else(|| {
+            status
+                .canonical_reason()
+                .unwrap_or("Unknown Error")
+                .to_owned()
+        });
+        Err(Error::from(RequestError::Server { status, message }))
     }
 
-    let status = response.status();
-    let message = response.text().await.unwrap_or_else(|_| {
-        status
-            .canonical_reason()
-            .unwrap_or("Unknown Error")
-            .to_string()
-    });
+    async fn read_error_message(&self, response: Response) -> reqwest::Result<String> {
+        let limit = self.max_error_body_bytes;
+        let mut body = Vec::with_capacity(limit.min(DEFAULT_MAX_ERROR_BODY_BYTES));
+        let mut chunks = response.bytes_stream();
+        let mut truncated = false;
+        while let Some(chunk) = chunks.next().await {
+            let chunk = chunk?;
+            let remaining = limit - body.len();
+            body.extend_from_slice(&chunk[..chunk.len().min(remaining)]);
+            if chunk.len() > remaining {
+                truncated = true;
+                break;
+            }
+        }
+        drop(chunks);
 
-    Err(Error::from(RequestError::Server { status, message }))
+        // Native reqwest retains a UTF-8 BOM; browser Response.text() strips it.
+        let body = body.as_slice();
+        #[cfg(target_arch = "wasm32")]
+        let body = body.strip_prefix(b"\xef\xbb\xbf").unwrap_or(body);
+        let mut message = String::from_utf8_lossy(body).into_owned();
+        if truncated {
+            write!(message, "\n[response body truncated at {limit} bytes]")
+                .expect("writing to a String cannot fail");
+        }
+        Ok(message)
+    }
 }
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests;

--- a/pubky-sdk/src/util/tests.rs
+++ b/pubky-sdk/src/util/tests.rs
@@ -1,0 +1,256 @@
+use crate::{Error, PubkyHttpClient, errors::RequestError};
+use reqwest::{Response, StatusCode};
+use std::{fmt::Write, time::Duration};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+};
+
+fn client(limit: Option<usize>) -> PubkyHttpClient {
+    let mut builder = PubkyHttpClient::builder();
+    builder.isolated_pkarr_test();
+    if let Some(limit) = limit {
+        builder.max_error_body_bytes(limit);
+    }
+    builder.build().unwrap()
+}
+
+// Keep the server socket alive after returning headers/body. Tests decide when
+// EOF happens, so a response reader cannot pass by waiting for the whole body.
+async fn serve_response(status: u16, framing: &str, body: &[u8]) -> (Response, TcpStream) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("http://{}", listener.local_addr().unwrap());
+    let client = reqwest::Client::new();
+    let send = client.get(url).send();
+    let serve = async {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut request = Vec::new();
+        loop {
+            let byte = socket.read_u8().await.unwrap();
+            request.push(byte);
+            if request.ends_with(b"\r\n\r\n") {
+                break;
+            }
+            assert!(request.len() < 16 * 1024);
+        }
+        socket
+            .write_all(format!("HTTP/1.1 {status} Test\r\n{framing}\r\n").as_bytes())
+            .await
+            .unwrap();
+        socket.write_all(body).await.unwrap();
+        socket
+    };
+    let (response, socket) = tokio::join!(send, serve);
+    (response.unwrap(), socket)
+}
+
+async fn server_error(response: Response, client: PubkyHttpClient) -> (StatusCode, String) {
+    let error = tokio::time::timeout(Duration::from_secs(2), client.check_http_status(response))
+        .await
+        .expect("status handling must not wait for the rest of an oversized body")
+        .unwrap_err();
+    let Error::Request(RequestError::Server { status, message }) = error else {
+        panic!("unexpected error: {error:?}");
+    };
+    (status, message)
+}
+
+#[tokio::test]
+async fn oversized_error_stops_before_eof() {
+    let body = format!("1001\r\n{}\r\n", "x".repeat(4097));
+    let (response, _socket) =
+        serve_response(500, "Transfer-Encoding: chunked\r\n", body.as_bytes()).await;
+    let (status, message) = server_error(response, client(None)).await;
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(
+        message,
+        format!(
+            "{}\n[response body truncated at 4096 bytes]",
+            "x".repeat(4096)
+        )
+    );
+}
+
+#[tokio::test]
+async fn error_body_limits_follow_client_configuration() {
+    for setting in [None, Some(16), Some(8192)] {
+        let client = client(setting);
+        let limit = setting.unwrap_or(4096);
+        for size in [0, 3, limit - 1, limit, limit + 1] {
+            let body = vec![b'x'; size];
+            let (response, _socket) =
+                serve_response(429, &format!("Content-Length: {size}\r\n"), &body).await;
+            let (status, message) = server_error(response, client.clone()).await;
+            assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
+            let mut expected = "x".repeat(size.min(limit));
+            if size > limit {
+                write!(expected, "\n[response body truncated at {limit} bytes]").unwrap();
+            }
+            assert_eq!(message, expected, "limit {limit}, body size {size}");
+        }
+    }
+}
+
+#[tokio::test]
+async fn clients_keep_independent_limits_when_cloned() {
+    let small = client(Some(3));
+    let larger = client(Some(5));
+    for (client, limit) in [(small.clone(), 3), (larger, 5), (small, 3)] {
+        let (response, _socket) =
+            serve_response(500, "Content-Length: 10\r\n", b"xxxxxxxxxx").await;
+        let (_, message) = server_error(response, client).await;
+        assert_eq!(
+            message,
+            format!(
+                "{}\n[response body truncated at {limit} bytes]",
+                "x".repeat(limit)
+            )
+        );
+    }
+}
+
+#[tokio::test]
+async fn zero_limit_does_not_wait_for_error_bodies() {
+    for (status, reason) in [
+        (404, "Not Found"),
+        (410, "Gone"),
+        (500, "Internal Server Error"),
+        (599, "Unknown Error"),
+    ] {
+        let (response, _socket) =
+            serve_response(status, "Content-Length: 1000000000\r\n", b"").await;
+        let (actual, message) = server_error(response, client(Some(0))).await;
+        assert_eq!(actual.as_u16(), status);
+        assert_eq!(message, reason);
+    }
+}
+
+#[tokio::test]
+async fn large_limit_does_not_require_a_large_allocation() {
+    let (response, _socket) = serve_response(500, "Content-Length: 5\r\n", b"short").await;
+    let (_, message) = server_error(response, client(Some(usize::MAX))).await;
+    assert_eq!(message, "short");
+}
+
+#[tokio::test]
+async fn error_limit_is_independent_of_framing_and_chunk_boundaries() {
+    for framing in ["", "Content-Length: 1000000000000\r\n"] {
+        let (response, _socket) = serve_response(503, framing, &vec![b'x'; 4097]).await;
+        let (_, message) = server_error(response, client(None)).await;
+        assert_eq!(
+            message,
+            format!(
+                "{}\n[response body truncated at 4096 bytes]",
+                "x".repeat(4096)
+            )
+        );
+    }
+
+    let (response, mut socket) = serve_response(500, "Transfer-Encoding: chunked\r\n", b"").await;
+    let read = tokio::spawn(server_error(response, client(None)));
+    for _ in 0..4096 {
+        socket.write_all(b"1\r\nx\r\n").await.unwrap();
+    }
+    // Reaching the limit alone is not truncation; the next byte proves overflow.
+    socket.write_all(b"1\r\ny\r\n").await.unwrap();
+    let (_, message) = read.await.unwrap();
+    assert_eq!(
+        message,
+        format!(
+            "{}\n[response body truncated at 4096 bytes]",
+            "x".repeat(4096)
+        )
+    );
+}
+
+#[tokio::test]
+async fn checked_success_does_not_consume_the_body() {
+    let (response, mut socket) = serve_response(200, "Content-Length: 5\r\n", b"").await;
+    let response = tokio::time::timeout(
+        Duration::from_secs(2),
+        client(Some(0)).check_http_status(response),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    socket.write_all(b"hello").await.unwrap();
+    assert_eq!(response.text().await.unwrap(), "hello");
+}
+
+#[tokio::test]
+async fn error_text_decoding_and_read_failure() {
+    for body in [
+        b"\xef\xbb\xbfhello".as_slice(),
+        b"bad\xfftext",
+        "caf\u{e9}".as_bytes(),
+    ] {
+        let (response, _socket) =
+            serve_response(400, &format!("Content-Length: {}\r\n", body.len()), body).await;
+        let (_, message) = server_error(response, client(None)).await;
+        assert_eq!(message, String::from_utf8_lossy(body));
+    }
+    let mut body = vec![b'x'; 4095];
+    body.extend_from_slice("\u{20ac}".as_bytes());
+    let (response, _socket) =
+        serve_response(400, &format!("Content-Length: {}\r\n", body.len()), &body).await;
+    let (_, message) = server_error(response, client(None)).await;
+    assert_eq!(
+        message,
+        format!(
+            "{}\u{fffd}\n[response body truncated at 4096 bytes]",
+            "x".repeat(4095)
+        )
+    );
+
+    for (status, fallback) in [(500, "Internal Server Error"), (599, "Unknown Error")] {
+        let (response, socket) =
+            serve_response(status, "Content-Length: 100\r\n", b"partial").await;
+        drop(socket);
+        let (actual, message) = server_error(response, client(None)).await;
+        assert_eq!(actual.as_u16(), status);
+        assert_eq!(message, fallback);
+    }
+}
+
+#[tokio::test]
+async fn small_head_does_not_protect_against_oversized_get_errors() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("http://{}", listener.local_addr().unwrap());
+    let peer = tokio::spawn(async move {
+        for method in ["HEAD", "GET"] {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = Vec::new();
+            while !request.ends_with(b"\r\n\r\n") {
+                request.push(socket.read_u8().await.unwrap());
+                assert!(request.len() < 16 * 1024);
+            }
+            assert!(request.starts_with(method.as_bytes()));
+            if method == "HEAD" {
+                socket
+                    .write_all(
+                        b"HTTP/1.1 200 OK\r\nContent-Length: 16\r\nConnection: close\r\n\r\n",
+                    )
+                    .await
+                    .unwrap();
+            } else {
+                socket.write_all(format!("HTTP/1.1 500 Error\r\nTransfer-Encoding: chunked\r\n\r\n1001\r\n{}\r\n", "x".repeat(4097)).as_bytes()).await.unwrap();
+                return socket; // Withhold EOF until the checked GET has returned.
+            }
+        }
+        unreachable!()
+    });
+    let http = reqwest::Client::new();
+    let head = http.head(&url).send().await.unwrap();
+    assert_eq!(head.headers()["content-length"], "16");
+    let response = http.get(&url).send().await.unwrap();
+    let _socket = peer.await.unwrap();
+    let (status, message) = server_error(response, client(None)).await;
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(
+        message,
+        format!(
+            "{}\n[response body truncated at 4096 bytes]",
+            "x".repeat(4096)
+        )
+    );
+}


### PR DESCRIPTION
Closes [https://github.com/pubky/pubky-homeserver/issues/604](https://github.com/pubky/pubky-homeserver/issues/604)

### Summary

Bounds HTTP error bodies across SDK requests. Previously, a server could make the SDK collect an arbitrarily large error body.

### Behavior

- Defaults to capturing 4096 bytes.
- Stops reading after detecting overflow and appends `[response body truncated at N bytes]`.
- Setting `0` skips error-body reads and uses the HTTP status reason.
- Preserves error status codes and successful-response handling.

Configure the limit when creating the client:

```rust
use pubky::{Pubky, PubkyHttpClient};

let client = PubkyHttpClient::builder()
    .max_error_body_bytes(1024)
    .build()?;

let pubky = Pubky::with_client(client);
```

```typescript
import { Client, Pubky } from "@synonymdev/pubky";

const pubky = Pubky.withClient(
  new Client({ maxErrorBodyBytes: 1024 }),
);
```

### Acceptance criteria

- [x] Covers default, custom and zero limits, boundary sizes, UTF-8 decoding and body-read failures.
- [x] Returns after overflow without waiting for EOF; verifies browser stream cancellation.
- [x] Preserves grant and legacy-cookie private reads.
- [x] Applies the configured limit to refresh errors and prevents the storage GET when refresh fails.
- [x] Passes native tests, Node/browser regressions, formatting, Clippy and WASM checks.